### PR TITLE
Use job to install HyperShift operator

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -159,7 +159,7 @@ func (o *AgentOptions) runControllerManager(ctx context.Context) error {
 		o.HypershiftOperatorImage, o.PullSecretName, o.WithOverride)
 
 	// retry 3 times, in case something wrong with creating the hypershift install job
-	if err := uCtrl.RunHypershiftCmdWithRetires(ctx, 3, time.Second*10, uCtrl.RunHypershiftInstall); err != nil {
+	if err := uCtrl.RunHypershiftInstall(ctx); err != nil {
 		log.Error(err, "failed to install hypershift Operator")
 		return err
 	}

--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -153,7 +153,7 @@ func (c *UpgradeController) RunHypershiftInstall(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		c.log.Error(err, "hypershift operator exists but not deployed by addon, skip update")
+		c.log.Info("hypershift operator exists but not deployed by addon, skip update")
 		return nil
 	}
 

--- a/pkg/install/hypershift_test.go
+++ b/pkg/install/hypershift_test.go
@@ -22,24 +22,26 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/apimachinery/pkg/util/wait"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	imageapi "github.com/openshift/api/image/v1"
+	kbatch "k8s.io/api/batch/v1"
 )
 
 const (
 	hsOperatorImage = "hypershift-operator"
 )
 
