### PR TITLE
disable readOnlyRootFilesystem

### DIFF
--- a/pkg/manager/manifests/templates/deployment.yaml
+++ b/pkg/manager/manifests/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
             drop:
             - ALL
           privileged: false
-          readOnlyRootFilesystem: true
+          readOnlyRootFilesystem: false
         args:
           - "./hypershift-addon"
           - "agent"


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

# Description of the change(s):
* In the hypershift addon agent deployment YAML, disable readOnlyRootFilesystem in the container security context because the agent needs to write a hypershift image override reference file to the /tmp filesystem for hypershift operator installation.

## Why do we need this PR:
*  Same as above

## Issue reference: 
* https://github.com/stolostron/backlog/issues/24122

## Test API/Unit - Success
Now the addon agent can write to /tmp/hypershift-imagestream742529715 and install the hypershift operator with `--image-refs /tmp/hypershift-imagestream742529715` parameter.

```script
kubectl logs hypershift-addon-agent-6fc8794694-rlqdq -n open-cluster-management-agent-addon
I0714 17:29:33.037209       1 request.go:601] Waited for 1.046798497s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/apis/scheduling.k8s.io/v1?timeout=32s
2022-07-14T17:29:40.472Z	INFO	agent.agent-reconciler	agent/hypershift.go:200	enter runHypershiftInstall
2022-07-14T17:29:40.538Z	INFO	agent.agent-reconciler	agent/hypershift.go:378	createorupdate the the secret (hypershift/hypershift-operator-oidc-provider-s3-credentials) on cluster local-cluster
2022-07-14T17:29:40.569Z	INFO	agent.agent-reconciler	agent/hypershift.go:250	oidc s3 bucket, region & credential arguments included
2022-07-14T17:29:40.574Z	INFO	agent.agent-reconciler	agent/hypershift.go:390	mce pull secret not found, skip copy it to the hypershift namespace	{"namespace": "open-cluster-management-agent-addon", "name": "open-cluster-management-image-pull-credentials"}
2022-07-14T17:29:40.582Z	INFO	agent.agent-reconciler	agent/hypershift.go:277	private-link secret(local-cluster/hypershift-operator-private-link-credentials) was not found
2022-07-14T17:29:40.596Z	INFO	agent.agent-reconciler	agent/hypershift.go:491	imagestream at: /tmp/hypershift-imagestream742529715
2022-07-14T17:29:40.596Z	INFO	agent.agent-reconciler	agent/hypershift.go:294	hypershift install args: [render --format json --namespace hypershift --oidc-storage-provider-s3-bucket-name rj-aws-hyper --oidc-storage-provider-s3-region us-east-1 --oidc-storage-provider-s3-secret hypershift-operator-oidc-provider-s3-credentials --image-refs /tmp/hypershift-imagestream742529715]
```
