### PR TITLE
s3 bucket secret should be optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ spec:
 EOF
 ```
 
-3. Create a hypershift-operator-oidc-provider-s3-credentials for the hypershift addon in the <cluster1> namespace
+3. Create a hypershift-operator-oidc-provider-s3-credentials for the hypershift addon in the <cluster1> namespace if you plan to provision hosted clusters on AWS platform.
 ```
 oc create secret generic hypershift-operator-oidc-provider-s3-credentials --from-file=credentials=${HOME}/.aws/credentials --from-literal=bucket=<bucket-name> --from-literal=region=us-east-1 -n cluster1
 ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ spec:
 EOF
 ```
 
-3. Create a hypershift-operator-oidc-provider-s3-credentials for the hypershift addon in the <cluster1> namespace if you plan to provision hosted clusters on AWS platform.
+3. Create a hypershift-operator-oidc-provider-s3-credentials for the hypershift addon in the <cluster1> namespace if you plan to provision hosted clusters on the AWS platform.
 ```
 oc create secret generic hypershift-operator-oidc-provider-s3-credentials --from-file=credentials=${HOME}/.aws/credentials --from-literal=bucket=<bucket-name> --from-literal=region=us-east-1 -n cluster1
 ```

--- a/pkg/agent/hypershift.go
+++ b/pkg/agent/hypershift.go
@@ -205,41 +205,51 @@ func (c *agentController) runHypershiftInstall(ctx context.Context) error {
 		return nil
 	}
 
+	awsPlatform := true
+
 	bucketSecretKey := types.NamespacedName{Name: hypershiftBucketSecretName, Namespace: c.clusterName}
 	se := &corev1.Secret{}
 	if err := c.hubClient.Get(ctx, bucketSecretKey, se); err != nil {
-		c.log.Error(err, fmt.Sprintf("failed to get bucket secret(%s) from hub, will retry.", bucketSecretKey))
-		return err
-	}
+		c.log.Info(fmt.Sprintf("bucket secret(%s) not found on the hub, installaing hypershift operator for non-AWS platform.", bucketSecretKey))
 
-	bucketName := string(se.Data["bucket"])
-	bucketRegion := string(se.Data["region"])
-	bucketCreds := se.Data["credentials"]
-
-	file, err := ioutil.TempFile("", ".aws-creds")
-	if err != nil { // likely a unrecoverable error, don't retry
-		return fmt.Errorf("failed to create temp file for hoding aws credentials, err: %w", err)
-	}
-
-	credsFile := file.Name()
-	defer os.Remove(credsFile)
-
-	c.log.Info(fmt.Sprintf("aws config at: %s", credsFile))
-	if err := ioutil.WriteFile(credsFile, bucketCreds, 0600); err != nil { // likely a unrecoverable error, don't retry
-		return fmt.Errorf("failed to write to temp file for aws credentials, err: %w", err)
-	}
-
-	if err := c.ensurePullSecret(ctx); err != nil {
-		return fmt.Errorf("failed to deploy pull secret to hypershift namespace, err: %w", err)
+		awsPlatform = false
 	}
 
 	args := []string{
 		"render",
 		"--format", "json",
 		"--namespace", hypershiftOperatorKey.Namespace,
-		"--oidc-storage-provider-s3-bucket-name", bucketName,
-		"--oidc-storage-provider-s3-region", bucketRegion,
-		"--oidc-storage-provider-s3-credentials", credsFile,
+	}
+
+	if awsPlatform { // if the S3 secret is found, install hypershift with s3 options
+		bucketName := string(se.Data["bucket"])
+		bucketRegion := string(se.Data["region"])
+		bucketCreds := se.Data["credentials"]
+
+		file, err := ioutil.TempFile("", ".aws-creds")
+		if err != nil { // likely a unrecoverable error, don't retry
+			return fmt.Errorf("failed to create temp file for hoding aws credentials, err: %w", err)
+		}
+
+		credsFile := file.Name()
+		defer os.Remove(credsFile)
+
+		c.log.Info(fmt.Sprintf("aws config at: %s", credsFile))
+		if err := ioutil.WriteFile(credsFile, bucketCreds, 0600); err != nil { // likely a unrecoverable error, don't retry
+			return fmt.Errorf("failed to write to temp file for aws credentials, err: %w", err)
+		}
+
+		if err := c.ensurePullSecret(ctx); err != nil {
+			return fmt.Errorf("failed to deploy pull secret to hypershift namespace, err: %w", err)
+		}
+
+		awsArgs := []string{
+			"--oidc-storage-provider-s3-bucket-name", bucketName,
+			"--oidc-storage-provider-s3-region", bucketRegion,
+			"--oidc-storage-provider-s3-credentials", credsFile,
+		}
+
+		args = append(args, awsArgs...)
 	}
 
 	if c.withOverride {

--- a/pkg/agent/hypershift.go
+++ b/pkg/agent/hypershift.go
@@ -210,7 +210,7 @@ func (c *agentController) runHypershiftInstall(ctx context.Context) error {
 	bucketSecretKey := types.NamespacedName{Name: hypershiftBucketSecretName, Namespace: c.clusterName}
 	se := &corev1.Secret{}
 	if err := c.hubClient.Get(ctx, bucketSecretKey, se); err != nil {
-		c.log.Info(fmt.Sprintf("bucket secret(%s) not found on the hub, installaing hypershift operator for non-AWS platform.", bucketSecretKey))
+		c.log.Info(fmt.Sprintf("bucket secret(%s) not found on the hub, installing hypershift operator for non-AWS platform.", bucketSecretKey))
 
 		awsPlatform = false
 	}

--- a/pkg/agent/hypershift_test.go
+++ b/pkg/agent/hypershift_test.go
@@ -434,6 +434,11 @@ func TestRunHypershiftInstall(t *testing.T) {
 	err = aCtrl.spokeUncachedClient.Get(ctx, types.NamespacedName{Name: pullSecret.Name, Namespace: hypershiftOperatorKey.Namespace}, hsPullSecret)
 	assert.True(t, err != nil && errors.IsNotFound(err), "is true if the pull secret is not copied to the HyperShift namespace")
 
+	// Run hypershift install again with s3 bucket secret deleted
+	aCtrl.hubClient.Delete(ctx, bucketSecret)
+	err = aCtrl.runHypershiftInstall(ctx)
+	assert.Nil(t, err, "is nil if install HyperShift is sucessful")
+
 	// Cleanup
 	o := &AgentOptions{
 		Log:            zapr.NewLogger(zapLog),


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

# Description of the change(s):
* A user currently requires to create S3 bucket secret on the hub for the hypershift addon to install hypershift operator on a hosting cluster. S3 bucket secret is required only if you plan to create hosted clusters on AWS platform.
* TODO in backplane 2.1: Make the addon configurable with other hypershift operator installation options.

## Why do we need this PR:
*  We want to enable the hypershift addon without the S3 bucket secret for non-AWS platform provisioning,

## Issue reference: 
* https://github.com/stolostron/backlog/issues/22814

## Test API/Unit - Success
```script
r github.com/stolostron/hypershift-addon-operator/pkg/util -coverprofile cover.out
?   	github.com/stolostron/hypershift-addon-operator/cmd	[no test files]
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	11.465s	coverage: 69.6% of statements
?   	github.com/stolostron/hypershift-addon-operator/pkg/manager	[no test files]
?   	github.com/stolostron/hypershift-addon-operator/pkg/util	[no test files]
```
