### PR TITLE
Bump golang to 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.17-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.18-linux AS builder
 WORKDIR /go/src/github.com/stolostron/hypershift-addon-operator
 COPY . .
 ENV GO_PACKAGE github.com/stolostron/hypershift-addon-operator

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/hypershift-addon-operator
 
-go 1.17
+go 1.18
 
 require (
 	github.com/go-logr/logr v1.2.1


### PR DESCRIPTION
Signed-off-by: zhujian <jiazhu@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Bump golang to 1.18

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  The upstream hypershift project is using golang 1.18, and hypershift-addon-operator builds the hypershift cli binary in there image.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://github.com/stolostron/backlog/issues/22238

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?   	github.com/stolostron/hypershift-addon-operator/cmd	[no test files]
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	0.036s	coverage: 6.0% of statements
?   	github.com/stolostron/hypershift-addon-operator/pkg/manager	[no test files]
?   	github.com/stolostron/hypershift-addon-operator/pkg/util	[no test files]
```
