### PR TITLE
Change name of kubeconfig and kubeadmin-password to use infraId

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -232,9 +232,9 @@ func (c *agentController) scaffoldHostedclusterSecrets(hcKey types.NamespacedNam
 				Name:      "admin-kubeconfig",
 				Namespace: hcKey.Namespace,
 				Labels: map[string]string{
-					"synced-from-spoke": "true",
-					"cluster-name":      hcKey.Name,
-					"hosting-namespace": hcKey.Namespace,
+					"synced-from-spoke":                  "true",
+					util.HypershiftClusterNameLabel:      hcKey.Name,
+					util.HypershiftHostingNamespaceLabel: hcKey.Namespace,
 				},
 			},
 		},
@@ -243,9 +243,9 @@ func (c *agentController) scaffoldHostedclusterSecrets(hcKey types.NamespacedNam
 				Name:      "kubeadmin-password",
 				Namespace: hcKey.Namespace,
 				Labels: map[string]string{
-					"synced-from-spoke": "true",
-					"cluster-name":      hcKey.Name,
-					"hosting-namespace": hcKey.Namespace,
+					"synced-from-spoke":                  "true",
+					util.HypershiftClusterNameLabel:      hcKey.Name,
+					util.HypershiftHostingNamespaceLabel: hcKey.Namespace,
 				},
 			},
 		},
@@ -260,8 +260,8 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	deleteMirrorSecrets := func() error {
 		secretSelector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
 			MatchLabels: map[string]string{
-				"cluster-name":      req.Name,
-				"hosting-namespace": req.Namespace,
+				util.HypershiftClusterNameLabel:      req.Name,
+				util.HypershiftHostingNamespaceLabel: req.Namespace,
 			},
 		})
 		if err != nil {

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -38,6 +38,7 @@ func TestReconcile(t *testing.T) {
 	hcNN := types.NamespacedName{Name: "hd-1", Namespace: "clusters"}
 	secrets := aCtrl.scaffoldHostedclusterSecrets(hcNN)
 	for _, sec := range secrets {
+		sec.SetName(fmt.Sprintf("%s-%s", hcNN.Name, sec.Name))
 		aCtrl.hubClient.Create(ctx, sec)
 		defer aCtrl.hubClient.Delete(ctx, sec)
 	}
@@ -55,11 +56,11 @@ func TestReconcile(t *testing.T) {
 
 	// Secret for kubconfig and kubeadmin-password are created
 	secret := &corev1.Secret{}
-	kcSecretNN := types.NamespacedName{Name: fmt.Sprintf("%s-%s-admin-kubeconfig", hcNN.Namespace, hcNN.Name), Namespace: aCtrl.clusterName}
+	kcSecretNN := types.NamespacedName{Name: fmt.Sprintf("%s-admin-kubeconfig", hc.Spec.InfraID), Namespace: aCtrl.clusterName}
 	err = aCtrl.hubClient.Get(ctx, kcSecretNN, secret)
 	assert.Nil(t, err, "is nil when the admin kubeconfig secret is found")
 
-	pwdSecretNN := types.NamespacedName{Name: fmt.Sprintf("%s-%s-kubeadmin-password", hcNN.Namespace, hcNN.Name), Namespace: aCtrl.clusterName}
+	pwdSecretNN := types.NamespacedName{Name: fmt.Sprintf("%s-kubeadmin-password", hc.Spec.InfraID), Namespace: aCtrl.clusterName}
 	err = aCtrl.hubClient.Get(ctx, pwdSecretNN, secret)
 	assert.Nil(t, err, "is nil when the kubeadmin password secret is found")
 
@@ -99,6 +100,7 @@ func getHostedCluster(hcNN types.NamespacedName) *hyperv1alpha1.HostedCluster {
 			Etcd: hyperv1alpha1.EtcdSpec{
 				ManagementType: hyperv1alpha1.Managed,
 			},
+			InfraID: "infra-abcdef",
 		},
 		Status: hyperv1alpha1.HostedClusterStatus{
 			KubeConfig:        &corev1.LocalObjectReference{Name: "kubeconfig"},

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -25,6 +25,10 @@ const (
 
 	HypershiftOperatorNamespace = "hypershift"
 	HypershiftOperatorName      = "operator"
+
+	// Labels for resources to reference the Hosted Cluster
+	HypershiftClusterNameLabel      = "hypershiftdeployments.cluster.open-cluster-management.io/cluster-name"
+	HypershiftHostingNamespaceLabel = "hypershiftdeployments.cluster.open-cluster-management.io/hosting-namespace"
 )
 
 // GenerateClientConfigFromSecret generate a client config from a given secret


### PR DESCRIPTION
Signed-off-by: Philip Wu <phwu@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Per SD request, update kubeconfig and kubeadmin-password secrets in managed cluster NS to use infraID in the name:
```
[infraID]-admin-kubeconfig 
[infraID]-kubeadmin-password 
```

Also needed new labels to help with filtering:
```
 labels:
    cluster-name: [hd-name]
    hosting-namespace:[hosting NS]
```

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Old name contains the hosting NS and HD name which users don't know

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/CMCS-102

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?   	github.com/stolostron/hypershift-addon-operator/cmd	[no test files]
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	7.290s	coverage: 69.9% of statements
?   	github.com/stolostron/hypershift-addon-operator/pkg/manager	[no test files]
?   	github.com/stolostron/hypershift-addon-operator/pkg/util	[no test files]
```
