### PR TITLE
Add image pull secret for addon agent

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -92,13 +92,15 @@ func NewAgentOptions(addonName string, logger logr.Logger) *AgentOptions {
 func (o *AgentOptions) AddFlags(cmd *cobra.Command) {
 	flags := cmd.Flags()
 	// This command only supports reading from config
-	flags.StringVar(&o.HubKubeconfigFile, "hub-kubeconfig", o.HubKubeconfigFile, "Location of kubeconfig file to connect to hub cluster.")
+	flags.StringVar(&o.HubKubeconfigFile, "hub-kubeconfig", o.HubKubeconfigFile,
+		"Location of kubeconfig file to connect to hub cluster.")
 	flags.StringVar(&o.SpokeClusterName, "cluster-name", o.SpokeClusterName, "Name of spoke cluster.")
-	flags.StringVar(&o.AddonNamespace, "addon-namespace", util.AgentInstallationNamespace, "Installation namespace of addon.")
-	flags.StringVar(&o.PullSecretName, "multicluster-pull-secret", util.MulticlusterHubPullSecret, "Pull secret that will be injected to hypershift serviceaccount")
-
-	flags.StringVar(&o.HypershiftOperatorImage, "hypershfit-operator-image", util.DefaultHypershiftOperatorImage, "The HyperShift operator image to deploy")
-
+	flags.StringVar(&o.AddonNamespace, "addon-namespace", util.AgentInstallationNamespace,
+		"Installation namespace of addon.")
+	flags.StringVar(&o.PullSecretName, "multicluster-pull-secret", util.MulticlusterEnginePullSecret,
+		"Pull secret that will be injected to hypershift serviceaccount")
+	flags.StringVar(&o.HypershiftOperatorImage, "hypershfit-operator-image", util.DefaultHypershiftOperatorImage,
+		"The HyperShift operator image to deploy")
 	flags.BoolVar(&o.WithOverride, "with-image-override", false, "Use image from override configmap")
 
 	flags.StringVar(&o.MetricAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -240,6 +240,7 @@ func (o *override) getValueForAgentTemplate(cluster *clusterv1.ManagedCluster,
 		HypershiftOverrideKey               string
 		HypershiftDownstreamOverrideContent string
 		HyeprshiftImageOverride             bool
+		MulticlusterEnginePullSecret        string
 	}{
 		KubeConfigSecret:                    fmt.Sprintf("%s-hub-kubeconfig", addon.Name),
 		AddonInstallNamespace:               installNamespace,
@@ -253,6 +254,7 @@ func (o *override) getValueForAgentTemplate(cluster *clusterv1.ManagedCluster,
 		HypershiftOverrideKey:               util.HypershiftOverrideKey,
 		HypershiftDownstreamOverride:        util.HypershiftDownstreamOverride,
 		HypershiftDownstreamOverrideContent: content,
+		MulticlusterEnginePullSecret:        util.MulticlusterEnginePullSecret,
 	}
 
 	return addonfactory.StructToValues(manifestConfig), nil

--- a/pkg/manager/manifests/templates/deployment.yaml
+++ b/pkg/manager/manifests/templates/deployment.yaml
@@ -32,6 +32,11 @@ spec:
           - "--addon-namespace={{ .AddonInstallNamespace }}"
           - "--with-image-override={{ .HyeprshiftImageOverride }}"
           - "--hypershfit-operator-image={{ .HypershiftOperatorImage }}"
+          - "--multicluster-pull-secret= {{ .MulticlusterEnginePullSecret }}"
         volumeMounts:
           - name: hub-config
             mountPath: /var/run/hub
+      {{- if .MulticlusterEnginePullSecret }}
+      imagePullSecrets:
+      - name: "{{ .MulticlusterEnginePullSecret }}"
+      {{- end }}

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -17,7 +17,7 @@ const (
 	// AgentInstallationNamespace is the namespace on the managed cluster to install the addon agent.
 	AgentInstallationNamespace = "open-cluster-management-agent-addon"
 
-	MulticlusterHubPullSecret = "open-cluster-management-image-pull-credentials"
+	MulticlusterEnginePullSecret = "open-cluster-management-image-pull-credentials"
 
 	HypershiftDownstreamOverride = "hypershift-operator-imagestream"
 	HypershiftOverrideKey        = "imagestream"


### PR DESCRIPTION
Signed-off-by: zhujian <jiazhu@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Add image pull secret for addon agent

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  The addon agent can not be installed in QE environment

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://github.com/stolostron/backlog/issues/22321

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?   	github.com/stolostron/hypershift-addon-operator/cmd	[no test files]
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	0.031s	coverage: 6.0% of statements
?   	github.com/stolostron/hypershift-addon-operator/pkg/manager	[no test files]
?   	github.com/stolostron/hypershift-addon-operator/pkg/util	[no test files]
```
