### PR TITLE
Back-port upgrade of images for Hypershift operators

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,16 +3,19 @@ module github.com/stolostron/hypershift-addon-operator
 go 1.18
 
 require (
+	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.1
 	github.com/go-logr/zapr v1.2.0
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.19.0
+	github.com/openshift/api v0.0.0-20220525145417-ee5b62754c68
 	github.com/openshift/hypershift v0.0.0-20220810221813-2b7ac5268ac7
 	github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.1
 	go.uber.org/zap v1.19.1
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.24.2
 	k8s.io/apimachinery v0.24.2
 	k8s.io/client-go v0.24.2
@@ -56,7 +59,6 @@ require (
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/felixge/httpsnoop v1.0.2 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
-	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.6 // indirect
 	github.com/go-openapi/swag v0.21.1 // indirect
@@ -86,7 +88,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
-	github.com/openshift/api v0.0.0-20220525145417-ee5b62754c68 // indirect
 	github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a // indirect
 	github.com/openshift/cluster-api-provider-agent/api v0.0.0-20220227135922-dd6353f609dc // indirect
 	github.com/openshift/custom-resource-status v0.0.0-20200602122900-c002fd1547ca // indirect
@@ -137,7 +138,6 @@ require (
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	helm.sh/helm/v3 v3.7.2 // indirect
 	k8s.io/apiextensions-apiserver v0.24.2 // indirect

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -8,15 +8,21 @@ import (
 	"github.com/go-logr/zapr"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	configv1 "github.com/openshift/api/config/v1"
 	hyperv1alpha1 "github.com/openshift/hypershift/api/v1alpha1"
+
+	"github.com/stolostron/hypershift-addon-operator/pkg/util"
 )
 
 func TestReconcile(t *testing.T) {
@@ -25,15 +31,10 @@ func TestReconcile(t *testing.T) {
 	zapLog, _ := zap.NewDevelopment()
 
 	aCtrl := &agentController{
-		spokeUncachedClient:       client,
-		spokeClient:               client,
-		hubClient:                 client,
-		log:                       zapr.NewLogger(zapLog),
-		addonNamespace:            "addon",
-		operatorImage:             "my-test-image",
-		clusterName:               "cluster1",
-		pullSecret:                "pull-secret",
-		hypershiftInstallExecutor: &HypershiftTestCliExecutor{},
+		spokeUncachedClient: client,
+		spokeClient:         client,
+		hubClient:           client,
+		log:                 zapr.NewLogger(zapLog),
 	}
 
 	// Create secrets
@@ -109,7 +110,7 @@ func getHostedCluster(hcNN types.NamespacedName) *hyperv1alpha1.HostedCluster {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        hcNN.Name,
 			Namespace:   hcNN.Namespace,
-			Annotations: map[string]string{hypershiftDeploymentAnnoKey: "test-hd1"},
+			Annotations: map[string]string{util.HypershiftDeploymentAnnoKey: "test-hd1"},
 		},
 		Spec: hyperv1alpha1.HostedClusterSpec{
 			Platform: hyperv1alpha1.PlatformSpec{
@@ -143,4 +144,47 @@ func TestAgentCommand(t *testing.T) {
 	zapLog, _ := zap.NewDevelopment()
 	cleanupCmd := NewAgentCommand("operator", zapr.NewLogger(zapLog))
 	assert.Equal(t, "agent", cleanupCmd.Use)
+}
+
+func TestCleanupCommand(t *testing.T) {
+	ctx := context.Background()
+	zapLog, _ := zap.NewDevelopment()
+	cleanupCmd := NewCleanupCommand("operator", zapr.NewLogger(zapLog))
+	assert.Equal(t, "cleanup", cleanupCmd.Use)
+
+	// Cleanup
+	// Hypershift deployment is not deleted because there is an existing hostedcluster
+	o := &AgentOptions{
+		Log:            zapr.NewLogger(zapLog),
+		AddonName:      "hypershift-addon",
+		AddonNamespace: "hypershift",
+	}
+	err := o.runCleanup(ctx, nil)
+	assert.Nil(t, err, "is nil if cleanup is succcessful")
+}
+
+func TestRunControllerManager(t *testing.T) {
+	ctx := context.Background()
+	zapLog, _ := zap.NewDevelopment()
+	o := &AgentOptions{
+		Log:            zapr.NewLogger(zapLog),
+		AddonName:      "hypershift-addon",
+		AddonNamespace: "hypershift",
+	}
+	err := o.runControllerManager(ctx)
+	assert.NotNil(t, err, "err it not nil if the controller fail to run")
+}
+
+func initClient() client.Client {
+	scheme := runtime.NewScheme()
+	//corev1.AddToScheme(scheme)
+	appsv1.AddToScheme(scheme)
+	corev1.AddToScheme(scheme)
+	metav1.AddMetaToScheme(scheme)
+	hyperv1alpha1.AddToScheme(scheme)
+
+	ncb := fake.NewClientBuilder()
+	ncb.WithScheme(scheme)
+	return ncb.Build()
+
 }

--- a/pkg/install/hypershift_executor.go
+++ b/pkg/install/hypershift_executor.go
@@ -1,4 +1,4 @@
-package agent
+package install
 
 import (
 	"bytes"

--- a/pkg/install/upgrade.go
+++ b/pkg/install/upgrade.go
@@ -1,0 +1,176 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/stolostron/hypershift-addon-operator/pkg/util"
+)
+
+type UpgradeController struct {
+	hubClient                 client.Client
+	spokeUncachedClient       client.Client
+	log                       logr.Logger
+	addonName                 string
+	addonNamespace            string
+	clusterName               string
+	operatorImage             string
+	pullSecret                string
+	withOverride              bool
+	hypershiftInstallExecutor HypershiftInstallExecutorInterface
+}
+
+func NewUpgradeController(hubClient, spokeClient client.Client, logger logr.Logger, addonName, addonNamespace, clusterName, operatorImage,
+	pullSecretName string, withOverride bool) *UpgradeController {
+	return &UpgradeController{
+		hubClient:                 hubClient,
+		spokeUncachedClient:       spokeClient,
+		log:                       logger,
+		addonName:                 addonName,
+		addonNamespace:            addonNamespace,
+		clusterName:               clusterName,
+		operatorImage:             operatorImage,
+		pullSecret:                pullSecretName,
+		withOverride:              withOverride,
+		hypershiftInstallExecutor: &HypershiftLibExecutor{},
+	}
+}
+
+func (c *UpgradeController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	c.log.Info(fmt.Sprintf("Reconciling hypershift update images configmap %s", req))
+	defer c.log.Info(fmt.Sprintf("Done hypershift update images configmap %s", req))
+
+	upgradeRequired, err := c.upgradeImageCheck()
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if upgradeRequired {
+		c.log.Info("image changes detected, upgrade the HyperShift operator")
+		if err := c.RunHypershiftCmdWithRetries(ctx, 3, time.Second*10, c.RunHypershiftInstall); err != nil {
+			c.log.Error(err, "failed to install hypershift Operator")
+			return ctrl.Result{}, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (c *UpgradeController) upgradeImageCheck() (bool, error) {
+	hsOperatorKey := types.NamespacedName{
+		Name:      util.HypershiftOperatorName,
+		Namespace: util.HypershiftOperatorNamespace,
+	}
+
+	hsOperator := &appsv1.Deployment{}
+	if err := c.spokeUncachedClient.Get(context.TODO(), hsOperatorKey, hsOperator); err != nil {
+		return false, fmt.Errorf("failed to get the hypershift operator deployment, err: %w", err)
+	}
+
+	if len(hsOperator.Spec.Template.Spec.Containers) != 1 {
+		c.log.Info("no containers found for HyperShift operator deployment, skip upgrade")
+		return false, nil
+	}
+
+	if hsOperator.Annotations[util.HypershiftAddonAnnotationKey] != util.AddonControllerName {
+		c.log.Info("HyperShift operator deployment not deployed by the HyperShift addon, skip upgrade")
+		return false, nil
+	}
+
+	imageOverrideMap, err := c.getImageOverrideMap()
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			c.log.Info("image override configmap is deleted, re-install HyperShift operator using imagestream images")
+			return true, nil
+		}
+
+		return false, fmt.Errorf("failed to get the image override configmap, err: %w", err)
+	}
+
+	hsOperatorContainer := hsOperator.Spec.Template.Spec.Containers[0]
+	for k, v := range imageOverrideMap {
+		switch k {
+		case util.ImageStreamAgentCapiProvider:
+			if v != getContainerEnvVar(hsOperatorContainer.Env, util.HypershiftEnvVarImageAgentCapiProvider) {
+				return true, nil
+			}
+		case util.ImageStreamAwsCapiProvider:
+			if v != getContainerEnvVar(hsOperatorContainer.Env, util.HypershiftEnvVarImageAwsCapiProvider) {
+				return true, nil
+			}
+		case util.ImageStreamAwsEncyptionProvider:
+			if v != getContainerEnvVar(hsOperatorContainer.Env, util.HypershiftEnvVarImageAwsEncyptionProvider) {
+				return true, nil
+			}
+		case util.ImageStreamAzureCapiProvider:
+			if v != getContainerEnvVar(hsOperatorContainer.Env, util.HypershiftEnvVarImageAzureCapiProvider) {
+				return true, nil
+			}
+		case util.ImageStreamClusterApi:
+			if v != getContainerEnvVar(hsOperatorContainer.Env, util.HypershiftEnvVarImageClusterApi) {
+				return true, nil
+			}
+		case util.ImageStreamKonnectivity:
+			if v != getContainerEnvVar(hsOperatorContainer.Env, util.HypershiftEnvVarImageKonnectivity) {
+				return true, nil
+			}
+		case util.ImageStreamKubevertCapiProvider:
+			if v != getContainerEnvVar(hsOperatorContainer.Env, util.HypershiftEnvVarImageKubevertCapiProvider) {
+				return true, nil
+			}
+		case util.ImageStreamHypershiftOperator:
+			if v != hsOperatorContainer.Image {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+func (c *UpgradeController) SetupWithManager(mgr ctrl.Manager) error {
+	filterByCM := func(obj client.Object) bool {
+		if obj.GetName() == util.HypershiftOverrideImagesCM && obj.GetNamespace() == c.addonNamespace {
+			return true
+		}
+
+		return false
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.ConfigMap{}).
+		WithEventFilter(predicate.NewPredicateFuncs(filterByCM)).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
+		Complete(c)
+}
+
+func (c *UpgradeController) getImageOverrideMap() (map[string]string, error) {
+	overrideImagesCm := &corev1.ConfigMap{}
+	overrideImagesCmKey := types.NamespacedName{Name: util.HypershiftOverrideImagesCM, Namespace: c.addonNamespace}
+	if err := c.spokeUncachedClient.Get(context.TODO(), overrideImagesCmKey, overrideImagesCm); err != nil {
+		return nil, err
+	}
+
+	return overrideImagesCm.Data, nil
+}
+
+func getContainerEnvVar(envVars []corev1.EnvVar, imageName string) string {
+	for _, ev := range envVars {
+		if ev.Name == imageName {
+			return ev.Value
+		}
+	}
+	return ""
+}

--- a/pkg/install/upgrade_test.go
+++ b/pkg/install/upgrade_test.go
@@ -1,0 +1,178 @@
+package install
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/zapr"
+	"github.com/stolostron/hypershift-addon-operator/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestUpgradeImageCheck(t *testing.T) {
+	ctx := context.Background()
+	zapLog, _ := zap.NewDevelopment()
+	uCtrl := NewUpgradeController(nil, initClient(), zapr.NewLogger(zapLog), "hypershift-addon",
+		"open-cluster-management-agent-addon", "local-cluster", "hs-op-image", "pull-secret", true)
+
+	dp := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "operator",
+			Namespace:   "hypershift",
+			Annotations: map[string]string{util.HypershiftAddonAnnotationKey: util.AddonControllerName},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "nginx",
+						Image: "nginx:1.14.2",
+						Ports: []corev1.ContainerPort{{ContainerPort: 80}},
+						Env:   []corev1.EnvVar{{Name: util.HypershiftEnvVarImageAgentCapiProvider, Value: "123"}},
+					}},
+				},
+			},
+		},
+	}
+	uCtrl.spokeUncachedClient.Create(ctx, dp)
+
+	overrideCM := &corev1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      util.HypershiftOverrideImagesCM,
+			Namespace: uCtrl.addonNamespace,
+		},
+	}
+	uCtrl.spokeUncachedClient.Create(ctx, overrideCM)
+
+	cases := []struct {
+		name       string
+		imageName  string
+		imageHash  string
+		expectedOk bool
+	}{
+		{
+			name:       "check image update: " + util.ImageStreamAwsCapiProvider,
+			imageName:  util.ImageStreamAwsCapiProvider,
+			imageHash:  "abc",
+			expectedOk: true,
+		},
+		{
+			name:       "check image update: " + util.ImageStreamAgentCapiProvider,
+			imageName:  util.ImageStreamAgentCapiProvider,
+			imageHash:  "abc",
+			expectedOk: true,
+		},
+		{
+			name:       "check image update: " + util.ImageStreamAwsEncyptionProvider,
+			imageName:  util.ImageStreamAwsEncyptionProvider,
+			imageHash:  "abc",
+			expectedOk: true,
+		},
+		{
+			name:       "check image update: " + util.ImageStreamAzureCapiProvider,
+			imageName:  util.ImageStreamAzureCapiProvider,
+			imageHash:  "abc",
+			expectedOk: true,
+		},
+		{
+			name:       "check image update: " + util.ImageStreamClusterApi,
+			imageName:  util.ImageStreamClusterApi,
+			imageHash:  "abc",
+			expectedOk: true,
+		},
+		{
+			name:       "check image update: " + util.ImageStreamKonnectivity,
+			imageName:  util.ImageStreamKonnectivity,
+			imageHash:  "abc",
+			expectedOk: true,
+		},
+		{
+			name:       "check image update: " + util.ImageStreamKubevertCapiProvider,
+			imageName:  util.ImageStreamKubevertCapiProvider,
+			imageHash:  "abc",
+			expectedOk: true,
+		},
+		{
+			name:       "check image update: " + util.ImageStreamHypershiftOperator,
+			imageName:  util.ImageStreamHypershiftOperator,
+			imageHash:  "abc",
+			expectedOk: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			overrideCM.Data = map[string]string{c.imageName: c.imageHash}
+			uCtrl.spokeUncachedClient.Update(ctx, overrideCM)
+			upgradeRequired, _ := uCtrl.upgradeImageCheck()
+			assert.Equal(t, c.expectedOk, upgradeRequired, "ok as expected")
+		})
+	}
+
+	// Image override CM does not exist
+	uCtrl.spokeUncachedClient.Delete(ctx, overrideCM)
+	upgradeRequired, err := uCtrl.upgradeImageCheck()
+	assert.Nil(t, err, "error is nil if image override CM does not exist")
+	assert.True(t, upgradeRequired, "image upgrade is required if image override CM does not exist")
+
+	// No deployment
+	uCtrl.spokeUncachedClient.Delete(ctx, dp)
+	_, err = uCtrl.upgradeImageCheck()
+	assert.NotNil(t, err, "error is not nil if deployment does not exist")
+	assert.Contains(t, err.Error(), "failed to get the hypershift operator deployment")
+
+	// Deployment has no containers
+	dp = &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "operator",
+			Namespace:   "hypershift",
+			Annotations: map[string]string{util.HypershiftAddonAnnotationKey: util.AddonControllerName},
+		},
+	}
+	uCtrl.spokeUncachedClient.Create(ctx, dp)
+	upgradeRequired, err = uCtrl.upgradeImageCheck()
+	assert.Nil(t, err, "error is nil if deployment does not have a container")
+	assert.False(t, upgradeRequired, "no containers found for HyperShift operator deployment - upgrade not required")
+	uCtrl.spokeUncachedClient.Delete(ctx, dp)
+
+	// Deployment does not have addon annotation
+	dp = &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "operator",
+			Namespace: "hypershift",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "nginx",
+						Image: "nginx:1.14.2",
+						Ports: []corev1.ContainerPort{{ContainerPort: 80}},
+						Env:   []corev1.EnvVar{{Name: util.HypershiftEnvVarImageAgentCapiProvider, Value: "123"}},
+					}},
+				},
+			},
+		},
+	}
+	uCtrl.spokeUncachedClient.Create(ctx, dp)
+	upgradeRequired, err = uCtrl.upgradeImageCheck()
+	assert.Nil(t, err, "error is nil if deployment does not have addon annotation")
+	assert.False(t, upgradeRequired, "HyperShift operator deployment not deployed by the HyperShift addon - upgrade not required")
+}

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -23,12 +23,41 @@ const (
 	HypershiftOverrideKey        = "imagestream"
 	AddonControllerName          = "hypershift-addon"
 
+	HypershiftOverrideImagesCM = "hypershift-override-images"
+	ImageUpgradeControllerName = "hypershift-image-upgrade"
+
 	HypershiftOperatorNamespace = "hypershift"
 	HypershiftOperatorName      = "operator"
 
 	// Labels for resources to reference the Hosted Cluster
 	HypershiftClusterNameLabel      = "hypershiftdeployments.cluster.open-cluster-management.io/cluster-name"
 	HypershiftHostingNamespaceLabel = "hypershiftdeployments.cluster.open-cluster-management.io/hosting-namespace"
+	HypershiftAddonAnnotationKey    = "hypershift.open-cluster-management.io/createBy"
+
+	// Hypershift Operator Deployment env vars for images
+	HypershiftEnvVarImageAwsCapiProvider      = "IMAGE_AWS_CAPI_PROVIDER"
+	HypershiftEnvVarImageAzureCapiProvider    = "IMAGE_AZURE_CAPI_PROVIDER"
+	HypershiftEnvVarImageKubevertCapiProvider = "IMAGE_KUBEVIRT_CAPI_PROVIDER"
+	HypershiftEnvVarImageKonnectivity         = "IMAGE_KONNECTIVITY"
+	HypershiftEnvVarImageAwsEncyptionProvider = "IMAGE_AWS_ENCRYPTION_PROVIDER"
+	HypershiftEnvVarImageClusterApi           = "IMAGE_CLUSTER_API"
+	HypershiftEnvVarImageAgentCapiProvider    = "IMAGE_AGENT_CAPI_PROVIDER"
+
+	// ImageStream image names
+	ImageStreamAwsCapiProvider      = "cluster-api-provider-aws"
+	ImageStreamAzureCapiProvider    = "cluster-api-provider-azure"
+	ImageStreamKubevertCapiProvider = "cluster-api-provider-kubevirt"
+	ImageStreamKonnectivity         = "apiserver-network-proxy"
+	ImageStreamAwsEncyptionProvider = "aws-encryption-provider"
+	ImageStreamClusterApi           = "cluster-api"
+	ImageStreamAgentCapiProvider    = "cluster-api-provider-agent"
+	ImageStreamHypershiftOperator   = "hypershift-operator"
+
+	HypershiftBucketSecretName      = "hypershift-operator-oidc-provider-s3-credentials"
+	HypershiftPrivateLinkSecretName = "hypershift-operator-private-link-credentials"
+	HypershiftExternalDNSSecretName = "hypershift-operator-external-dns-credentials"
+	HypershiftDeploymentAnnoKey     = "cluster.open-cluster-management.io/hypershiftdeployment"
+	ManagedClusterAnnoKey           = "cluster.open-cluster-management.io/managedcluster-name"
 )
 
 // GenerateClientConfigFromSecret generate a client config from a given secret


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* This features enables the ability to upgrade images for individual HyperShift operators through a configmap. When an image(s) is updated in the configmap (open-cluster-management-agent-addon/hypershift-upgrade-images), the HyperShift add-on pod is restarted and the HyperShift operator is upgraded with the images in the configmap.


<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  This is for back-porting the work that was done for MCE 2.2 in https://github.com/stolostron/hypershift-addon-operator/pull/73

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-1759

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
ok      github.com/stolostron/hypershift-addon-operator/pkg/agent       10.534s coverage: 61.6% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/install     1.680s  coverage: 80.8% of statements
```
