### PR TITLE
Noticed that we did no upgrade the hypershift-operator 

### DIFF
--- a/pkg/agent/hypershift.go
+++ b/pkg/agent/hypershift.go
@@ -302,7 +302,11 @@ func (c *agentController) runHypershiftInstall() error {
 			continue
 		}
 
-		if err := c.spokeUncachedClient.Patch(ctx, &item, ctrlClient.RawPatch(types.ApplyPatchType, itemBytes), ctrlClient.ForceOwnership, ctrlClient.FieldOwner("hypershift")); err != nil {
+		if err := c.spokeUncachedClient.Patch(ctx,
+			&item,
+			ctrlClient.RawPatch(types.ApplyPatchType, itemBytes),
+			ctrlClient.ForceOwnership,
+			ctrlClient.FieldOwner("hypershift")); err != nil {
 			c.log.Error(err, fmt.Sprintf("failed to apply %s, %s", item.GetKind(), client.ObjectKeyFromObject(&item)))
 			continue
 		}
@@ -350,7 +354,9 @@ func (c *agentController) ensurePullSecret(ctx context.Context) error {
 		return out
 	}
 
-	if err := c.spokeUncachedClient.Create(ctx, overrideFunc(obj, hypershiftOperatorKey.Namespace)); err != nil && !apierrors.IsAlreadyExists(err) {
+	if err := c.spokeUncachedClient.Create(ctx, overrideFunc(obj, hypershiftOperatorKey.Namespace)); err != nil &&
+		!apierrors.IsAlreadyExists(err) {
+
 		return fmt.Errorf("failed to create hypershift operator's namespace, err: %w", err)
 	}
 

--- a/pkg/agent/hypershift.go
+++ b/pkg/agent/hypershift.go
@@ -199,8 +199,8 @@ func (c *agentController) runHypershiftInstall() error {
 	defer c.log.Info("exit runHypershiftInstall")
 	ctx := context.TODO()
 
-	if err, ok := c.deploymentExist(ctx); ok {
-		c.log.Error(err, "hypershift operator already exist or failed to get deployment, skip install")
+	if err, ok := c.deploymentExistWithNoImageChange(ctx); ok {
+		c.log.Error(err, "hypershift operator already exists at the required image level, skip update")
 		return nil
 	}
 
@@ -296,11 +296,17 @@ func (c *agentController) runHypershiftInstall() error {
 			item.SetAnnotations(a)
 		}
 
-		if err := c.spokeUncachedClient.Create(ctx, &item); err != nil && !apierrors.IsAlreadyExists(err) {
-			c.log.Error(err, fmt.Sprintf("failed to create %s, %s", item.GetKind(), client.ObjectKeyFromObject(&item)))
+		itemBytes, err := item.MarshalJSON()
+		if err != nil {
+			c.log.Error(err, fmt.Sprintf("failed to marshal json %s, %s", item.GetKind(), client.ObjectKeyFromObject(&item)))
+			continue
 		}
 
-		c.log.Info(fmt.Sprintf("created: %s at %s", item.GetKind(), client.ObjectKeyFromObject(&item)))
+		if err := c.spokeUncachedClient.Patch(ctx, &item, ctrlClient.RawPatch(types.ApplyPatchType, itemBytes), ctrlClient.ForceOwnership, ctrlClient.FieldOwner("hypershift")); err != nil {
+			c.log.Error(err, fmt.Sprintf("failed to apply %s, %s", item.GetKind(), client.ObjectKeyFromObject(&item)))
+			continue
+		}
+		c.log.Info(fmt.Sprintf("applied: %s at %s", item.GetKind(), client.ObjectKeyFromObject(&item)))
 	}
 
 	return nil
@@ -367,7 +373,7 @@ func (c *agentController) isDeploymentMarked(ctx context.Context) bool {
 	return true
 }
 
-func (c *agentController) deploymentExist(ctx context.Context) (error, bool) {
+func (c *agentController) deploymentExistWithNoImageChange(ctx context.Context) (error, bool) {
 	obj := &appsv1.Deployment{}
 
 	if err := c.spokeUncachedClient.Get(ctx, hypershiftOperatorKey, obj); err != nil {
@@ -377,7 +383,12 @@ func (c *agentController) deploymentExist(ctx context.Context) (error, bool) {
 
 		return err, false
 	}
-
+	// Check if image has changed
+	if len(obj.Spec.Template.Spec.Containers) == 1 &&
+		len(c.operatorImage) > 0 &&
+		obj.Spec.Template.Spec.Containers[0].Image != c.operatorImage {
+		return nil, false
+	}
 	return nil, true
 }
 

--- a/pkg/manager/manifests/templates/deployment.yaml
+++ b/pkg/manager/manifests/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
       - name: {{ .AddonName }}
         image: {{ .Image }}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         args:
           - "./hypershift-addon"
           - "agent"


### PR DESCRIPTION
When a new image is available. We also did not upgrade any of the other resources.

* Now patch all resources with changes
* Changed the imagePullPolicy from Always to IfNotPresent

Signed-off-by: Joshua Packer <jpacker@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Make sure that when a new hypershift-operator is available we patch all kube resources related to the `hypershift-operator`

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  The hypershift-operator will not be upgraded otherwise.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-1321

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output -->
## Test API/Unit - Success
```script
?       github.com/stolostron/hypershift-addon-operator/cmd     [no test files]
ok      github.com/stolostron/hypershift-addon-operator/pkg/agent       0.018s  coverage: 6.0% of statements
?       github.com/stolostron/hypershift-addon-operator/pkg/manager     [no test files]
?       github.com/stolostron/hypershift-addon-operator/pkg/util        [no test files]
```
