### PR TITLE
Make the hypershift operator image configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Repo hosting the image with path
-REPO ?= ""
+REPO ?= "quay.io/stolostron/"
 
 # Image URL to use all building/pushing image targets
 IMG ?= $(REPO)hypershift-addon-operator:latest

--- a/example/addon-manager-deployment.yaml
+++ b/example/addon-manager-deployment.yaml
@@ -43,10 +43,15 @@ spec:
       securityContext: {}
       containers:
         - name: hypershift-addon-agent
-          image: 'quay.io/ianzhang366/hypershift-addon-operator:latest'
+          image: 'quay.io/stolostron/hypershift-addon-operator:latest'
           args:
             - ./hypershift-addon
             - manager
             - '--namespace=open-cluster-management'
           imagePullPolicy: Always
+          env:
+            - name: HYPERSHIFT_OPERATOR_IMAGE_NAME
+              value: 'quay.io/hypershift/hypershift-operator:latest'
+            - name: HYPERSHIFT_ADDON_IMAGE_NAME
+              value: 'quay.io/stolostron/hypershift-addon-operator:latest'
       serviceAccount: hypershift-addon-manager-sa

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -35,8 +35,9 @@ var (
 )
 
 const (
-	hypershiftAddonImageName = "HYPERSHIFT_ADDON_IMAGE_NAME"
-	templatePath             = "manifests/templates"
+	hypershiftAddonImageName    = "HYPERSHIFT_ADDON_IMAGE_NAME"
+	hypershiftOperatorImageName = "HYPERSHIFT_OPERATOR_IMAGE_NAME"
+	templatePath                = "manifests/templates"
 )
 
 //go:embed manifests
@@ -167,9 +168,14 @@ func getValueForAgentTemplate(cluster *clusterv1.ManagedCluster,
 		installNamespace = util.AgentInstallationNamespace
 	}
 
-	image := os.Getenv(hypershiftAddonImageName)
-	if len(image) == 0 {
-		image = util.DefaultHypershiftImage
+	addonImage := os.Getenv(hypershiftAddonImageName)
+	if len(addonImage) == 0 {
+		addonImage = util.DefaultHypershiftAddonImage
+	}
+
+	operatorImage := os.Getenv(hypershiftOperatorImageName)
+	if len(operatorImage) == 0 {
+		operatorImage = util.DefaultHypershiftOperatorImage
 	}
 
 	manifestConfig := struct {
@@ -178,6 +184,7 @@ func getValueForAgentTemplate(cluster *clusterv1.ManagedCluster,
 		AddonName                      string
 		AddonInstallNamespace          string
 		HypershiftBucketNamespaceOnHub string
+		HypershiftOperatorImage        string
 		Image                          string
 		SpokeRolebindingName           string
 		AgentServiceAccountName        string
@@ -187,7 +194,8 @@ func getValueForAgentTemplate(cluster *clusterv1.ManagedCluster,
 		HypershiftBucketNamespaceOnHub: util.HypershiftBucketNamespaceOnHub,
 		ClusterName:                    cluster.Name,
 		AddonName:                      fmt.Sprintf("%s-agent", addon.Name),
-		Image:                          image,
+		Image:                          addonImage,
+		HypershiftOperatorImage:        operatorImage,
 		SpokeRolebindingName:           addon.Name,
 		AgentServiceAccountName:        fmt.Sprintf("%s-agent-sa", addon.Name),
 	}

--- a/pkg/manager/manifests/templates/deployment.yaml
+++ b/pkg/manager/manifests/templates/deployment.yaml
@@ -31,6 +31,7 @@ spec:
           - "--cluster-name={{ .ClusterName }}"
           - "--addon-namespace={{ .AddonInstallNamespace }}"
           - "--hypershfit-bucket-namespace={{ .HypershiftBucketNamespaceOnHub }}"
+          - "--hypershfit-operator-image={{ .HypershiftOperatorImage }}"
         volumeMounts:
           - name: hub-config
             mountPath: /var/run/hub

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -1,7 +1,10 @@
 package util
 
 const (
-	DefaultHypershiftImage = "quay.io/ianzhang366/hypershift-addon-operator:latest"
+	DefaultHypershiftAddonImage = "quay.io/stolostron/hypershift-addon-operator:latest"
+
+	DefaultHypershiftOperatorImage = "quay.io/hypershift/hypershift-operator:latest"
+
 	// AgentInstallationNamespace is the namespace on the managed cluster to install the addon agent.
 	AgentInstallationNamespace = "open-cluster-management-agent-addon"
 


### PR DESCRIPTION
Signed-off-by: zhujian <jiazhu@redhat.com>
- make the hypershift operator image configurable, by setting an Env `HYPERSHIFT_OPERATOR_IMAGE_NAME` for the addon mgr
- change the default image from `quay.io/ianzhang366/hypershift-addon-operator:latest` to `quay.io/stolostron/hypershift-addon-operator:latest`

After this merged, I will add these two Envs `HYPERSHIFT_ADDON_IMAGE_NAME` and `HYPERSHIFT_OPERATOR_IMAGE_NAME` into https://github.com/stolostron/hypershift-addon-chart.