### PR TITLE
Add missing support for External DNS parameters and credentials

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -38,6 +38,7 @@ const (
 	hypershiftAddonAnnotationKey    = "hypershift.open-cluster-management.io/createBy"
 	hypershiftBucketSecretName      = "hypershift-operator-oidc-provider-s3-credentials"
 	hypershiftPrivateLinkSecretName = "hypershift-operator-private-link-credentials"
+	hypershiftExternalDNSSecretName = "hypershift-operator-external-dns-credentials"
 	kindAppliedManifestWork         = "AppliedManifestWork"
 	hypershiftDeploymentAnnoKey     = "cluster.open-cluster-management.io/hypershiftdeployment"
 	managedClusterAnnoKey           = "cluster.open-cluster-management.io/managedcluster-name"


### PR DESCRIPTION
Signed-off-by: Joshua Packer <jpacker@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Add missing External DNS support

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  This is one of three missing `hypershift install --help` options

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-1558

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?       github.com/stolostron/hypershift-addon-operator/cmd     [no test files]
ok      github.com/stolostron/hypershift-addon-operator/pkg/agent       5.559s  coverage: 72.3% of statements
?       github.com/stolostron/hypershift-addon-operator/pkg/manager     [no test files]
?       github.com/stolostron/hypershift-addon-operator/pkg/util        [no test files]
```