-func initClient() client.Client {
+func initClient() ctrlClient.Client {
 	scheme := runtime.NewScheme()
 	//corev1.AddToScheme(scheme)
 	appsv1.AddToScheme(scheme)
 	corev1.AddToScheme(scheme)
 	metav1.AddMetaToScheme(scheme)
 	hyperv1alpha1.AddToScheme(scheme)
+	kbatch.AddToScheme(scheme)
 
 	ncb := fake.NewClientBuilder()
 	ncb.WithScheme(scheme)
@@ -412,7 +414,7 @@ func TestRunHypershiftInstall(t *testing.T) {
 	aCtrl.hubClient.Create(ctx, incompleteDp)
 
 	// No Spec in hypershift deployment operator - skip all operations
-	err := aCtrl.RunHypershiftInstall(ctx)
+	err := installHyperShiftOperator(t, ctx, aCtrl)
 	assert.Nil(t, err, "is nil if install HyperShift is successful")
 	aCtrl.hubClient.Delete(ctx, incompleteDp)
 
@@ -441,7 +443,7 @@ func TestRunHypershiftInstall(t *testing.T) {
 	aCtrl.hubClient.Create(ctx, dp)
 	defer aCtrl.hubClient.Delete(ctx, dp)
 
-	err = aCtrl.RunHypershiftInstall(ctx)
+	err = installHyperShiftOperator(t, ctx, aCtrl)
 	assert.Nil(t, err, "is nil if install HyperShift is successful")
 
 	// Check hypershift-operator-oidc-provider-s3-credentials secret exists
@@ -465,12 +467,6 @@ func TestRunHypershiftInstall(t *testing.T) {
 	err = aCtrl.spokeUncachedClient.Get(ctx, ctrlClient.ObjectKeyFromObject(plSecret), plSecret)
 	assert.NotNil(t, err, "is not nil when private link secret is not provided")
 	assert.True(t, errors.IsNotFound(err), "private link secret should not be found")
-
-	// Check service account is created
-	testSa := &corev1.ServiceAccount{}
-	err = aCtrl.spokeUncachedClient.Get(ctx, types.NamespacedName{Name: "test-sa", Namespace: "default"}, testSa)
-	assert.Nil(t, err, "is nil if the service account is found")
-	assert.Equal(t, aCtrl.pullSecret, testSa.ImagePullSecrets[0].Name, "is equal if the image pull secret in the service account matches the provided pull secret")
 
 	// Check hypershift deployment still exists
 	err = aCtrl.spokeUncachedClient.Get(ctx, hypershiftOperatorKey, dp)
@@ -498,7 +494,8 @@ func TestRunHypershiftInstall(t *testing.T) {
 	aCtrl.withOverride = true
 	aCtrl.hubClient.Create(ctx, overrideCM)
 	defer aCtrl.hubClient.Delete(ctx, overrideCM)
-	err = aCtrl.RunHypershiftInstall(ctx)
+
+	err = installHyperShiftOperator(t, ctx, aCtrl)
 	assert.Nil(t, err, "is nil if install HyperShift is sucessful")
 
 	// Run hypershift install again with image override using image upgrade configmap
@@ -513,26 +510,32 @@ func TestRunHypershiftInstall(t *testing.T) {
 	}
 	err = aCtrl.hubClient.Create(ctx, imageUpgradeCM)
 	assert.Nil(t, err, "err nil when config map is created successfull")
-	err = aCtrl.RunHypershiftInstall(ctx)
+
+	err = installHyperShiftOperator(t, ctx, aCtrl)
 	assert.Nil(t, err, "is nil if install HyperShift is sucessful")
 
-	// Check HS operator deployment has the correct image
-	err = aCtrl.spokeUncachedClient.Get(ctx, hypershiftOperatorKey, dp)
-	assert.Nil(t, err, "is nil if the hypershift deployment exists")
-	// Patch type types.ApplyPatchType not supported by fake client
-	// assert.Equal(t, "quay.io/stolostron/hypershift-operator@sha256:eedb58e7b9c4d9e49c6c53d1b5b97dfddcdffe839bbffd4fb950760715d24244", dp.Spec.Template.Spec.Containers[0].Image)
+	// Install hypershift job failed
+	go updateHsInstallJobToFailed(ctx, aCtrl.spokeUncachedClient, aCtrl.addonNamespace)
+	err = aCtrl.RunHypershiftInstall(ctx)
+	assert.NotNil(t, err, "is nil if install HyperShift is sucessful")
+	assert.Equal(t, "install HyperShift job failed", err.Error())
+	if err := deleteAllInstallJobs(ctx, aCtrl.spokeUncachedClient, aCtrl.addonNamespace); err != nil {
+		t.Errorf("error cleaning up HyperShift install jobs: %s", err.Error())
+	}
 
 	// Run hypershift install again with pull secret deleted
 	aCtrl.hubClient.Delete(ctx, pullSecret)
 	aCtrl.hubClient.Delete(ctx, hsPullSecret)
-	err = aCtrl.RunHypershiftInstall(ctx)
+
+	err = installHyperShiftOperator(t, ctx, aCtrl)
 	assert.Nil(t, err, "is nil if install HyperShift is sucessful")
+
 	err = aCtrl.spokeUncachedClient.Get(ctx, types.NamespacedName{Name: pullSecret.Name, Namespace: hypershiftOperatorKey.Namespace}, hsPullSecret)
 	assert.True(t, err != nil && errors.IsNotFound(err), "is true if the pull secret is not copied to the HyperShift namespace")
 
 	// Run hypershift install again with s3 bucket secret deleted
 	aCtrl.hubClient.Delete(ctx, bucketSecret)
-	err = aCtrl.RunHypershiftInstall(ctx)
+	err = installHyperShiftOperator(t, ctx, aCtrl)
 	assert.Nil(t, err, "is nil if install HyperShift is sucessful")
 
 	// Create hosted cluster
@@ -546,10 +549,6 @@ func TestRunHypershiftInstall(t *testing.T) {
 	err = aCtrl.RunHypershiftCmdWithRetires(ctx, 3, time.Second*10, aCtrl.RunHypershiftCleanup)
 	assert.Nil(t, err, "is nil if cleanup is succcessful")
 
-	// Check service account is not deleted
-	err = aCtrl.spokeUncachedClient.Get(ctx, types.NamespacedName{Name: "test-sa", Namespace: "default"}, testSa)
-	assert.Nil(t, err, "is nil if the service account exists")
-
 	// Check hypershift deployment is not deleted
 	err = aCtrl.spokeUncachedClient.Get(ctx, hypershiftOperatorKey, dp)
 	assert.Nil(t, err, "is nil if the hypershift deployment exists")
@@ -561,11 +560,6 @@ func TestRunHypershiftInstall(t *testing.T) {
 	// Cleanup after HC is deleted
 	err = aCtrl.RunHypershiftCmdWithRetires(ctx, 3, time.Second*10, aCtrl.RunHypershiftCleanup)
 	assert.Nil(t, err, "is nil if cleanup is succcessful")
-
-	// Check service account is deleted
-	err = aCtrl.spokeUncachedClient.Get(ctx, types.NamespacedName{Name: "test-sa", Namespace: "default"}, testSa)
-	assert.NotNil(t, err, "is not nil if the service account is deleted")
-	assert.True(t, errors.IsNotFound(err))
 
 	// Check hypershift deployment is deleted
 	err = aCtrl.spokeUncachedClient.Get(ctx, hypershiftOperatorKey, dp)
@@ -762,7 +756,8 @@ func TestRunHypershiftInstallPrivateLinkExternalDNS(t *testing.T) {
 	}
 	aCtrl.hubClient.Create(ctx, dp)
 	defer aCtrl.hubClient.Delete(ctx, dp)
-	err := aCtrl.RunHypershiftInstall(ctx)
+
+	err := installHyperShiftOperator(t, ctx, aCtrl)
 	assert.Nil(t, err, "is nil if install HyperShift is successful")
 
 	// Check hypershift-operator-oidc-provider-s3-credentials secret exists
@@ -865,4 +860,79 @@ func getHostedCluster(hcNN types.NamespacedName) *hyperv1alpha1.HostedCluster {
 		},
 	}
 	return hc
+}
+
+func installHyperShiftOperator(t *testing.T, ctx context.Context, aCtrl *UpgradeController) error {
+	go updateHsInstallJobToSucceeded(ctx, aCtrl.spokeUncachedClient, aCtrl.addonNamespace)
+	err := aCtrl.RunHypershiftInstall(ctx)
+	if err := deleteAllInstallJobs(ctx, aCtrl.spokeUncachedClient, aCtrl.addonNamespace); err != nil {
+		t.Errorf("error cleaning up HyperShift install jobs: %s", err.Error())
+	}
+
+	return err
+}
+
+func markInstallJobFinished(ctx context.Context, client ctrlClient.Client, addonNamespace string, f func(*kbatch.Job)) wait.ConditionFunc {
+	return func() (bool, error) {
+		listopts := &ctrlClient.ListOptions{}
+		listopts.Namespace = addonNamespace
+		jobList := &kbatch.JobList{}
+		if err := client.List(ctx, jobList, listopts); err != nil {
+			return false, err
+		}
+
+		if len(jobList.Items) > 0 {
+			for _, job := range jobList.Items {
+				f(&job)
+				if err := client.Update(ctx, &job); err != nil {
+					return false, err
+				}
+			}
+			return true, nil
+		}
+
+		return false, nil
+	}
+}
+
+func markInstallJobSucceeded(ctx context.Context, client ctrlClient.Client, addonNamespace string) wait.ConditionFunc {
+	sFunc := func(job *kbatch.Job) {
+		job.Status.Succeeded = 1
+	}
+
+	return markInstallJobFinished(ctx, client, addonNamespace, sFunc)
+}
+
+func markInstallJobFailed(ctx context.Context, client ctrlClient.Client, addonNamespace string) wait.ConditionFunc {
+	sFunc := func(job *kbatch.Job) {
+		job.Status.Failed = 1
+	}
+
+	return markInstallJobFinished(ctx, client, addonNamespace, sFunc)
+}
+
+func updateHsInstallJobToSucceeded(ctx context.Context, client ctrlClient.Client, addonNamespace string) error {
+	return wait.PollImmediate(3*time.Second, 15*time.Second, markInstallJobSucceeded(ctx, client, addonNamespace))
+}
+
+func updateHsInstallJobToFailed(ctx context.Context, client ctrlClient.Client, addonNamespace string) error {
+	return wait.PollImmediate(3*time.Second, 15*time.Second, markInstallJobFailed(ctx, client, addonNamespace))
+}
+
+func deleteAllInstallJobs(ctx context.Context, client ctrlClient.Client, addonNamespace string) error {
+	listopts := &ctrlClient.ListOptions{}
+	listopts.Namespace = addonNamespace
+	jobList := &kbatch.JobList{}
+	if err := client.List(ctx, jobList, listopts); err != nil {
+		return err
+	}
+
+	if len(jobList.Items) > 0 {
+		for _, job := range jobList.Items {
+			if err := client.Delete(ctx, &job); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/install/install_job.go
+++ b/pkg/install/install_job.go
@@ -62,8 +62,8 @@ func (c *UpgradeController) runHyperShiftInstallJob(ctx context.Context, image, 
 		jobPodSpec.Containers[0].VolumeMounts = []corev1.VolumeMount{{Name: util.HypershiftInstallJobVolume, MountPath: mountPath}}
 	}
 
-	backoffLimit := int32(1)
-	activeDeadlineSeconds := int64(300)
+	backoffLimit := int32(3)
+	activeDeadlineSeconds := int64(600)
 	ttlSecondsAfterFinished := int32(300)
 	job := &kbatch.Job{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/install/install_job.go
+++ b/pkg/install/install_job.go
@@ -1,0 +1,119 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/stolostron/hypershift-addon-operator/pkg/util"
+	kbatch "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func (c *UpgradeController) runHyperShiftInstallJob(ctx context.Context, image, mountPath string, imageStreamCMData map[string]string, args []string) (*kbatch.Job, error) {
+	c.log.Info(fmt.Sprintf("HyperShift install args: %v", args))
+
+	jobPodSpec := corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:    util.ImageStreamHypershiftOperator,
+				Image:   image,
+				Command: []string{"hypershift", "install"},
+				Args:    args,
+			},
+		},
+		RestartPolicy:      "Never",
+		ServiceAccountName: util.HypershiftInstallJobServiceAccount,
+	}
+
+	if len(imageStreamCMData) > 0 {
+		imageStreamCM := &corev1.ConfigMap{
+			Data: imageStreamCMData,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      util.HypershiftInstallJobImageStream,
+				Namespace: c.addonNamespace,
+			},
+		}
+
+		mutateFunc := func(configmap *corev1.ConfigMap, data map[string]string) controllerutil.MutateFn {
+			return func() error {
+				configmap.Data = data
+				return nil
+			}
+		}
+
+		if _, err := controllerutil.CreateOrUpdate(ctx, c.spokeUncachedClient, imageStreamCM, mutateFunc(imageStreamCM, imageStreamCMData)); err != nil {
+			return nil, err
+		}
+
+		jobPodSpec.Volumes = []corev1.Volume{{Name: util.HypershiftInstallJobVolume,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: imageStreamCM.Name,
+					},
+				},
+			},
+		}}
+		jobPodSpec.Containers[0].VolumeMounts = []corev1.VolumeMount{{Name: util.HypershiftInstallJobVolume, MountPath: mountPath}}
+	}
+
+	backoffLimit := int32(1)
+	activeDeadlineSeconds := int64(300)
+	ttlSecondsAfterFinished := int32(300)
+	job := &kbatch.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: util.HypershiftInstallJobName,
+			Namespace:    c.addonNamespace,
+		},
+		Spec: kbatch.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: jobPodSpec,
+			},
+			BackoffLimit:            &backoffLimit,
+			ActiveDeadlineSeconds:   &activeDeadlineSeconds,
+			TTLSecondsAfterFinished: &ttlSecondsAfterFinished,
+		},
+	}
+	if err := c.spokeUncachedClient.Create(ctx, job); err != nil {
+		return nil, err
+	}
+
+	c.log.Info(fmt.Sprintf("created HyperShift install job: %s", job.Name))
+
+	return job, wait.PollImmediate(10*time.Second, 5*time.Minute, c.isInstallJobFinished(ctx, job.Name))
+}
+
+func (c *UpgradeController) isInstallJobSuccessful(ctx context.Context, jobName string) (bool, error) {
+	job := &kbatch.Job{}
+	jobKey := types.NamespacedName{Name: jobName, Namespace: c.addonNamespace}
+	if err := c.spokeUncachedClient.Get(ctx, jobKey, job); err != nil {
+		return false, err
+	}
+
+	if job.Status.Succeeded > 0 {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (c *UpgradeController) isInstallJobFinished(ctx context.Context, jobName string) wait.ConditionFunc {
+	return func() (bool, error) {
+		job := &kbatch.Job{}
+		jobKey := types.NamespacedName{Name: jobName, Namespace: c.addonNamespace}
+		if err := c.spokeUncachedClient.Get(ctx, jobKey, job); err != nil {
+			return false, err
+		}
+
+		if job.Status.Failed > 0 || job.Status.Succeeded > 0 {
+			return true, nil
+		}
+
+		return false, nil
+	}
+}

--- a/pkg/install/upgrade.go
+++ b/pkg/install/upgrade.go
@@ -3,7 +3,6 @@ package install
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -59,7 +58,7 @@ func (c *UpgradeController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	if upgradeRequired {
 		c.log.Info("image changes detected, upgrade the HyperShift operator")
-		if err := c.RunHypershiftCmdWithRetires(ctx, 3, time.Second*10, c.RunHypershiftInstall); err != nil {
+		if err := c.RunHypershiftInstall(ctx); err != nil {
 			c.log.Error(err, "failed to install hypershift Operator")
 			return ctrl.Result{}, err
 		}

--- a/pkg/manager/manifests/templates/clusterrole.yaml
+++ b/pkg/manager/manifests/templates/clusterrole.yaml
@@ -101,3 +101,9 @@ rules:
       - hostedclusters
     verbs:
       - '*'
+  - verbs:
+      - '*'
+    apiGroups:
+      - batch
+    resources:
+      - jobs

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -58,6 +58,12 @@ const (
 	HypershiftExternalDNSSecretName = "hypershift-operator-external-dns-credentials"
 	HypershiftDeploymentAnnoKey     = "cluster.open-cluster-management.io/hypershiftdeployment"
 	ManagedClusterAnnoKey           = "cluster.open-cluster-management.io/managedcluster-name"
+
+	// HyperShift install job
+	HypershiftInstallJobName           = "hypershift-install-job-"
+	HypershiftInstallJobServiceAccount = "hypershift-addon-agent-sa"
+	HypershiftInstallJobVolume         = "hypershift-imagestream-volume"
+	HypershiftInstallJobImageStream    = "hypershift-install-job-imagestream"
 )
 
 // GenerateClientConfigFromSecret generate a client config from a given secret


### PR DESCRIPTION
Signed-off-by: Philip Wu <phwu@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* A job is used to install the HyperShift operator. This container created from the job uses the HyperShift operator image specified in the imagestream, or the hypershift-override-images configmap if it exists. By using the HyperShift CLI from the target HyperShift operator image to install the HyperShift operator, all resources, including the CRDs, are upgraded to the level of the target HyperShift operator image.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  The previous implementation uses the templates output from HyperShift render function to upgrade the HyperShift operator. The resource templates, including CRDs, are specific to the version of HyperShift bundled with the HyperShift agent addon.  As a result, there may be a mismatch between the HyperShift resources from the render function, and the image of the upgraded HyperShift operator.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-1720

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	23.044scoverage: 61.6% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	93.743scoverage: 83.9% of statements


```
