### PR TITLE
enable telemetry in hypershift operator installation

### DIFF
--- a/pkg/agent/hypershift.go
+++ b/pkg/agent/hypershift.go
@@ -295,6 +295,13 @@ func (c *agentController) runHypershiftInstall(ctx context.Context) error {
 		c.log.Info(fmt.Sprintf("external dns secret(%s) was not found", extDNSSecretKey))
 	}
 
+	//Enable control plane telemetry forwarding
+	telemetryArgs := []string{
+		"--enable-uwm-telemetry-remote-write",
+		"--platform-monitoring", "OperatorOnly",
+	}
+	args = append(args, telemetryArgs...)
+
 	if c.withOverride {
 		imageStreamFile, err := c.readInDownstreamOverride()
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

# Description of the change(s):
* Enable telemetry when the addon installs hypershift operator so that it can forward control plane telemetry correctly.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-1574

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
The hypershift operator container runs with the telemetry arguments.
```script
  containers:
  - args:
    - run
    - --namespace=$(MY_NAMESPACE)
    - --pod-name=$(MY_NAME)
    - --metrics-addr=:9000
    - --enable-ocp-cluster-monitoring=false
    - --enable-ci-debug-output=false
    - --private-platform=None
    - --oidc-storage-provider-s3-bucket-name=rj-aws-hyper
    - --oidc-storage-provider-s3-region=us-east-1
    - --oidc-storage-provider-s3-credentials=/etc/oidc-storage-provider-s3-creds/credentials
    - --enable-uwm-telemetry-remote-write
    command:
    - /usr/bin/hypershift-operator
    env:
    - name: MY_NAMESPACE
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: metadata.namespace
    - name: MY_NAME
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: metadata.name
    - name: METRICS_SET
      value: Telemetry
```

HypershiftDeployment created successfully
```
NAMESPACE   NAME       VERSION   KUBECONFIG                  PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
clusters    rj-0816e   4.11.0    rj-0816e-admin-kubeconfig   Completed   True        False         The hosted control plane is available

NAME       TYPE   INFRA                  IAM                    MANIFESTWORK           PROVIDER REF   PROGRESS    AVAILABLE
rj-0816e   AWS    ConfiguredAsExpected   ConfiguredAsExpected   ConfiguredAsExpected   AsExpected     Completed   True
```

HypershiftDeployment, HC and NPs deleted successfully.
