### PR TITLE
Create secrets on the hub when the progress of the HC is completed

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	configv1 "github.com/openshift/api/config/v1"
 	hyperv1alpha1 "github.com/openshift/hypershift/api/v1alpha1"
 )
 
@@ -130,6 +131,9 @@ func getHostedCluster(hcNN types.NamespacedName) *hyperv1alpha1.HostedCluster {
 			KubeConfig:        &corev1.LocalObjectReference{Name: "kubeconfig"},
 			KubeadminPassword: &corev1.LocalObjectReference{Name: "kubeadmin"},
 			Conditions:        []metav1.Condition{{Type: string(hyperv1alpha1.HostedClusterAvailable), Status: metav1.ConditionTrue}},
+			Version: &hyperv1alpha1.ClusterVersionStatus{
+				History: []configv1.UpdateHistory{{State: configv1.CompletedUpdate}},
+			},
 		},
 	}
 	return hc


### PR DESCRIPTION
Signed-off-by: Philip Wu <phwu@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Create secrets on the hub when the progress of the HC is completed

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  The OCP version of the managed cluster could be wrong if the secrets are created too early.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://github.com/stolostron/backlog/issues/24918

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	12.823s	coverage: 72.1% of statements
```
