### PR TITLE
Update hypershift version to match hypershift deployment controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-logr/zapr v1.2.0
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.18.1
-	github.com/openshift/hypershift v0.0.0-20220530194701-151246fd8480
+	github.com/openshift/hypershift v0.0.0-20220614212330-01bbfba6b681
 	github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -970,8 +970,8 @@ github.com/openshift/cluster-api-provider-kubevirt v0.0.0-20211223062810-ef64d5f
 github.com/openshift/cluster-api-provider-kubevirt v0.0.0-20211223062810-ef64d5ff1cde/go.mod h1:Z4fR4Cg8/z9GEys79MU+8CpX98aZQqI+tl9YIao0KxQ=
 github.com/openshift/custom-resource-status v0.0.0-20200602122900-c002fd1547ca h1:F1MEnOMwSrTA0YAkO0he9ip9w0JhYzI/iCB2mXmaSPg=
 github.com/openshift/custom-resource-status v0.0.0-20200602122900-c002fd1547ca/go.mod h1:GDjWl0tX6FNIj82vIxeudWeSx2Ff6nDZ8uJn0ohUFvo=
-github.com/openshift/hypershift v0.0.0-20220530194701-151246fd8480 h1:tY5p+Qv0JL4FhF5qI/MsC2GglZ0m3LoRKsYwBwcgEFU=
-github.com/openshift/hypershift v0.0.0-20220530194701-151246fd8480/go.mod h1:yZU2irRqb0kFn+M3X4LHNnzCvY24fgeGzPyHqyWfY5o=
+github.com/openshift/hypershift v0.0.0-20220614212330-01bbfba6b681 h1:PJ43GLKNq/WmcZDAD7N+vNvXDftEJZGCy08/002Yijc=
+github.com/openshift/hypershift v0.0.0-20220614212330-01bbfba6b681/go.mod h1:yZU2irRqb0kFn+M3X4LHNnzCvY24fgeGzPyHqyWfY5o=
 github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc h1:j+upvKc1uLzuL+q/JXie8+IMohOooTCaEC9w+4d1Ztk=
 github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc/go.mod h1:AMZwYwSdbvALDl3QobEzcJ2IeDO7DYLsr42izKzh524=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Update the go mod hypershift version

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  to match hypershift deployment controller's hypershift version

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-1447

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?   	github.com/stolostron/hypershift-addon-operator/cmd	[no test files]
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	5.503s	coverage: 70.0% of statements
?   	github.com/stolostron/hypershift-addon-operator/pkg/manager	[no test files]
?   	github.com/stolostron/hypershift-addon-operator/pkg/util	[no test files]
```

/assign @jnpacker 
/assign @philipwu08 
/assign @rokej 
/assign @zhujian7 