### PR TITLE
Delete bucket namespace flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
 # hypershift-addon-operator
+
+hypershift-addon-operator can deploy a hypershift-operator to a managed cluster.
+
+## Install the hypershift addon manager
+
+```
+oc apply -f example/addon-manager-deployment.yaml
+```
+
+You can check the hypershift addon manager status by
+```
+╰─$ oc get deployment -n multicluster-engine | grep hypershift-addon
+hypershift-addon-manager              1/1     1            1           107m
+```
+
+## Enable a hypershift addon agent to a managed cluster
+
+1. Check the target managed cluster is imported to the hub, we will use managed cluster <cluster1> as an example.
+```
+╰─$ oc get managedcluster cluster1
+NAME            HUB ACCEPTED   MANAGED CLUSTER URLS          JOINED   AVAILABLE   AGE
+cluster1        true                                         True     True        147m
+```
+
+2. Install a hypershift addon to the managed cluster <cluster1>
+```
+╰─$ oc apply -f - <<EOF
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ManagedClusterAddOn
+metadata:
+  name: hypershift-addon
+  namespace: cluster1
+spec:
+  installNamespace: open-cluster-management-agent-addon
+EOF
+```
+
+3. Create a hypershift-operator-oidc-provider-s3-credentials for the hypershift addon in the <cluster1> namespace
+```
+oc create secret generic hypershift-operator-oidc-provider-s3-credentials --from-file=credentials=${HOME}/.aws/credentials --from-literal=bucket=<bucket-name> --from-literal=region=us-east-1 -n cluster1
+```
+
+4. Check the status of the hypershift-addon
+```
+╰─$ oc get managedclusteraddons -n cluster1 hypershift-addon
+NAME               AVAILABLE   DEGRADED   PROGRESSING
+hypershift-addon   True
+```

--- a/example/addon-manager-deployment.yaml
+++ b/example/addon-manager-deployment.yaml
@@ -10,19 +10,19 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: hypershift-addon-manager-sa
-    namespace: open-cluster-management
+    namespace: multicluster-engine
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: hypershift-addon-manager-sa
-  namespace: open-cluster-management
+  namespace: multicluster-engine
 ---
 kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: hypershift-addon-manager
-  namespace: open-cluster-management
+  namespace: multicluster-engine
   labels:
     app: hypershift-addon-manager
 spec:

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -178,25 +178,23 @@ func getValueForAgentTemplate(cluster *clusterv1.ManagedCluster,
 	}
 
 	manifestConfig := struct {
-		KubeConfigSecret               string
-		ClusterName                    string
-		AddonName                      string
-		AddonInstallNamespace          string
-		HypershiftBucketNamespaceOnHub string
-		HypershiftOperatorImage        string
-		Image                          string
-		SpokeRolebindingName           string
-		AgentServiceAccountName        string
+		KubeConfigSecret        string
+		ClusterName             string
+		AddonName               string
+		AddonInstallNamespace   string
+		HypershiftOperatorImage string
+		Image                   string
+		SpokeRolebindingName    string
+		AgentServiceAccountName string
 	}{
-		KubeConfigSecret:               fmt.Sprintf("%s-hub-kubeconfig", addon.Name),
-		AddonInstallNamespace:          installNamespace,
-		HypershiftBucketNamespaceOnHub: util.HypershiftBucketNamespaceOnHub,
-		ClusterName:                    cluster.Name,
-		AddonName:                      fmt.Sprintf("%s-agent", addon.Name),
-		Image:                          addonImage,
-		HypershiftOperatorImage:        operatorImage,
-		SpokeRolebindingName:           addon.Name,
-		AgentServiceAccountName:        fmt.Sprintf("%s-agent-sa", addon.Name),
+		KubeConfigSecret:        fmt.Sprintf("%s-hub-kubeconfig", addon.Name),
+		AddonInstallNamespace:   installNamespace,
+		ClusterName:             cluster.Name,
+		AddonName:               fmt.Sprintf("%s-agent", addon.Name),
+		Image:                   addonImage,
+		HypershiftOperatorImage: operatorImage,
+		SpokeRolebindingName:    addon.Name,
+		AgentServiceAccountName: fmt.Sprintf("%s-agent-sa", addon.Name),
 	}
 
 	return addonfactory.StructToValues(manifestConfig), nil

--- a/pkg/manager/manifests/templates/deployment.yaml
+++ b/pkg/manager/manifests/templates/deployment.yaml
@@ -30,7 +30,6 @@ spec:
           - "--hub-kubeconfig=/var/run/hub/kubeconfig"
           - "--cluster-name={{ .ClusterName }}"
           - "--addon-namespace={{ .AddonInstallNamespace }}"
-          - "--hypershfit-bucket-namespace={{ .HypershiftBucketNamespaceOnHub }}"
           - "--hypershfit-operator-image={{ .HypershiftOperatorImage }}"
         volumeMounts:
           - name: hub-config

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -8,8 +8,5 @@ const (
 	// AgentInstallationNamespace is the namespace on the managed cluster to install the addon agent.
 	AgentInstallationNamespace = "open-cluster-management-agent-addon"
 
-	//HypershiftBucketNamespaceOnHub which should be the same as the addon manager's namespace
-	HypershiftBucketNamespaceOnHub = "open-cluster-management"
-
 	AddonControllerName = "hypershift-addon"
 )


### PR DESCRIPTION
The bucket secret namespace **must** be the clusterName namespace, otherwise, the agent getting the secret will fail(permission problem, the permission manifest just grant the agent getting secret in the clusterName namespace)