### PR TITLE
Don’t provide the external-managed-kubeconfig secret until the hosted…

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -129,7 +129,8 @@ func getHostedCluster(hcNN types.NamespacedName) *hyperv1alpha1.HostedCluster {
 		Status: hyperv1alpha1.HostedClusterStatus{
 			KubeConfig:        &corev1.LocalObjectReference{Name: "kubeconfig"},
 			KubeadminPassword: &corev1.LocalObjectReference{Name: "kubeadmin"},
-			Conditions:        []metav1.Condition{{Type: string(hyperv1alpha1.HostedClusterAvailable), Status: metav1.ConditionTrue}},
+			Conditions: []metav1.Condition{{Type: string(hyperv1alpha1.HostedClusterAvailable), Status: metav1.ConditionTrue},
+				{Type: string(hyperv1alpha1.ClusterVersionSucceeding), Status: metav1.ConditionTrue}},
 		},
 	}
 	return hc


### PR DESCRIPTION
… cluster status is completed(condition ClusterVersionSucceeding to be true)

Signed-off-by: Mike Ng <ming@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Wait until the HC status condition ClusterVersionSucceeding is true before creating the external managed kubeconfig. The re-queue time is set to 1 minute. 

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  If the HC status is not fully completed then at the time of using the kubeconfig to connect to the cluster, the invalid ocp/k8s version is picked up.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://github.com/stolostron/backlog/issues/24918

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?   	github.com/stolostron/hypershift-addon-operator/cmd	[no test files]
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	1.648s	coverage: 71.7% of statements
?   	github.com/stolostron/hypershift-addon-operator/pkg/manager	[no test files]
?   	github.com/stolostron/hypershift-addon-operator/pkg/util	[no test files]
```
