### PR TITLE
Support upgrade of images for Hypershift operators

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,16 +3,19 @@ module github.com/stolostron/hypershift-addon-operator
 go 1.18
 
 require (
+	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.1
 	github.com/go-logr/zapr v1.2.0
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.19.0
+	github.com/openshift/api v0.0.0-20220525145417-ee5b62754c68
 	github.com/openshift/hypershift v0.0.0-20220810221813-2b7ac5268ac7
 	github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.1
 	go.uber.org/zap v1.19.1
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.24.2
 	k8s.io/apimachinery v0.24.2
 	k8s.io/client-go v0.24.2
@@ -56,7 +59,6 @@ require (
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/felixge/httpsnoop v1.0.2 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
-	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.6 // indirect
 	github.com/go-openapi/swag v0.21.1 // indirect
@@ -86,7 +88,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
-	github.com/openshift/api v0.0.0-20220525145417-ee5b62754c68 // indirect
 	github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a // indirect
 	github.com/openshift/cluster-api-provider-agent/api v0.0.0-20220227135922-dd6353f609dc // indirect
 	github.com/openshift/custom-resource-status v0.0.0-20200602122900-c002fd1547ca // indirect
@@ -137,7 +138,6 @@ require (
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	helm.sh/helm/v3 v3.7.2 // indirect
 	k8s.io/apiextensions-apiserver v0.24.2 // indirect

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -29,19 +29,11 @@ import (
 
 	hyperv1alpha1 "github.com/openshift/hypershift/api/v1alpha1"
 	"open-cluster-management.io/addon-framework/pkg/lease"
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
 
+	"github.com/stolostron/hypershift-addon-operator/pkg/install"
 	"github.com/stolostron/hypershift-addon-operator/pkg/util"
-)
-
-const (
-	hypershiftAddonAnnotationKey    = "hypershift.open-cluster-management.io/createBy"
-	hypershiftBucketSecretName      = "hypershift-operator-oidc-provider-s3-credentials"
-	hypershiftPrivateLinkSecretName = "hypershift-operator-private-link-credentials"
-	hypershiftExternalDNSSecretName = "hypershift-operator-external-dns-credentials"
-	kindAppliedManifestWork         = "AppliedManifestWork"
-	hypershiftDeploymentAnnoKey     = "cluster.open-cluster-management.io/hypershiftdeployment"
-	managedClusterAnnoKey           = "cluster.open-cluster-management.io/managedcluster-name"
 )
 
 var (
@@ -51,6 +43,7 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(hyperv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(addonv1alpha1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 
@@ -152,18 +145,21 @@ func (o *AgentOptions) runControllerManager(ctx context.Context) error {
 	}
 
 	aCtrl := &agentController{
-		hubClient:                 hubClient,
-		spokeUncachedClient:       spokeKubeClient,
-		spokeClient:               mgr.GetClient(),
-		spokeClustersClient:       spokeClusterClient,
-		hypershiftInstallExecutor: &HypershiftLibExecutor{},
+		hubClient:           hubClient,
+		spokeUncachedClient: spokeKubeClient,
+		spokeClient:         mgr.GetClient(),
+		spokeClustersClient: spokeClusterClient,
 	}
 
 	o.Log = o.Log.WithName("agent-reconciler")
 	aCtrl.plugInOption(o)
 
+	// Image upgrade controller
+	uCtrl := install.NewUpgradeController(hubClient, spokeKubeClient, o.Log, o.AddonName, o.AddonNamespace, o.SpokeClusterName,
+		o.HypershiftOperatorImage, o.PullSecretName, o.WithOverride)
+
 	// retry 3 times, in case something wrong with creating the hypershift install job
-	if err := aCtrl.runHypershiftCmdWithRetires(ctx, 3, time.Second*10, aCtrl.runHypershiftInstall); err != nil {
+	if err := uCtrl.RunHypershiftCmdWithRetires(ctx, 3, time.Second*10, uCtrl.RunHypershiftInstall); err != nil {
 		log.Error(err, "failed to install hypershift Operator")
 		return err
 	}
@@ -193,6 +189,11 @@ func (o *AgentOptions) runControllerManager(ctx context.Context) error {
 		return fmt.Errorf("unable to create agent controller: %s, err: %w", util.AddonControllerName, err)
 	}
 
+	//+kubebuilder:scaffold:builder
+	if err = uCtrl.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create image upgrade controller: %s, err: %w", util.ImageUpgradeControllerName, err)
+	}
+
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		return fmt.Errorf("unable to set up health check, err: %w", err)
 	}
@@ -204,29 +205,18 @@ func (o *AgentOptions) runControllerManager(ctx context.Context) error {
 }
 
 type agentController struct {
-	hubClient                 client.Client
-	spokeUncachedClient       client.Client
-	spokeClient               client.Client              //local for agent
-	spokeClustersClient       clusterclientset.Interface // client used to create cluster claim for the hypershift management cluster
-	log                       logr.Logger
-	recorder                  events.Recorder
-	clusterName               string
-	addonName                 string
-	addonNamespace            string
-	operatorImage             string
-	pullSecret                string
-	withOverride              bool
-	hypershiftInstallExecutor HypershiftInstallExecutorInterface
+	hubClient           client.Client
+	spokeUncachedClient client.Client
+	spokeClient         client.Client              //local for agent
+	spokeClustersClient clusterclientset.Interface // client used to create cluster claim for the hypershift management cluster
+	log                 logr.Logger
+	recorder            events.Recorder
+	clusterName         string
 }
 
 func (c *agentController) plugInOption(o *AgentOptions) {
 	c.log = o.Log
 	c.clusterName = o.SpokeClusterName
-	c.addonName = o.AddonName
-	c.addonNamespace = o.AddonNamespace
-	c.operatorImage = o.HypershiftOperatorImage
-	c.pullSecret = o.PullSecretName
-	c.withOverride = o.WithOverride
 }
 
 func (c *agentController) scaffoldHostedclusterSecrets(hcKey types.NamespacedName) []*corev1.Secret {
@@ -260,7 +250,7 @@ func (c *agentController) generateExtManagedKubeconfigSecret(ctx context.Context
 	// 1. Get hosted cluster's admin kubeconfig secret
 	secret := &corev1.Secret{}
 	secret.SetName("external-managed-kubeconfig")
-	managedClusterAnnoValue, ok := hc.GetAnnotations()[managedClusterAnnoKey]
+	managedClusterAnnoValue, ok := hc.GetAnnotations()[util.ManagedClusterAnnoKey]
 	if !ok || len(managedClusterAnnoValue) == 0 {
 		managedClusterAnnoValue = hc.Spec.InfraID
 	}
@@ -383,7 +373,7 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	createOrUpdateMirrorSecrets := func() error {
 		var lastErr error
-		hypershiftDeploymentAnnoValue, ok := hc.GetAnnotations()[hypershiftDeploymentAnnoKey]
+		hypershiftDeploymentAnnoValue, ok := hc.GetAnnotations()[util.HypershiftDeploymentAnnoKey]
 		if !ok || len(hypershiftDeploymentAnnoValue) == 0 {
 			lastErr = fmt.Errorf("failed to get hypershift deployment annotation from hosted cluster")
 		}
@@ -391,7 +381,7 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		hcSecrets := c.scaffoldHostedclusterSecrets(req.NamespacedName)
 		for _, se := range hcSecrets {
 			secretName := hc.Spec.InfraID
-			managedClusterAnnoValue, ok := hc.GetAnnotations()[managedClusterAnnoKey]
+			managedClusterAnnoValue, ok := hc.GetAnnotations()[util.ManagedClusterAnnoKey]
 			if ok && len(managedClusterAnnoValue) > 0 {
 				secretName = managedClusterAnnoValue
 			}
@@ -407,7 +397,7 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			}
 
 			if len(hypershiftDeploymentAnnoValue) != 0 {
-				hubMirrorSecret.SetAnnotations(map[string]string{hypershiftDeploymentAnnoKey: hypershiftDeploymentAnnoValue})
+				hubMirrorSecret.SetAnnotations(map[string]string{util.HypershiftDeploymentAnnoKey: hypershiftDeploymentAnnoValue})
 			}
 			hubMirrorSecret.Data = se.Data
 
@@ -460,7 +450,7 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 func (c *agentController) SetupWithManager(mgr ctrl.Manager) error {
 	filterByOwner := func(obj client.Object) bool {
-		hypershiftDeploymentAnnoValue, ok := obj.GetAnnotations()[hypershiftDeploymentAnnoKey]
+		hypershiftDeploymentAnnoValue, ok := obj.GetAnnotations()[util.HypershiftDeploymentAnnoKey]
 		if !ok || len(hypershiftDeploymentAnnoValue) == 0 {
 			return false
 		}
@@ -472,4 +462,57 @@ func (c *agentController) SetupWithManager(mgr ctrl.Manager) error {
 		WithEventFilter(predicate.NewPredicateFuncs(filterByOwner)).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
 		Complete(c)
+}
+
+func NewCleanupCommand(addonName string, logger logr.Logger) *cobra.Command {
+	o := NewAgentOptions(addonName, logger)
+
+	ctx := context.TODO()
+
+	cmd := &cobra.Command{
+		Use:   "cleanup",
+		Short: fmt.Sprintf("clean up the hypershift operator if it's deployed by %s", addonName),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return o.runCleanup(ctx, nil)
+		},
+	}
+
+	o.AddFlags(cmd)
+
+	cmd.FParseErrWhitelist.UnknownFlags = true
+
+	return cmd
+}
+
+func (o *AgentOptions) runCleanup(ctx context.Context, uCtrl *install.UpgradeController) error {
+	log := o.Log.WithName("controller-manager-setup")
+
+	flag.Parse()
+
+	if uCtrl == nil {
+		spokeConfig := ctrl.GetConfigOrDie()
+
+		c, err := client.New(spokeConfig, client.Options{Scheme: scheme})
+		if err != nil {
+			return fmt.Errorf("failed to create spokeUncacheClient, err: %w", err)
+		}
+
+		if err := hyperv1alpha1.AddToScheme(scheme); err != nil {
+			log.Error(err, "unable add HyperShift APIs to scheme")
+			return fmt.Errorf("unable add HyperShift APIs to scheme, err: %w", err)
+		}
+
+		// Image upgrade controller
+		o.Log = o.Log.WithName("hypersfhit-operation")
+		uCtrl = install.NewUpgradeController(nil, c, o.Log, o.AddonName, o.AddonNamespace, o.SpokeClusterName,
+			o.HypershiftOperatorImage, o.PullSecretName, o.WithOverride)
+	}
+
+	// retry 3 times, in case something wrong with deleting the hypershift install job
+	if err := uCtrl.RunHypershiftCmdWithRetires(ctx, 3, time.Second*10, uCtrl.RunHypershiftCleanup); err != nil {
+		log.Error(err, "failed to clean up hypershift Operator")
+		return err
+	}
+
+	return nil
 }

--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -1,35 +1,28 @@
-package agent
+package install
 
 import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"math/big"
 	"os"
 	"time"
 
-	"github.com/go-logr/logr"
-	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	imageapi "github.com/openshift/api/image/v1"
 	hyperv1alpha1 "github.com/openshift/hypershift/api/v1alpha1"
-	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 
 	"github.com/stolostron/hypershift-addon-operator/pkg/util"
 )
@@ -41,67 +34,7 @@ var (
 	}
 )
 
-func init() {
-	utilruntime.Must(addonv1alpha1.AddToScheme(scheme))
-}
-
-func NewCleanupCommand(addonName string, logger logr.Logger) *cobra.Command {
-	o := NewAgentOptions(addonName, logger)
-
-	ctx := context.TODO()
-
-	cmd := &cobra.Command{
-		Use:   "cleanup",
-		Short: fmt.Sprintf("clean up the hypershift operator if it's deployed by %s", addonName),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return o.runCleanup(ctx, nil)
-		},
-	}
-
-	o.AddFlags(cmd)
-
-	cmd.FParseErrWhitelist.UnknownFlags = true
-
-	return cmd
-}
-
-func (o *AgentOptions) runCleanup(ctx context.Context, aCtrl *agentController) error {
-	log := o.Log.WithName("controller-manager-setup")
-
-	flag.Parse()
-
-	if aCtrl == nil {
-		spokeConfig := ctrl.GetConfigOrDie()
-
-		c, err := ctrlClient.New(spokeConfig, ctrlClient.Options{Scheme: scheme})
-		if err != nil {
-			return fmt.Errorf("failed to create spokeUncacheClient, err: %w", err)
-		}
-
-		if err := hyperv1alpha1.AddToScheme(scheme); err != nil {
-			log.Error(err, "unable add HyperShift APIs to scheme")
-			return fmt.Errorf("unable add HyperShift APIs to scheme, err: %w", err)
-		}
-
-		aCtrl = &agentController{
-			spokeUncachedClient:       c,
-			hypershiftInstallExecutor: &HypershiftLibExecutor{},
-		}
-	}
-
-	o.Log = o.Log.WithName("hypersfhit-operation")
-	aCtrl.plugInOption(o)
-
-	// retry 3 times, in case something wrong with deleting the hypershift install job
-	if err := aCtrl.runHypershiftCmdWithRetires(ctx, 3, time.Second*10, aCtrl.runHypershiftCleanup); err != nil {
-		log.Error(err, "failed to clean up hypershift Operator")
-		return err
-	}
-
-	return nil
-}
-
-func (c *agentController) runHypershiftCmdWithRetires(
+func (c *UpgradeController) RunHypershiftCmdWithRetires(
 	ctx context.Context, attempts int, sleep time.Duration, f func(context.Context) error) error {
 	var err error
 	for i := attempts; i > 0; i-- {
@@ -134,7 +67,7 @@ func getRandInt(m int64) int64 {
 	return n.Int64()
 }
 
-func (c *agentController) runHypershiftRender(ctx context.Context, args []string) ([]unstructured.Unstructured, error) {
+func (c *UpgradeController) runHypershiftRender(ctx context.Context, args []string) ([]unstructured.Unstructured, error) {
 	out := []unstructured.Unstructured{}
 	if c.hypershiftInstallExecutor == nil {
 		return out, fmt.Errorf("failed to run hypershift cmd, no install executor specified")
@@ -171,9 +104,9 @@ func (c *agentController) runHypershiftRender(ctx context.Context, args []string
 	return out, nil
 }
 
-func (c *agentController) runHypershiftCleanup(ctx context.Context) error {
-	c.log.Info("enter runHypershiftCleanup")
-	defer c.log.Info("exit runHypershiftCleanup")
+func (c *UpgradeController) RunHypershiftCleanup(ctx context.Context) error {
+	c.log.Info("enter RunHypershiftCleanup")
+	defer c.log.Info("exit RunHypershiftCleanup")
 
 	if !c.isDeploymentMarked(ctx) {
 		c.log.Info(fmt.Sprintf("skip deletion of the hypershift operator, not created by %s", util.AddonControllerName))
@@ -212,21 +145,21 @@ func (c *agentController) runHypershiftCleanup(ctx context.Context) error {
 	return nil
 }
 
-func (c *agentController) runHypershiftInstall(ctx context.Context) error {
+func (c *UpgradeController) RunHypershiftInstall(ctx context.Context) error {
 	c.log.Info("enter runHypershiftInstall")
 	defer c.log.Info("exit runHypershiftInstall")
 
-	if err, ok := c.deploymentExistWithNoImageChange(ctx); ok || err != nil {
+	if err, ok := c.deploymentUpgradable(ctx); !ok || err != nil {
 		if err != nil {
 			return err
 		}
-		c.log.Error(err, "hypershift operator already exists at the required image level, skip update")
+		c.log.Error(err, "hypershift operator exists but not deployed by addon, skip update")
 		return nil
 	}
 
 	awsPlatform := true
 
-	bucketSecretKey := types.NamespacedName{Name: hypershiftBucketSecretName, Namespace: c.clusterName}
+	bucketSecretKey := types.NamespacedName{Name: util.HypershiftBucketSecretName, Namespace: c.clusterName}
 	se := &corev1.Secret{}
 	if err := c.hubClient.Get(ctx, bucketSecretKey, se); err != nil {
 		c.log.Info(fmt.Sprintf("bucket secret(%s) not found on the hub, installing hypershift operator for non-AWS platform.", bucketSecretKey))
@@ -249,9 +182,9 @@ func (c *agentController) runHypershiftInstall(ctx context.Context) error {
 		}
 
 		// Seed the hypershift namespace, the uninstall will remove this namespace.
-		ns := &corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: hypershiftOperatorKey.Namespace}}
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: hypershiftOperatorKey.Namespace}}
 		if err := c.spokeUncachedClient.Get(ctx, client.ObjectKeyFromObject(ns), ns); err != nil {
-			if errors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				if err := c.spokeUncachedClient.Create(ctx, ns); err != nil {
 					return err
 				}
@@ -267,7 +200,7 @@ func (c *agentController) runHypershiftInstall(ctx context.Context) error {
 		awsArgs := []string{
 			"--oidc-storage-provider-s3-bucket-name", bucketName,
 			"--oidc-storage-provider-s3-region", bucketRegion,
-			"--oidc-storage-provider-s3-secret", hypershiftBucketSecretName,
+			"--oidc-storage-provider-s3-secret", util.HypershiftBucketSecretName,
 		}
 		args = append(args, awsArgs...)
 
@@ -276,7 +209,7 @@ func (c *agentController) runHypershiftInstall(ctx context.Context) error {
 		}
 
 		//Private link creds
-		privateSecretKey := types.NamespacedName{Name: hypershiftPrivateLinkSecretName, Namespace: c.clusterName}
+		privateSecretKey := types.NamespacedName{Name: util.HypershiftPrivateLinkSecretName, Namespace: c.clusterName}
 		spl := &corev1.Secret{}
 		if err := c.hubClient.Get(ctx, privateSecretKey, spl); err == nil {
 			if err := c.createAwsSpokeSecret(ctx, spl); err != nil {
@@ -284,7 +217,7 @@ func (c *agentController) runHypershiftInstall(ctx context.Context) error {
 			}
 			c.log.Info(fmt.Sprintf("private link region & credential arguments included"))
 			awsArgs := []string{
-				"--aws-private-secret", hypershiftPrivateLinkSecretName,
+				"--aws-private-secret", util.HypershiftPrivateLinkSecretName,
 				"--aws-private-region", string(spl.Data["region"]),
 				"--private-platform", "AWS",
 			}
@@ -294,7 +227,7 @@ func (c *agentController) runHypershiftInstall(ctx context.Context) error {
 		}
 	}
 	//External DNS
-	extDNSSecretKey := types.NamespacedName{Name: hypershiftExternalDNSSecretName, Namespace: c.clusterName}
+	extDNSSecretKey := types.NamespacedName{Name: util.HypershiftExternalDNSSecretName, Namespace: c.clusterName}
 	sExtDNS := &corev1.Secret{}
 	if err := c.hubClient.Get(ctx, extDNSSecretKey, sExtDNS); err == nil {
 		if err := c.createSpokeSecret(ctx, sExtDNS); err != nil {
@@ -302,7 +235,7 @@ func (c *agentController) runHypershiftInstall(ctx context.Context) error {
 		}
 		c.log.Info(fmt.Sprintf("external dns provider & domain-filter arguments included"))
 		awsArgs := []string{
-			"--external-dns-secret", hypershiftExternalDNSSecretName,
+			"--external-dns-secret", util.HypershiftExternalDNSSecretName,
 			"--external-dns-domain-filter", string(sExtDNS.Data["domain-filter"]),
 			"--external-dns-provider", string(sExtDNS.Data["provider"]),
 		}
@@ -367,7 +300,7 @@ func (c *agentController) runHypershiftInstall(ctx context.Context) error {
 				a = map[string]string{}
 			}
 
-			a[hypershiftAddonAnnotationKey] = "hypershift-addon"
+			a[util.HypershiftAddonAnnotationKey] = "hypershift-addon"
 
 			item.SetAnnotations(a)
 		}
@@ -380,9 +313,9 @@ func (c *agentController) runHypershiftInstall(ctx context.Context) error {
 
 		if err := c.spokeUncachedClient.Patch(ctx,
 			&item,
-			ctrlClient.RawPatch(types.ApplyPatchType, itemBytes),
-			ctrlClient.ForceOwnership,
-			ctrlClient.FieldOwner("hypershift")); err != nil {
+			client.RawPatch(types.ApplyPatchType, itemBytes),
+			client.ForceOwnership,
+			client.FieldOwner("hypershift")); err != nil {
 			c.log.Error(err, fmt.Sprintf("failed to apply %s, %s", item.GetKind(), client.ObjectKeyFromObject(&item)))
 			continue
 		}
@@ -392,7 +325,7 @@ func (c *agentController) runHypershiftInstall(ctx context.Context) error {
 	return nil
 }
 
-func (c *agentController) createAwsSpokeSecret(ctx context.Context, hubSecret *corev1.Secret) error {
+func (c *UpgradeController) createAwsSpokeSecret(ctx context.Context, hubSecret *corev1.Secret) error {
 
 	region := hubSecret.Data["region"]
 	awsSecretKey := hubSecret.Data["aws-secret-access-key"]
@@ -408,10 +341,10 @@ func (c *agentController) createAwsSpokeSecret(ctx context.Context, hubSecret *c
 	return c.createSpokeSecret(ctx, hubSecret)
 }
 
-func (c *agentController) createSpokeSecret(ctx context.Context, hubSecret *corev1.Secret) error {
+func (c *UpgradeController) createSpokeSecret(ctx context.Context, hubSecret *corev1.Secret) error {
 
 	spokeSecret := &corev1.Secret{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      hubSecret.Name,
 			Namespace: hypershiftOperatorKey.Namespace,
 		},
@@ -425,7 +358,7 @@ func (c *agentController) createSpokeSecret(ctx context.Context, hubSecret *core
 	return err
 }
 
-func (c *agentController) ensurePullSecret(ctx context.Context) error {
+func (c *UpgradeController) ensurePullSecret(ctx context.Context) error {
 	obj := &corev1.Secret{}
 	mcePullSecretKey := types.NamespacedName{Name: c.pullSecret, Namespace: c.addonNamespace}
 
@@ -472,7 +405,7 @@ func (c *agentController) ensurePullSecret(ctx context.Context) error {
 	return nil
 }
 
-func (c *agentController) isDeploymentMarked(ctx context.Context) bool {
+func (c *UpgradeController) isDeploymentMarked(ctx context.Context) bool {
 	obj := &appsv1.Deployment{}
 
 	if err := c.spokeUncachedClient.Get(ctx, hypershiftOperatorKey, obj); err != nil {
@@ -481,14 +414,14 @@ func (c *agentController) isDeploymentMarked(ctx context.Context) bool {
 	}
 
 	a := obj.GetAnnotations()
-	if len(a) == 0 || len(a[hypershiftAddonAnnotationKey]) == 0 {
+	if len(a) == 0 || len(a[util.HypershiftAddonAnnotationKey]) == 0 {
 		return false
 	}
 
 	return true
 }
 
-func (c *agentController) hasHostedClusters(ctx context.Context) (bool, error) {
+func (c *UpgradeController) hasHostedClusters(ctx context.Context) (bool, error) {
 	listopts := &client.ListOptions{}
 	hcList := &hyperv1alpha1.HostedClusterList{}
 	if err := c.spokeUncachedClient.List(ctx, hcList, listopts); err != nil {
@@ -498,29 +431,26 @@ func (c *agentController) hasHostedClusters(ctx context.Context) (bool, error) {
 	return len(hcList.Items) != 0, nil
 }
 
-func (c *agentController) deploymentExistWithNoImageChange(ctx context.Context) (error, bool) {
+func (c *UpgradeController) deploymentUpgradable(ctx context.Context) (error, bool) {
 	obj := &appsv1.Deployment{}
 
 	if err := c.spokeUncachedClient.Get(ctx, hypershiftOperatorKey, obj); err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil, false
+			return nil, true
 		}
 
 		return err, false
 	}
 
-	// Check if image has changed
-	if len(obj.Spec.Template.Spec.Containers) == 1 &&
-		len(c.operatorImage) > 0 &&
-		obj.Spec.Template.Spec.Containers[0].Image != c.operatorImage &&
-		len(obj.Annotations) > 0 &&
-		obj.Annotations[hypershiftAddonAnnotationKey] == util.AddonControllerName {
-		return nil, false
+	// Check if deployment is created by the addon
+	if obj.Annotations[util.HypershiftAddonAnnotationKey] == util.AddonControllerName {
+		return nil, true
 	}
-	return nil, true
+
+	return nil, false
 }
 
-func (c *agentController) readInDownstreamOverride() (*os.File, error) {
+func (c *UpgradeController) readInDownstreamOverride() (*os.File, error) {
 	cm := &corev1.ConfigMap{}
 	cmKey := types.NamespacedName{Name: util.HypershiftDownstreamOverride, Namespace: c.addonNamespace}
 
@@ -533,6 +463,19 @@ func (c *agentController) readInDownstreamOverride() (*os.File, error) {
 	im, err := base64.StdEncoding.DecodeString(d)
 	if err != nil {
 		return nil, err
+	}
+
+	// If upgrade images CM exists, replace values in the imagestream
+	imUpgradeMap, err := c.getImageOverrideMap()
+	if err == nil {
+		c.log.Info(fmt.Sprintf("found %s configmap, overriding hypershift images in the imagestream", util.HypershiftOverrideImagesCM))
+
+		im, err = c.getUpdatedImageStream(im, imUpgradeMap)
+		if err != nil {
+			return nil, err
+		}
+	} else if !apierrors.IsNotFound(err) {
+		return nil, fmt.Errorf("failed to get the image override configmap, err: %w", err)
 	}
 
 	file, err := ioutil.TempFile("", "hypershift-imagestream")
@@ -548,4 +491,32 @@ func (c *agentController) readInDownstreamOverride() (*os.File, error) {
 	}
 
 	return file, nil
+}
+
+func (c *UpgradeController) getUpdatedImageStream(im []byte, upgradeImagesMap map[string]string) ([]byte, error) {
+	imObj := &imageapi.ImageStream{}
+	if err := yaml.Unmarshal(im, imObj); err != nil {
+		return nil, err
+	}
+
+	for k, v := range upgradeImagesMap {
+		c.log.Info(fmt.Sprintf("upgrade image %s:%s", k, v))
+		overrideImageInImageStream(imObj, k, v)
+	}
+
+	im, err := yaml.Marshal(imObj)
+	if err != nil {
+		return nil, err
+	}
+
+	return im, nil
+}
+
+func overrideImageInImageStream(imObj *imageapi.ImageStream, overrideImageName, overrideImageValue string) {
+	for _, tag := range imObj.Spec.Tags {
+		if tag.Name == overrideImageName {
+			tag.From.Name = overrideImageValue
+			break
+		}
+	}
 }

--- a/pkg/install/hypershift_executor.go
+++ b/pkg/install/hypershift_executor.go
@@ -1,4 +1,4 @@
-package agent
+package install
 
 import (
 	"bytes"

--- a/pkg/install/hypershift_test.go
+++ b/pkg/install/hypershift_test.go
@@ -1,13 +1,15 @@
-package agent
+package install
 
 import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"testing"
 	"time"
 
+	"github.com/ghodss/yaml"
 	"github.com/go-logr/zapr"
 	hyperv1alpha1 "github.com/openshift/hypershift/api/v1alpha1"
 	"github.com/stolostron/hypershift-addon-operator/pkg/util"
@@ -23,6 +25,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	imageapi "github.com/openshift/api/image/v1"
+)
+
+const (
+	hsOperatorImage = "hypershift-operator"
 )
 
 func initClient() client.Client {
@@ -51,7 +59,7 @@ func initDeployObj() *appsv1.Deployment {
 func initDeployAddonObj() *appsv1.Deployment {
 	deploy := initDeployObj()
 	deploy.Annotations = map[string]string{
-		hypershiftAddonAnnotationKey: util.AddonControllerName,
+		util.HypershiftAddonAnnotationKey: util.AddonControllerName,
 	}
 	return deploy
 }
@@ -59,7 +67,7 @@ func initDeployAddonObj() *appsv1.Deployment {
 func initDeployAddonImageDiffObj() *appsv1.Deployment {
 	deploy := initDeployObj()
 	deploy.Annotations = map[string]string{
-		hypershiftAddonAnnotationKey: util.AddonControllerName,
+		util.HypershiftAddonAnnotationKey: util.AddonControllerName,
 	}
 	deploy.Spec.Template.Spec.Containers = []corev1.Container{
 		corev1.Container{Image: "testimage"},
@@ -98,6 +106,11 @@ func (c *HypershiftTestCliExecutor) Execute(ctx context.Context, args []string) 
 	}
 	items = append(items, sa)
 
+	container := corev1.Container{
+		Name:  "operator",
+		Image: "",
+	}
+
 	dp := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
@@ -107,7 +120,39 @@ func (c *HypershiftTestCliExecutor) Execute(ctx context.Context, args []string) 
 			Name:      "operator",
 			Namespace: "hypershift",
 		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{container},
+				},
+			},
+		},
 	}
+
+	// Override HS operator image
+	for i, arg := range args {
+		if arg == "--image-refs" {
+			im, err := ioutil.ReadFile(args[i+1])
+			if err != nil {
+				return nil, err
+			}
+
+			ims := &imageapi.ImageStream{}
+			if err = yaml.Unmarshal(im, ims); err != nil {
+				return nil, err
+			}
+
+			for _, tag := range ims.Spec.Tags {
+				if tag.Name == hsOperatorImage {
+					dp.Spec.Template.Spec.Containers[0].Image = tag.From.Name
+				}
+				break
+			}
+
+			break
+		}
+	}
+
 	items = append(items, dp)
 
 	out := make(map[string]interface{})
@@ -144,7 +189,7 @@ func TestIsDeploymentMarked(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			ctx := context.Background()
 			zapLog, _ := zap.NewDevelopment()
-			aCtrl := &agentController{
+			aCtrl := &UpgradeController{
 				spokeUncachedClient: initClient(),
 				log:                 zapr.NewLogger(zapLog),
 			}
@@ -168,14 +213,14 @@ func TestDeploymentExistsWithNoImage(t *testing.T) {
 		expectedOk    bool
 	}{
 		{
-			name:       "no deployment, function returns false",
+			name:       "no deployment, function returns true",
 			deploy:     nil,
-			expectedOk: false,
+			expectedOk: true,
 		},
 		{
 			name:       "hypershift-operator Deployment, not owned by acm addon",
 			deploy:     initDeployObj(),
-			expectedOk: true,
+			expectedOk: false,
 		},
 		{
 			name:       "hypershift-operator Deployment, owned by acm addon with identical images",
@@ -186,14 +231,14 @@ func TestDeploymentExistsWithNoImage(t *testing.T) {
 			name:          "hypershift-operator Deployment, owned by acm addon with identical images",
 			deploy:        initDeployAddonImageDiffObj(),
 			operatorImage: "my-new-image02",
-			expectedOk:    false,
+			expectedOk:    true,
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			ctx := context.Background()
-			aCtrl := &agentController{
+			aCtrl := &UpgradeController{
 				spokeUncachedClient: initClient(),
 				operatorImage:       c.operatorImage,
 			}
@@ -201,7 +246,7 @@ func TestDeploymentExistsWithNoImage(t *testing.T) {
 				assert.Nil(t, aCtrl.spokeUncachedClient.Create(ctx, c.deploy), "")
 			}
 
-			err, ok := aCtrl.deploymentExistWithNoImageChange(ctx)
+			err, ok := aCtrl.deploymentUpgradable(ctx)
 			if len(c.expectedErr) == 0 {
 				assert.Nil(t, err, "nil when function is successful")
 				assert.Equal(t, c.expectedOk, ok, "ok as expected")
@@ -221,7 +266,7 @@ func TestRunHypershiftRender(t *testing.T) {
 		"--format", "json",
 	}
 
-	ctl := agentController{
+	ctl := UpgradeController{
 		hypershiftInstallExecutor: &HypershiftLibExecutor{},
 	}
 	outputs, err := ctl.runHypershiftRender(ctx, args)
@@ -309,7 +354,7 @@ func TestRunHypershiftInstall(t *testing.T) {
 
 	zapLog, _ := zap.NewDevelopment()
 	client := initClient()
-	aCtrl := &agentController{
+	aCtrl := &UpgradeController{
 		spokeUncachedClient:       client,
 		hubClient:                 client,
 		log:                       zapr.NewLogger(zapLog),
@@ -341,7 +386,7 @@ func TestRunHypershiftInstall(t *testing.T) {
 
 	bucketSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      hypershiftBucketSecretName,
+			Name:      util.HypershiftBucketSecretName,
 			Namespace: aCtrl.clusterName,
 		},
 		Data: map[string][]byte{
@@ -361,13 +406,13 @@ func TestRunHypershiftInstall(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "operator",
 			Namespace:   "hypershift",
-			Annotations: map[string]string{hypershiftAddonAnnotationKey: util.AddonControllerName},
+			Annotations: map[string]string{util.HypershiftAddonAnnotationKey: util.AddonControllerName},
 		},
 	}
 	aCtrl.hubClient.Create(ctx, incompleteDp)
 
 	// No Spec in hypershift deployment operator - skip all operations
-	err := aCtrl.runHypershiftInstall(ctx)
+	err := aCtrl.RunHypershiftInstall(ctx)
 	assert.Nil(t, err, "is nil if install HyperShift is successful")
 	aCtrl.hubClient.Delete(ctx, incompleteDp)
 
@@ -379,7 +424,7 @@ func TestRunHypershiftInstall(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "operator",
 			Namespace:   "hypershift",
-			Annotations: map[string]string{hypershiftAddonAnnotationKey: util.AddonControllerName},
+			Annotations: map[string]string{util.HypershiftAddonAnnotationKey: util.AddonControllerName},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Template: corev1.PodTemplateSpec{
@@ -396,13 +441,13 @@ func TestRunHypershiftInstall(t *testing.T) {
 	aCtrl.hubClient.Create(ctx, dp)
 	defer aCtrl.hubClient.Delete(ctx, dp)
 
-	err = aCtrl.runHypershiftInstall(ctx)
+	err = aCtrl.RunHypershiftInstall(ctx)
 	assert.Nil(t, err, "is nil if install HyperShift is successful")
 
 	// Check hypershift-operator-oidc-provider-s3-credentials secret exists
 	oidcSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      hypershiftBucketSecretName,
+			Name:      util.HypershiftBucketSecretName,
 			Namespace: "hypershift",
 		},
 	}
@@ -413,7 +458,7 @@ func TestRunHypershiftInstall(t *testing.T) {
 	// Check hypershift-operator-private-link-credentials secret does NOT exist
 	plSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      hypershiftPrivateLinkSecretName,
+			Name:      util.HypershiftPrivateLinkSecretName,
 			Namespace: "hypershift",
 		},
 	}
@@ -436,30 +481,58 @@ func TestRunHypershiftInstall(t *testing.T) {
 	err = aCtrl.spokeUncachedClient.Get(ctx, types.NamespacedName{Name: pullSecret.Name, Namespace: hypershiftOperatorKey.Namespace}, hsPullSecret)
 	assert.Nil(t, err, "is nil if the pull secret in the HyperShift namespace is found")
 
+	tr := []imageapi.TagReference{}
+	tr = append(tr, imageapi.TagReference{Name: hsOperatorImage, From: &corev1.ObjectReference{Name: "quay.io/stolostron/hypershift-operator@sha256:122a59aaf2fa72d1e3c0befb0de61df2aeea848676b0f41055b07ca0e6291391"}})
+	ims := &imageapi.ImageStream{}
+	ims.Spec.Tags = tr
+	imb, err := yaml.Marshal(ims)
+
 	// Run hypershift install again with image override
 	overrideCM := &corev1.ConfigMap{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      util.HypershiftDownstreamOverride,
 			Namespace: aCtrl.addonNamespace,
 		},
-		Data: map[string]string{util.HypershiftOverrideKey: base64.StdEncoding.EncodeToString([]byte("test"))},
+		Data: map[string]string{util.HypershiftOverrideKey: base64.StdEncoding.EncodeToString(imb)},
 	}
 	aCtrl.withOverride = true
 	aCtrl.hubClient.Create(ctx, overrideCM)
 	defer aCtrl.hubClient.Delete(ctx, overrideCM)
+	err = aCtrl.RunHypershiftInstall(ctx)
 	assert.Nil(t, err, "is nil if install HyperShift is sucessful")
+
+	// Run hypershift install again with image override using image upgrade configmap
+	imageUpgradeCM := &corev1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      util.HypershiftOverrideImagesCM,
+			Namespace: aCtrl.addonNamespace,
+		},
+		Data: map[string]string{
+			"hypershift-operator": "quay.io/stolostron/hypershift-operator@sha256:eedb58e7b9c4d9e49c6c53d1b5b97dfddcdffe839bbffd4fb950760715d24244",
+		},
+	}
+	err = aCtrl.hubClient.Create(ctx, imageUpgradeCM)
+	assert.Nil(t, err, "err nil when config map is created successfull")
+	err = aCtrl.RunHypershiftInstall(ctx)
+	assert.Nil(t, err, "is nil if install HyperShift is sucessful")
+
+	// Check HS operator deployment has the correct image
+	err = aCtrl.spokeUncachedClient.Get(ctx, hypershiftOperatorKey, dp)
+	assert.Nil(t, err, "is nil if the hypershift deployment exists")
+	// Patch type types.ApplyPatchType not supported by fake client
+	// assert.Equal(t, "quay.io/stolostron/hypershift-operator@sha256:eedb58e7b9c4d9e49c6c53d1b5b97dfddcdffe839bbffd4fb950760715d24244", dp.Spec.Template.Spec.Containers[0].Image)
 
 	// Run hypershift install again with pull secret deleted
 	aCtrl.hubClient.Delete(ctx, pullSecret)
 	aCtrl.hubClient.Delete(ctx, hsPullSecret)
-	err = aCtrl.runHypershiftInstall(ctx)
+	err = aCtrl.RunHypershiftInstall(ctx)
 	assert.Nil(t, err, "is nil if install HyperShift is sucessful")
 	err = aCtrl.spokeUncachedClient.Get(ctx, types.NamespacedName{Name: pullSecret.Name, Namespace: hypershiftOperatorKey.Namespace}, hsPullSecret)
 	assert.True(t, err != nil && errors.IsNotFound(err), "is true if the pull secret is not copied to the HyperShift namespace")
 
 	// Run hypershift install again with s3 bucket secret deleted
 	aCtrl.hubClient.Delete(ctx, bucketSecret)
-	err = aCtrl.runHypershiftInstall(ctx)
+	err = aCtrl.RunHypershiftInstall(ctx)
 	assert.Nil(t, err, "is nil if install HyperShift is sucessful")
 
 	// Create hosted cluster
@@ -470,12 +543,7 @@ func TestRunHypershiftInstall(t *testing.T) {
 
 	// Cleanup
 	// Hypershift deployment is not deleted because there is an existing hostedcluster
-	o := &AgentOptions{
-		Log:            zapr.NewLogger(zapLog),
-		AddonName:      "hypershift-addon",
-		AddonNamespace: "hypershift",
-	}
-	err = o.runCleanup(ctx, aCtrl)
+	err = aCtrl.RunHypershiftCmdWithRetires(ctx, 3, time.Second*10, aCtrl.RunHypershiftCleanup)
 	assert.Nil(t, err, "is nil if cleanup is succcessful")
 
 	// Check service account is not deleted
@@ -491,7 +559,7 @@ func TestRunHypershiftInstall(t *testing.T) {
 	assert.Nil(t, err, "err nil when hosted cluster is deleted successfull")
 
 	// Cleanup after HC is deleted
-	err = o.runCleanup(ctx, aCtrl)
+	err = aCtrl.RunHypershiftCmdWithRetires(ctx, 3, time.Second*10, aCtrl.RunHypershiftCleanup)
 	assert.Nil(t, err, "is nil if cleanup is succcessful")
 
 	// Check service account is deleted
@@ -505,7 +573,7 @@ func TestRunHypershiftInstall(t *testing.T) {
 	assert.True(t, errors.IsNotFound(err))
 
 	// Cleanup again with nil aCtrl is successful
-	err = o.runCleanup(ctx, nil)
+	err = aCtrl.RunHypershiftCmdWithRetires(ctx, 3, time.Second*10, aCtrl.RunHypershiftCleanup)
 	assert.Nil(t, err, "is nil if cleanup is successful")
 }
 
@@ -514,7 +582,7 @@ func TestReadDownstreamOverride(t *testing.T) {
 
 	zapLog, _ := zap.NewDevelopment()
 	client := initClient()
-	aCtrl := &agentController{
+	aCtrl := &UpgradeController{
 		spokeUncachedClient: client,
 		hubClient:           client,
 		log:                 zapr.NewLogger(zapLog),
@@ -547,7 +615,7 @@ func TestRunCommandWithRetries(t *testing.T) {
 
 	zapLog, _ := zap.NewDevelopment()
 	client := initClient()
-	aCtrl := &agentController{
+	aCtrl := &UpgradeController{
 		spokeUncachedClient: client,
 		hubClient:           client,
 		log:                 zapr.NewLogger(zapLog),
@@ -589,14 +657,8 @@ func TestRunCommandWithRetries(t *testing.T) {
 		return fmt.Errorf("failed 1st call")
 	}
 
-	err := aCtrl.runHypershiftCmdWithRetires(ctx, 3, 1*time.Second, cmd)
+	err := aCtrl.RunHypershiftCmdWithRetires(ctx, 3, 1*time.Second, cmd)
 	assert.Nil(t, err, "is nil if retry is successful")
-}
-
-func TestCleanupCommand(t *testing.T) {
-	zapLog, _ := zap.NewDevelopment()
-	cleanupCmd := NewCleanupCommand("operator", zapr.NewLogger(zapLog))
-	assert.Equal(t, "cleanup", cleanupCmd.Use)
 }
 
 func TestRunHypershiftInstallPrivateLinkExternalDNS(t *testing.T) {
@@ -604,7 +666,7 @@ func TestRunHypershiftInstallPrivateLinkExternalDNS(t *testing.T) {
 
 	zapLog, _ := zap.NewDevelopment()
 	client := initClient()
-	aCtrl := &agentController{
+	aCtrl := &UpgradeController{
 		spokeUncachedClient:       client,
 		hubClient:                 client,
 		log:                       zapr.NewLogger(zapLog),
@@ -636,7 +698,7 @@ func TestRunHypershiftInstallPrivateLinkExternalDNS(t *testing.T) {
 
 	bucketSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      hypershiftBucketSecretName,
+			Name:      util.HypershiftBucketSecretName,
 			Namespace: aCtrl.clusterName,
 		},
 		Data: map[string][]byte{
@@ -648,7 +710,7 @@ func TestRunHypershiftInstallPrivateLinkExternalDNS(t *testing.T) {
 	}
 	privateSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      hypershiftPrivateLinkSecretName,
+			Name:      util.HypershiftPrivateLinkSecretName,
 			Namespace: aCtrl.clusterName,
 		},
 		Data: map[string][]byte{
@@ -659,7 +721,7 @@ func TestRunHypershiftInstallPrivateLinkExternalDNS(t *testing.T) {
 	}
 	externalDnsSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      hypershiftExternalDNSSecretName,
+			Name:      util.HypershiftExternalDNSSecretName,
 			Namespace: aCtrl.clusterName,
 		},
 		Data: map[string][]byte{
@@ -684,7 +746,7 @@ func TestRunHypershiftInstallPrivateLinkExternalDNS(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "operator",
 			Namespace:   "hypershift",
-			Annotations: map[string]string{hypershiftAddonAnnotationKey: util.AddonControllerName},
+			Annotations: map[string]string{util.HypershiftAddonAnnotationKey: util.AddonControllerName},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Template: corev1.PodTemplateSpec{
@@ -700,13 +762,13 @@ func TestRunHypershiftInstallPrivateLinkExternalDNS(t *testing.T) {
 	}
 	aCtrl.hubClient.Create(ctx, dp)
 	defer aCtrl.hubClient.Delete(ctx, dp)
-	err := aCtrl.runHypershiftInstall(ctx)
+	err := aCtrl.RunHypershiftInstall(ctx)
 	assert.Nil(t, err, "is nil if install HyperShift is successful")
 
 	// Check hypershift-operator-oidc-provider-s3-credentials secret exists
 	oidcSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      hypershiftBucketSecretName,
+			Name:      util.HypershiftBucketSecretName,
 			Namespace: "hypershift",
 		},
 	}
@@ -717,7 +779,7 @@ func TestRunHypershiftInstallPrivateLinkExternalDNS(t *testing.T) {
 	// Check hypershift-operator-private-link-credentials secret exists
 	plSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      hypershiftPrivateLinkSecretName,
+			Name:      util.HypershiftPrivateLinkSecretName,
 			Namespace: "hypershift",
 		},
 	}
@@ -728,7 +790,7 @@ func TestRunHypershiftInstallPrivateLinkExternalDNS(t *testing.T) {
 	// Check hypershift-operator-external-dns-credentials secret exists
 	edSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      hypershiftExternalDNSSecretName,
+			Name:      util.HypershiftExternalDNSSecretName,
 			Namespace: "hypershift",
 		},
 	}
@@ -737,12 +799,7 @@ func TestRunHypershiftInstallPrivateLinkExternalDNS(t *testing.T) {
 	assert.Equal(t, []byte(`private_secret`), edSecret.Data["credentials"], "the credentials should be equal if the copy was a success")
 
 	// Cleanup
-	o := &AgentOptions{
-		Log:            zapr.NewLogger(zapLog),
-		AddonName:      "hypershift-addon",
-		AddonNamespace: "hypershift",
-	}
-	err = o.runCleanup(ctx, aCtrl)
+	err = aCtrl.RunHypershiftCmdWithRetires(ctx, 3, time.Second*10, aCtrl.RunHypershiftCleanup)
 	assert.Nil(t, err, "is nil if cleanup is succcessful")
 }
 
@@ -751,7 +808,7 @@ func TestCreateSpokeCredential(t *testing.T) {
 
 	zapLog, _ := zap.NewDevelopment()
 	client := initClient()
-	aCtrl := &agentController{
+	aCtrl := &UpgradeController{
 		spokeUncachedClient:       client,
 		hubClient:                 client,
 		log:                       zapr.NewLogger(zapLog),
@@ -764,7 +821,7 @@ func TestCreateSpokeCredential(t *testing.T) {
 
 	bucketSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      hypershiftBucketSecretName,
+			Name:      util.HypershiftBucketSecretName,
 			Namespace: aCtrl.clusterName,
 		},
 	}
@@ -772,4 +829,40 @@ func TestCreateSpokeCredential(t *testing.T) {
 	err := aCtrl.createAwsSpokeSecret(ctx, bucketSecret)
 	assert.NotNil(t, err, "is not nil, when secret is not well formed")
 
+}
+
+func getHostedCluster(hcNN types.NamespacedName) *hyperv1alpha1.HostedCluster {
+	hc := &hyperv1alpha1.HostedCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "HostedCluster",
+			APIVersion: "hypershift.openshift.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        hcNN.Name,
+			Namespace:   hcNN.Namespace,
+			Annotations: map[string]string{util.HypershiftDeploymentAnnoKey: "test-hd1"},
+		},
+		Spec: hyperv1alpha1.HostedClusterSpec{
+			Platform: hyperv1alpha1.PlatformSpec{
+				Type: hyperv1alpha1.AWSPlatform,
+			},
+			Networking: hyperv1alpha1.ClusterNetworking{
+				NetworkType: hyperv1alpha1.OpenShiftSDN,
+			},
+			Services: []hyperv1alpha1.ServicePublishingStrategyMapping{},
+			Release: hyperv1alpha1.Release{
+				Image: "test-image",
+			},
+			Etcd: hyperv1alpha1.EtcdSpec{
+				ManagementType: hyperv1alpha1.Managed,
+			},
+			InfraID: "infra-abcdef",
+		},
+		Status: hyperv1alpha1.HostedClusterStatus{
+			KubeConfig:        &corev1.LocalObjectReference{Name: "kubeconfig"},
+			KubeadminPassword: &corev1.LocalObjectReference{Name: "kubeadmin"},
+			Conditions:        []metav1.Condition{{Type: string(hyperv1alpha1.HostedClusterAvailable), Status: metav1.ConditionTrue}},
+		},
+	}
+	return hc
 }

--- a/pkg/install/upgrade.go
+++ b/pkg/install/upgrade.go
@@ -1,0 +1,176 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/stolostron/hypershift-addon-operator/pkg/util"
+)
+
+type UpgradeController struct {
+	hubClient                 client.Client
+	spokeUncachedClient       client.Client
+	log                       logr.Logger
+	addonName                 string
+	addonNamespace            string
+	clusterName               string
+	operatorImage             string
+	pullSecret                string
+	withOverride              bool
+	hypershiftInstallExecutor HypershiftInstallExecutorInterface
+}
+
+func NewUpgradeController(hubClient, spokeClient client.Client, logger logr.Logger, addonName, addonNamespace, clusterName, operatorImage,
+	pullSecretName string, withOverride bool) *UpgradeController {
+	return &UpgradeController{
+		hubClient:                 hubClient,
+		spokeUncachedClient:       spokeClient,
+		log:                       logger,
+		addonName:                 addonName,
+		addonNamespace:            addonNamespace,
+		clusterName:               clusterName,
+		operatorImage:             operatorImage,
+		pullSecret:                pullSecretName,
+		withOverride:              withOverride,
+		hypershiftInstallExecutor: &HypershiftLibExecutor{},
+	}
+}
+
+func (c *UpgradeController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	c.log.Info(fmt.Sprintf("Reconciling hypershift update images configmap %s", req))
+	defer c.log.Info(fmt.Sprintf("Done hypershift update images configmap %s", req))
+
+	upgradeRequired, err := c.upgradeImageCheck()
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if upgradeRequired {
+		c.log.Info("image changes detected, upgrade the HyperShift operator")
+		if err := c.RunHypershiftCmdWithRetires(ctx, 3, time.Second*10, c.RunHypershiftInstall); err != nil {
+			c.log.Error(err, "failed to install hypershift Operator")
+			return ctrl.Result{}, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (c *UpgradeController) upgradeImageCheck() (bool, error) {
+	hsOperatorKey := types.NamespacedName{
+		Name:      util.HypershiftOperatorName,
+		Namespace: util.HypershiftOperatorNamespace,
+	}
+
+	hsOperator := &appsv1.Deployment{}
+	if err := c.spokeUncachedClient.Get(context.TODO(), hsOperatorKey, hsOperator); err != nil {
+		return false, fmt.Errorf("failed to get the hypershift operator deployment, err: %w", err)
+	}
+
+	if len(hsOperator.Spec.Template.Spec.Containers) != 1 {
+		c.log.Info("no containers found for HyperShift operator deployment, skip upgrade")
+		return false, nil
+	}
+
+	if hsOperator.Annotations[util.HypershiftAddonAnnotationKey] != util.AddonControllerName {
+		c.log.Info("HyperShift operator deployment not deployed by the HyperShift addon, skip upgrade")
+		return false, nil
+	}
+
+	imageOverrideMap, err := c.getImageOverrideMap()
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			c.log.Info("image override configmap is deleted, re-install HyperShift operator using imagestream images")
+			return true, nil
+		}
+
+		return false, fmt.Errorf("failed to get the image override configmap, err: %w", err)
+	}
+
+	hsOperatorContainer := hsOperator.Spec.Template.Spec.Containers[0]
+	for k, v := range imageOverrideMap {
+		switch k {
+		case util.ImageStreamAgentCapiProvider:
+			if v != getContainerEnvVar(hsOperatorContainer.Env, util.HypershiftEnvVarImageAgentCapiProvider) {
+				return true, nil
+			}
+		case util.ImageStreamAwsCapiProvider:
+			if v != getContainerEnvVar(hsOperatorContainer.Env, util.HypershiftEnvVarImageAwsCapiProvider) {
+				return true, nil
+			}
+		case util.ImageStreamAwsEncyptionProvider:
+			if v != getContainerEnvVar(hsOperatorContainer.Env, util.HypershiftEnvVarImageAwsEncyptionProvider) {
+				return true, nil
+			}
+		case util.ImageStreamAzureCapiProvider:
+			if v != getContainerEnvVar(hsOperatorContainer.Env, util.HypershiftEnvVarImageAzureCapiProvider) {
+				return true, nil
+			}
+		case util.ImageStreamClusterApi:
+			if v != getContainerEnvVar(hsOperatorContainer.Env, util.HypershiftEnvVarImageClusterApi) {
+				return true, nil
+			}
+		case util.ImageStreamKonnectivity:
+			if v != getContainerEnvVar(hsOperatorContainer.Env, util.HypershiftEnvVarImageKonnectivity) {
+				return true, nil
+			}
+		case util.ImageStreamKubevertCapiProvider:
+			if v != getContainerEnvVar(hsOperatorContainer.Env, util.HypershiftEnvVarImageKubevertCapiProvider) {
+				return true, nil
+			}
+		case util.ImageStreamHypershiftOperator:
+			if v != hsOperatorContainer.Image {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+func (c *UpgradeController) SetupWithManager(mgr ctrl.Manager) error {
+	filterByCM := func(obj client.Object) bool {
+		if obj.GetName() == util.HypershiftOverrideImagesCM && obj.GetNamespace() == c.addonNamespace {
+			return true
+		}
+
+		return false
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.ConfigMap{}).
+		WithEventFilter(predicate.NewPredicateFuncs(filterByCM)).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
+		Complete(c)
+}
+
+func (c *UpgradeController) getImageOverrideMap() (map[string]string, error) {
+	overrideImagesCm := &corev1.ConfigMap{}
+	overrideImagesCmKey := types.NamespacedName{Name: util.HypershiftOverrideImagesCM, Namespace: c.addonNamespace}
+	if err := c.spokeUncachedClient.Get(context.TODO(), overrideImagesCmKey, overrideImagesCm); err != nil {
+		return nil, err
+	}
+
+	return overrideImagesCm.Data, nil
+}
+
+func getContainerEnvVar(envVars []corev1.EnvVar, imageName string) string {
+	for _, ev := range envVars {
+		if ev.Name == imageName {
+			return ev.Value
+		}
+	}
+	return ""
+}

--- a/pkg/install/upgrade_test.go
+++ b/pkg/install/upgrade_test.go
@@ -1,0 +1,178 @@
+package install
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/zapr"
+	"github.com/stolostron/hypershift-addon-operator/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestUpgradeImageCheck(t *testing.T) {
+	ctx := context.Background()
+	zapLog, _ := zap.NewDevelopment()
+	uCtrl := NewUpgradeController(nil, initClient(), zapr.NewLogger(zapLog), "hypershift-addon",
+		"open-cluster-management-agent-addon", "local-cluster", "hs-op-image", "pull-secret", true)
+
+	dp := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "operator",
+			Namespace:   "hypershift",
+			Annotations: map[string]string{util.HypershiftAddonAnnotationKey: util.AddonControllerName},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "nginx",
+						Image: "nginx:1.14.2",
+						Ports: []corev1.ContainerPort{{ContainerPort: 80}},
+						Env:   []corev1.EnvVar{{Name: util.HypershiftEnvVarImageAgentCapiProvider, Value: "123"}},
+					}},
+				},
+			},
+		},
+	}
+	uCtrl.spokeUncachedClient.Create(ctx, dp)
+
+	overrideCM := &corev1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      util.HypershiftOverrideImagesCM,
+			Namespace: uCtrl.addonNamespace,
+		},
+	}
+	uCtrl.spokeUncachedClient.Create(ctx, overrideCM)
+
+	cases := []struct {
+		name       string
+		imageName  string
+		imageHash  string
+		expectedOk bool
+	}{
+		{
+			name:       "check image update: " + util.ImageStreamAwsCapiProvider,
+			imageName:  util.ImageStreamAwsCapiProvider,
+			imageHash:  "abc",
+			expectedOk: true,
+		},
+		{
+			name:       "check image update: " + util.ImageStreamAgentCapiProvider,
+			imageName:  util.ImageStreamAgentCapiProvider,
+			imageHash:  "abc",
+			expectedOk: true,
+		},
+		{
+			name:       "check image update: " + util.ImageStreamAwsEncyptionProvider,
+			imageName:  util.ImageStreamAwsEncyptionProvider,
+			imageHash:  "abc",
+			expectedOk: true,
+		},
+		{
+			name:       "check image update: " + util.ImageStreamAzureCapiProvider,
+			imageName:  util.ImageStreamAzureCapiProvider,
+			imageHash:  "abc",
+			expectedOk: true,
+		},
+		{
+			name:       "check image update: " + util.ImageStreamClusterApi,
+			imageName:  util.ImageStreamClusterApi,
+			imageHash:  "abc",
+			expectedOk: true,
+		},
+		{
+			name:       "check image update: " + util.ImageStreamKonnectivity,
+			imageName:  util.ImageStreamKonnectivity,
+			imageHash:  "abc",
+			expectedOk: true,
+		},
+		{
+			name:       "check image update: " + util.ImageStreamKubevertCapiProvider,
+			imageName:  util.ImageStreamKubevertCapiProvider,
+			imageHash:  "abc",
+			expectedOk: true,
+		},
+		{
+			name:       "check image update: " + util.ImageStreamHypershiftOperator,
+			imageName:  util.ImageStreamHypershiftOperator,
+			imageHash:  "abc",
+			expectedOk: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			overrideCM.Data = map[string]string{c.imageName: c.imageHash}
+			uCtrl.spokeUncachedClient.Update(ctx, overrideCM)
+			upgradeRequired, _ := uCtrl.upgradeImageCheck()
+			assert.Equal(t, c.expectedOk, upgradeRequired, "ok as expected")
+		})
+	}
+
+	// Image override CM does not exist
+	uCtrl.spokeUncachedClient.Delete(ctx, overrideCM)
+	upgradeRequired, err := uCtrl.upgradeImageCheck()
+	assert.Nil(t, err, "error is nil if image override CM does not exist")
+	assert.True(t, upgradeRequired, "image upgrade is required if image override CM does not exist")
+
+	// No deployment
+	uCtrl.spokeUncachedClient.Delete(ctx, dp)
+	_, err = uCtrl.upgradeImageCheck()
+	assert.NotNil(t, err, "error is not nil if deployment does not exist")
+	assert.Contains(t, err.Error(), "failed to get the hypershift operator deployment")
+
+	// Deployment has no containers
+	dp = &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "operator",
+			Namespace:   "hypershift",
+			Annotations: map[string]string{util.HypershiftAddonAnnotationKey: util.AddonControllerName},
+		},
+	}
+	uCtrl.spokeUncachedClient.Create(ctx, dp)
+	upgradeRequired, err = uCtrl.upgradeImageCheck()
+	assert.Nil(t, err, "error is nil if deployment does not have a container")
+	assert.False(t, upgradeRequired, "no containers found for HyperShift operator deployment - upgrade not required")
+	uCtrl.spokeUncachedClient.Delete(ctx, dp)
+
+	// Deployment does not have addon annotation
+	dp = &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "operator",
+			Namespace: "hypershift",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "nginx",
+						Image: "nginx:1.14.2",
+						Ports: []corev1.ContainerPort{{ContainerPort: 80}},
+						Env:   []corev1.EnvVar{{Name: util.HypershiftEnvVarImageAgentCapiProvider, Value: "123"}},
+					}},
+				},
+			},
+		},
+	}
+	uCtrl.spokeUncachedClient.Create(ctx, dp)
+	upgradeRequired, err = uCtrl.upgradeImageCheck()
+	assert.Nil(t, err, "error is nil if deployment does not have addon annotation")
+	assert.False(t, upgradeRequired, "HyperShift operator deployment not deployed by the HyperShift addon - upgrade not required")
+}

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -23,12 +23,41 @@ const (
 	HypershiftOverrideKey        = "imagestream"
 	AddonControllerName          = "hypershift-addon"
 
+	HypershiftOverrideImagesCM = "hypershift-override-images"
+	ImageUpgradeControllerName = "hypershift-image-upgrade"
+
 	HypershiftOperatorNamespace = "hypershift"
 	HypershiftOperatorName      = "operator"
 
 	// Labels for resources to reference the Hosted Cluster
 	HypershiftClusterNameLabel      = "hypershiftdeployments.cluster.open-cluster-management.io/cluster-name"
 	HypershiftHostingNamespaceLabel = "hypershiftdeployments.cluster.open-cluster-management.io/hosting-namespace"
+	HypershiftAddonAnnotationKey    = "hypershift.open-cluster-management.io/createBy"
+
+	// Hypershift Operator Deployment env vars for images
+	HypershiftEnvVarImageAwsCapiProvider      = "IMAGE_AWS_CAPI_PROVIDER"
+	HypershiftEnvVarImageAzureCapiProvider    = "IMAGE_AZURE_CAPI_PROVIDER"
+	HypershiftEnvVarImageKubevertCapiProvider = "IMAGE_KUBEVIRT_CAPI_PROVIDER"
+	HypershiftEnvVarImageKonnectivity         = "IMAGE_KONNECTIVITY"
+	HypershiftEnvVarImageAwsEncyptionProvider = "IMAGE_AWS_ENCRYPTION_PROVIDER"
+	HypershiftEnvVarImageClusterApi           = "IMAGE_CLUSTER_API"
+	HypershiftEnvVarImageAgentCapiProvider    = "IMAGE_AGENT_CAPI_PROVIDER"
+
+	// ImageStream image names
+	ImageStreamAwsCapiProvider      = "cluster-api-provider-aws"
+	ImageStreamAzureCapiProvider    = "cluster-api-provider-azure"
+	ImageStreamKubevertCapiProvider = "cluster-api-provider-kubevirt"
+	ImageStreamKonnectivity         = "apiserver-network-proxy"
+	ImageStreamAwsEncyptionProvider = "aws-encryption-provider"
+	ImageStreamClusterApi           = "cluster-api"
+	ImageStreamAgentCapiProvider    = "cluster-api-provider-agent"
+	ImageStreamHypershiftOperator   = "hypershift-operator"
+
+	HypershiftBucketSecretName      = "hypershift-operator-oidc-provider-s3-credentials"
+	HypershiftPrivateLinkSecretName = "hypershift-operator-private-link-credentials"
+	HypershiftExternalDNSSecretName = "hypershift-operator-external-dns-credentials"
+	HypershiftDeploymentAnnoKey     = "cluster.open-cluster-management.io/hypershiftdeployment"
+	ManagedClusterAnnoKey           = "cluster.open-cluster-management.io/managedcluster-name"
 )
 
 // GenerateClientConfigFromSecret generate a client config from a given secret


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* This features enables the ability to upgrade images for individual HyperShift operators through a configmap. When an image(s) is updated in the configmap (open-cluster-management-agent-addon/hypershift-upgrade-images), the HyperShift add-on pod is restarted and the HyperShift operator is upgraded with the images in the configmap.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  This allows Service Delivery to define an upgrade strategy for their Management Clusters (specifically the Hypershift Addon). 

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-1648

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	12.148s	coverage: 61.4% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	2.920s	coverage: 80.8% of statements
```
Signed-off-by: Philip Wu <phwu@redhat.com>

