### PR TITLE
use deployment annotation to mark the creation

### DIFF
--- a/pkg/agent/hypershift.go
+++ b/pkg/agent/hypershift.go
@@ -157,6 +157,7 @@ func (c *agentController) runHypershiftCleanup() error {
 	}
 
 	for _, item := range items {
+		item := item
 		if err := c.spokeUncachedClient.Delete(ctx, &item); err != nil && !apierrors.IsNotFound(err) {
 			c.log.Error(err, fmt.Sprintf("failed to delete %s, %s", item.GetKind(), client.ObjectKeyFromObject(&item)))
 		}
@@ -260,6 +261,7 @@ func (c *agentController) runHypershiftInstall() error {
 
 	//TODO: @ianzhang366 fix the dependecy issue and use better way to inject the pull secret
 	for _, item := range items {
+		item := item
 		if item.GetKind() == "ServiceAccount" {
 			sa := &corev1.ServiceAccount{
 				ImagePullSecrets: []corev1.LocalObjectReference{

--- a/pkg/manager/manifests/templates/clusterrole.yaml
+++ b/pkg/manager/manifests/templates/clusterrole.yaml
@@ -21,6 +21,7 @@ rules:
   resources:
   - secret
   - configmap
+  - namespace
   verbs:
   - create
   - delete

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -8,5 +8,7 @@ const (
 	// AgentInstallationNamespace is the namespace on the managed cluster to install the addon agent.
 	AgentInstallationNamespace = "open-cluster-management-agent-addon"
 
+	MulticlusterHubPullSecret = "multiclusterhub-operator-pull-secret"
+
 	AddonControllerName = "hypershift-addon"
 )


### PR DESCRIPTION
- mark deployment directly instead of use the managedclusteraddon
- mount the multicluster pull secret to hypershift's serviceaccount for downstream images

Signed-off-by: Ian Zhang <izhang@redhat.com>