### PR TITLE
Disable install strategy all

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -66,7 +66,6 @@ func NewManagerCommand(componentName string, log logr.Logger) *cobra.Command {
 		agentAddon, err := addonfactory.NewAgentAddonFactory(componentName, fs, templatePath).
 			WithGetValuesFuncs(getValueForAgentTemplate, addonfactory.GetValuesFromAddonAnnotation).
 			WithAgentRegistrationOption(registrationOption).
-			WithInstallStrategy(frameworkagent.InstallAllStrategy(util.AgentInstallationNamespace)).
 			BuildTemplateAgentAddon()
 		if err != nil {
 			log.Error(err, "failed to build agent")


### PR DESCRIPTION
Signed-off-by: zhujian <jiazhu@redhat.com>

Disable the install strategy all, all means the manager will install the addon on ALL managed clusters automatically, but we want to install it by users manually.