### PR TITLE
support private link hosted cluster

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -308,9 +308,9 @@ func (c *agentController) generateExtManagedKubeconfigSecret(ctx context.Context
 	if err != nil {
 		c.log.Error(err, "failed to createOrUpdate external-managed-kubeconfig secret", "secret", client.ObjectKeyFromObject(secret))
 		return err
-	} else {
-		c.log.Info("createOrUpdate external-managed-kubeconfig secret", "secret", client.ObjectKeyFromObject(secret))
 	}
+
+	c.log.Info("createOrUpdate external-managed-kubeconfig secret", "secret", client.ObjectKeyFromObject(secret))
 
 	return nil
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -253,6 +254,69 @@ func (c *agentController) scaffoldHostedclusterSecrets(hcKey types.NamespacedNam
 	}
 }
 
+func (c *agentController) generateExtManagedKubeconfigSecret(ctx context.Context, secretData map[string][]byte, hc hyperv1alpha1.HostedCluster) error {
+	// 1. Get hosted cluster's admin kubeconfig secret
+	secret := &corev1.Secret{}
+	secret.SetName("external-managed-kubeconfig")
+	secret.SetNamespace("klusterlet-" + hc.Spec.InfraID)
+
+	kubeconfigData := secretData["kubeconfig"]
+
+	if kubeconfigData != nil {
+		kubeconfig, err := clientcmd.Load(kubeconfigData)
+
+		if err != nil {
+			c.log.Error(err, err.Error())
+			return fmt.Errorf("failed to load kubeconfig from secret: %s", secret.GetName())
+		}
+
+		if len(kubeconfig.Clusters) == 0 {
+			c.log.Error(err, err.Error())
+			return fmt.Errorf("there is no cluster in kubeconfig from secret: %s", secret.GetName())
+		}
+
+		if kubeconfig.Clusters["cluster"] == nil {
+			c.log.Error(err, err.Error())
+			return fmt.Errorf("failed to get a cluster from kubeconfig in secret: %s", secret.GetName())
+		}
+
+		// 2. Replace the config.Clusters["cluster"].Server URL with internal kubeadpi service URL kube-apiserver.<Namespace>.svc.cluster.local
+		clusterServerURL := "https://kube-apiserver." + hc.Namespace + "-" + hc.Name + ".svc.cluster.local:6443"
+
+		kubeconfig.Clusters["cluster"].Server = clusterServerURL
+
+		newKubeconfig, err := clientcmd.Write(*kubeconfig)
+
+		if err != nil {
+			c.log.Error(err, err.Error())
+			return fmt.Errorf("failed to write new kubeconfig to secret: %s", secret.GetName())
+		}
+
+		secretData["kubeconfig"] = newKubeconfig
+
+		secret.Data = secretData
+
+		c.log.Info(fmt.Sprintf("Set the cluster server URL to %s in external-managed-kubeconfig secret", clusterServerURL))
+
+		nilFunc := func() error { return nil }
+
+		// 3. Create the admin kubeconfig secret as external-managed-kubeconfig in klusterlet-<infraID> namespace
+		_, err = controllerutil.CreateOrUpdate(ctx, c.spokeClient, secret, nilFunc)
+		if err != nil {
+			c.log.Error(err, fmt.Sprintf("failed to createOrUpdate external-managed-kubeconfig secret %s", client.ObjectKeyFromObject(secret)))
+			return err
+		} else {
+			c.log.Info(fmt.Sprintf("createOrUpdate external-managed-kubeconfig secret %s", client.ObjectKeyFromObject(secret)))
+		}
+
+	} else {
+		//c.log.Error(fmt.Errorf("failed to get kubeconfig from secret: %s", secret.GetName()), "failed to get kubeconfig from secret: %s", secret.GetName())
+		return fmt.Errorf("failed to get kubeconfig from secret: %s", secret.GetName())
+	}
+
+	return nil
+}
+
 func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	c.log.Info(fmt.Sprintf("Reconciling hostedcluster secrect %s", req))
 	defer c.log.Info(fmt.Sprintf("Done reconcile hostedcluster secrect %s", req))
@@ -339,6 +403,21 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			}
 			hubMirrorSecret.Data = se.Data
 
+			// Create or update external-managed-kubeconfig secret for managed cluster registration agent
+			if strings.HasSuffix(hubMirrorSecret.Name, "admin-kubeconfig") {
+				c.log.Info("Generating external-managed-kubeconfig secret")
+
+				extSecret := se.DeepCopy()
+
+				errExt := c.generateExtManagedKubeconfigSecret(ctx, extSecret.Data, *hc)
+
+				if errExt != nil {
+					lastErr = errExt
+				} else {
+					c.log.Info("Successfully generated external-managed-kubeconfig secret")
+				}
+			}
+
 			nilFunc := func() error { return nil }
 
 			_, err := controllerutil.CreateOrUpdate(ctx, c.hubClient, hubMirrorSecret, nilFunc)
@@ -348,6 +427,7 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			} else {
 				c.log.Info(fmt.Sprintf("createOrUpdate hostedcluster secret %s to hub", client.ObjectKeyFromObject(hubMirrorSecret)))
 			}
+
 		}
 
 		return lastErr


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
*  Create `external-managed-kubeconfig` with internal hosted cluster kube API server URL so in both private and public modes, the registration agent can connect to the hosted cluster's API server for managed cluster registration.
* https://github.com/stolostron/backlog/issues/23514#issuecomment-1157738028

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  To support private mode hosted clusters

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://github.com/stolostron/backlog/issues/23514
* https://issues.redhat.com/browse/ACM-1466

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
Running tool: /usr/local/go/bin/go test -timeout 30s -run ^TestReconcile$ github.com/stolostron/hypershift-addon-operator/pkg/agent

ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	0.843s
```


Deployed an AWS hosted cluster successfully and the server URL in `klusterlet-rj-0620a-tkh4g/external-managed-kubeconfig` was set as the following.

```
    server: https://kube-apiserver.clusters-rj-0620a.svc.cluster.local:6443
```