### PR TITLE
Reduce pod privilege

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,12 @@ RUN make build --warn-undefined-variables
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
-
-ENV USER_UID=1001
-
 # Add the binaries
 COPY --from=builder /go/src/github.com/stolostron/hypershift-addon-operator/bin/hypershift-addon .
+<<<<<<< Updated upstream
 
 
 USER ${USER_UID}
+=======
+COPY --from=builder /go/src/github.com/stolostron/hypershift-addon-operator/bin/hypershift /usr/bin
+>>>>>>> Stashed changes

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,3 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 # Add the binaries
 COPY --from=builder /go/src/github.com/stolostron/hypershift-addon-operator/bin/hypershift-addon .
-<<<<<<< Updated upstream
-
-
-USER ${USER_UID}
-=======
-COPY --from=builder /go/src/github.com/stolostron/hypershift-addon-operator/bin/hypershift /usr/bin
->>>>>>> Stashed changes

--- a/pkg/manager/manifests/templates/deployment.yaml
+++ b/pkg/manager/manifests/templates/deployment.yaml
@@ -20,10 +20,19 @@ spec:
       - name: hub-config
         secret:
           secretName: {{ .KubeConfigSecret }}
+      securityContext:
+        runAsNonRoot: true
       containers:
       - name: {{ .AddonName }}
         image: {{ .Image }}
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
         args:
           - "./hypershift-addon"
           - "agent"


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Remove user id from Dockerfile
* Add reduced security context in the deployment

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  During runtime analysis pod(s) were identified not using the OpenShift restricted SCC.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://github.com/stolostron/backlog/issues/23950

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
Verified that the addon agent container runs fine and reconciles. 
```script
rokej@rjung-mac HypershiftAgent % kubectl logs hypershift-addon-agent-7687684966-dz8rq -n open-cluster-management-agent-addon
I0712 01:22:50.301235       1 request.go:601] Waited for 1.047915861s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/apis/autoscaling.openshift.io/v1beta1?timeout=32s
2022-07-12T01:22:58.614Z	INFO	agent.agent-reconciler	agent/hypershift.go:200	enter runHypershiftInstall
2022-07-12T01:22:58.619Z	ERROR	agent.agent-reconciler	agent/hypershift.go:207	hypershift operator already exists at the required image level, skip update
github.com/stolostron/hypershift-addon-operator/pkg/agent.(*agentController).runHypershiftInstall
	/go/src/github.com/stolostron/hypershift-addon-operator/pkg/agent/hypershift.go:207
github.com/stolostron/hypershift-addon-operator/pkg/agent.(*agentController).runHypershiftCmdWithRetires
	/go/src/github.com/stolostron/hypershift-addon-operator/pkg/agent/hypershift.go:102
github.com/stolostron/hypershift-addon-operator/pkg/agent.(*AgentOptions).runControllerManager
	/go/src/github.com/stolostron/hypershift-addon-operator/pkg/agent/agent.go:164
github.com/stolostron/hypershift-addon-operator/pkg/agent.NewAgentCommand.func1
	/go/src/github.com/stolostron/hypershift-addon-operator/pkg/agent/agent.go:64
github.com/spf13/cobra.(*Command).execute
	/go/src/github.com/stolostron/hypershift-addon-operator/vendor/github.com/spf13/cobra/command.go:856
github.com/spf13/cobra.(*Command).ExecuteC
	/go/src/github.com/stolostron/hypershift-addon-operator/vendor/github.com/spf13/cobra/command.go:974
github.com/spf13/cobra.(*Command).Execute
	/go/src/github.com/stolostron/hypershift-addon-operator/vendor/github.com/spf13/cobra/command.go:902
main.main
	/go/src/github.com/stolostron/hypershift-addon-operator/cmd/main.go:41
runtime.main
	/usr/local/go/src/runtime/proc.go:250
2022-07-12T01:22:58.619Z	INFO	agent.agent-reconciler	agent/hypershift.go:208	exit runHypershiftInstall
2022-07-12T01:22:58.623Z	INFO	agent.controller-manager-setup	agent/agent.go:187	starting manager
2022-07-12T01:31:34.166Z	INFO	agent.agent-reconciler	agent/agent.go:319	Reconciling hostedcluster secrect clusters/rj-0620a
2022-07-12T01:31:34.166Z	INFO	agent.agent-reconciler	agent/agent.go:376	Done reconcile hostedcluster secrect clusters/rj-0620a
2022-07-12T01:31:34.191Z	INFO	agent.agent-reconciler	agent/agent.go:319	Reconciling hostedcluster secrect clusters/rj-0620a
2022-07-12T01:31:34.191Z	INFO	agent.agent-reconciler	agent/agent.go:376	Done reconcile hostedcluster secrect clusters/rj-0620a
2022-07-12T01:31:34.214Z	INFO	agent.agent-reconciler	agent/agent.go:319	Reconciling hostedcluster secrect clusters/rj-0620a
2022-07-12T01:31:34.214Z	INFO	agent.agent-reconciler	agent/agent.go:376	Done reconcile hostedcluster secrect clusters/rj-0620a
2022-07-12T01:31:36.586Z	INFO	agent.agent-reconciler	agent/agent.go:319	Reconciling hostedcluster secrect clusters/rj-0620a
2022-07-12T01:31:36.586Z	INFO	agent.agent-reconciler	agent/agent.go:376	Done reconcile hostedcluster secrect clusters/rj-0620a
2022-07-12T01:31:37.750Z	INFO	agent.agent-reconciler	agent/agent.go:319	Reconciling hostedcluster secrect clusters/rj-0620a
2022-07-12T01:31:37.750Z	INFO	agent.agent-reconciler	agent/agent.go:376	Done reconcile hostedcluster secrect clusters/rj-0620a
2022-07-12T01:32:07.504Z	INFO	agent.agent-reconciler	agent/agent.go:319	Reconciling hostedcluster secrect clusters/rj-0620a
2022-07-12T01:32:07.505Z	INFO	agent.agent-reconciler	agent/agent.go:376	Done reconcile hostedcluster secrect clusters/rj-0620a
2022-07-12T01:32:07.835Z	INFO	agent.agent-reconciler	agent/agent.go:319	Reconciling hostedcluster secrect clusters/rj-0620a
2022-07-12T01:32:07.835Z	INFO	agent.agent-reconciler	agent/agent.go:376	Done reconcile hostedcluster secrect clusters/rj-0620a
2022-07-12T01:32:10.439Z	INFO	agent.agent-reconciler	agent/agent.go:319	Reconciling hostedcluster secrect clusters/rj-0620a
2022-07-12T01:32:10.439Z	INFO	agent.agent-reconciler	agent/agent.go:376	Done reconcile hostedcluster secrect clusters/rj-0620a
2022-07-12T01:32:37.856Z	INFO	agent.agent-reconciler	agent/agent.go:319	Reconciling hostedcluster secrect clusters/rj-0620a
2022-07-12T01:32:37.856Z	INFO	agent.agent-reconciler	agent/agent.go:376	Done reconcile hostedcluster secrect clusters/rj-0620a
2022-07-12T01:32:50.067Z	INFO	agent.agent-reconciler	agent/agent.go:319	Reconciling hostedcluster secrect clusters/rj-0620a
2022-07-12T01:32:50.067Z	INFO	agent.agent-reconciler	agent/agent.go:376	Done reconcile hostedcluster secrect clusters/rj-0620a
2022-07-12T01:32:50.232Z	INFO	agent.agent-reconciler	agent/agent.go:319	Reconciling hostedcluster secrect clusters/rj-0620a
2022-07-12T01:32:50.232Z	INFO	agent.agent-reconciler	agent/agent.go:376	Done reconcile hostedcluster secrect clusters/rj-0620a
2022-07-12T01:32:50.250Z	INFO	agent.agent-reconciler	agent/agent.go:319	Reconciling hostedcluster secrect clusters/rj-0620a
2022-07-12T01:32:50.250Z	INFO	agent.agent-reconciler	agent/agent.go:376	Done reconcile hostedcluster secrect clusters/rj-0620a
2022-07-12T01:33:21.364Z	INFO	agent.agent-reconciler	agent/agent.go:319	Reconciling hostedcluster secrect clusters/rj-0620a
2022-07-12T01:33:21.765Z	INFO	agent.agent-reconciler	agent/agent.go:406	Generating external-managed-kubeconfig secret
2022-07-12T01:33:21.768Z	INFO	agent.agent-reconciler	agent/agent.go:302	Set the cluster server URL in external-managed-kubeconfig secret	{"clusterServerURL": "https://kube-apiserver.clusters-rj-0620a.svc.cluster.local:6443"}
2022-07-12T01:33:21.789Z	INFO	agent.agent-reconciler	agent/agent.go:313	createOrUpdate external-managed-kubeconfig secret	{"secret": "klusterlet-rj-0620a-9kg8x/external-managed-kubeconfig"}
2022-07-12T01:33:21.796Z	INFO	agent.agent-reconciler	agent/agent.go:415	Successfully generated external-managed-kubeconfig secret
2022-07-12T01:33:22.035Z	INFO	agent.agent-reconciler	agent/agent.go:426	createOrUpdate hostedcluster secret local-cluster/rj-0620a-9kg8x-admin-kubeconfig to hub
2022-07-12T01:33:22.035Z	ERROR	agent.agent-reconciler	agent/agent.go:395	failed to get hostedcluster secret clusters/rj-0620a-kubeadmin-password on local cluster, skip this one	{"error": "Secret \"rj-0620a-kubeadmin-password\" not found"}
github.com/stolostron/hypershift-addon-operator/pkg/agent.(*agentController).Reconcile.func2
	/go/src/github.com/stolostron/hypershift-addon-operator/pkg/agent/agent.go:395
github.com/stolostron/hypershift-addon-operator/pkg/agent.(*agentController).Reconcile
	/go/src/github.com/stolostron/hypershift-addon-operator/pkg/agent/agent.go:434
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
	/go/src/github.com/stolostron/hypershift-addon-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:121
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/src/github.com/stolostron/hypershift-addon-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:320
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/src/github.com/stolostron/hypershift-addon-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:273
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/go/src/github.com/stolostron/hypershift-addon-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:234
2022-07-12T01:33:22.035Z	INFO	agent.agent-reconciler	agent/agent.go:435	Done reconcile hostedcluster secrect clusters/rj-0620a
2022-07-12T01:33:22.040Z	INFO	agent.agent-reconciler	agent/agent.go:319	Reconciling hostedcluster secrect clusters/rj-0620a
2022-07-12T01:33:22.041Z	INFO	agent.agent-reconciler	agent/agent.go:406	Generating external-managed-kubeconfig secret

```

Container user list
```
sh-4.4$ whoami
1000700000
sh-4.4$ vi /etc/passwd
sh: vi: command not found
sh-4.4$ cat /etc/passwd
root:x:0:0:root:/root:/bin/bash
bin:x:1:1:bin:/bin:/sbin/nologin
daemon:x:2:2:daemon:/sbin:/sbin/nologin
adm:x:3:4:adm:/var/adm:/sbin/nologin
lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
sync:x:5:0:sync:/sbin:/bin/sync
shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
halt:x:7:0:halt:/sbin:/sbin/halt
mail:x:8:12:mail:/var/spool/mail:/sbin/nologin
operator:x:11:0:operator:/root:/sbin/nologin
games:x:12:100:games:/usr/games:/sbin/nologin
ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin
nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin
1000700000:x:1000700000:0:1000700000 user:/:/sbin/nologin
```

Pod SCC
```
  securityContext:
    fsGroup: 1000700000
    runAsNonRoot: true
    seLinuxOptions:
      level: s0:c26,c25
```