### PR TITLE
Hypershift update 2.1.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,8 @@ require (
 	github.com/go-logr/zapr v1.2.0
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.19.0
-	github.com/openshift/hypershift v0.0.0-20220810221813-2b7ac5268ac7
+	github.com/openshift/api v0.0.0-20220525145417-ee5b62754c68
+	github.com/openshift/hypershift v0.0.0-20220919131029-28abbc4660ee
 	github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
@@ -86,7 +87,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
-	github.com/openshift/api v0.0.0-20220525145417-ee5b62754c68 // indirect
 	github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a // indirect
 	github.com/openshift/cluster-api-provider-agent/api v0.0.0-20220227135922-dd6353f609dc // indirect
 	github.com/openshift/custom-resource-status v0.0.0-20200602122900-c002fd1547ca // indirect

--- a/go.sum
+++ b/go.sum
@@ -970,8 +970,8 @@ github.com/openshift/cluster-api-provider-kubevirt v0.0.0-20211223062810-ef64d5f
 github.com/openshift/cluster-api-provider-kubevirt v0.0.0-20211223062810-ef64d5ff1cde/go.mod h1:Z4fR4Cg8/z9GEys79MU+8CpX98aZQqI+tl9YIao0KxQ=
 github.com/openshift/custom-resource-status v0.0.0-20200602122900-c002fd1547ca h1:F1MEnOMwSrTA0YAkO0he9ip9w0JhYzI/iCB2mXmaSPg=
 github.com/openshift/custom-resource-status v0.0.0-20200602122900-c002fd1547ca/go.mod h1:GDjWl0tX6FNIj82vIxeudWeSx2Ff6nDZ8uJn0ohUFvo=
-github.com/openshift/hypershift v0.0.0-20220810221813-2b7ac5268ac7 h1:Bs2nHapFYluiOC4HstMxj8UgYSgNhP96TcFN+Yn98Ok=
-github.com/openshift/hypershift v0.0.0-20220810221813-2b7ac5268ac7/go.mod h1:YILhg4oa5ZN0z2a7p895NH63LCjW1wU1geAC0grAwAE=
+github.com/openshift/hypershift v0.0.0-20220919131029-28abbc4660ee h1:WovT9QYGXTMMou8YUtZrrtIzh1ZvYtmbCK9gbMuZC+8=
+github.com/openshift/hypershift v0.0.0-20220919131029-28abbc4660ee/go.mod h1:YILhg4oa5ZN0z2a7p895NH63LCjW1wU1geAC0grAwAE=
 github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc h1:j+upvKc1uLzuL+q/JXie8+IMohOooTCaEC9w+4d1Ztk=
 github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc/go.mod h1:AMZwYwSdbvALDl3QobEzcJ2IeDO7DYLsr42izKzh524=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Update hypershift 4.11 module with the latest

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Stay current

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://github.com/stolostron/backlog/issues/26083 opened for CICD to update the hypershift image SHAs

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
oc get hostedcluster -A
NAMESPACE   NAME       VERSION   KUBECONFIG                  PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
clusters    rj-0930a   4.11.7    rj-0930a-admin-kubeconfig   Completed   True        False         The hosted control plane is available

oc get hd -A
NAMESPACE   NAME       TYPE   INFRA                  IAM                    MANIFESTWORK           PROVIDER REF   PROGRESS    AVAILABLE
default     rj-0930a   AWS    ConfiguredAsExpected   ConfiguredAsExpected   ConfiguredAsExpected   AsExpected     Completed   True

oc get awsmachine -A
NAMESPACE           NAME             CLUSTER          STATE     READY   INSTANCEID                              MACHINE
clusters-rj-0930a   rj-0930a-jh978   rj-0930a-75zpx   running   true    aws:///us-east-1a/i-0eab429c37daaa505   rj-0930a-687f67c654-f76sm
clusters-rj-0930a   rj-0930a-l4wct   rj-0930a-75zpx   running   true    aws:///us-east-1a/i-012f51a42763fdf26   rj-0930a-687f67c654-p9kgq

oc delete -f hd.yaml
hypershiftdeployment.cluster.open-cluster-management.io "rj-0930a" deleted
```
