### PR TITLE
Use job to install HyperShift operator - 2.1

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -159,7 +159,7 @@ func (o *AgentOptions) runControllerManager(ctx context.Context) error {
 		o.HypershiftOperatorImage, o.PullSecretName, o.WithOverride)
 
 	// retry 3 times, in case something wrong with creating the hypershift install job
-	if err := uCtrl.RunHypershiftCmdWithRetries(ctx, 3, time.Second*10, uCtrl.RunHypershiftInstall); err != nil {
+	if err := uCtrl.RunHypershiftInstall(ctx); err != nil {
 		log.Error(err, "failed to install hypershift Operator")
 		return err
 	}

--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -6,9 +6,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
+	"path/filepath"
 	"time"
 
 	"gopkg.in/yaml.v2"
@@ -153,7 +153,7 @@ func (c *UpgradeController) RunHypershiftInstall(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		c.log.Error(err, "hypershift operator exists but not deployed by addon, skip update")
+		c.log.Info("hypershift operator exists but not deployed by addon, skip update")
 		return nil
 	}
 
@@ -168,8 +168,6 @@ func (c *UpgradeController) RunHypershiftInstall(ctx context.Context) error {
 	}
 
 	args := []string{
-		"render",
-		"--format", "json",
 		"--namespace", hypershiftOperatorKey.Namespace,
 	}
 
@@ -251,76 +249,38 @@ func (c *UpgradeController) RunHypershiftInstall(ctx context.Context) error {
 	}
 	args = append(args, telemetryArgs...)
 
+	hypershiftImage := c.operatorImage
+	imageStreamCMData := make(map[string]string, 0)
 	if c.withOverride {
-		imageStreamFile, err := c.readInDownstreamOverride()
+		im, err := c.readInDownstreamOverride()
 		if err != nil {
 			return fmt.Errorf("failed to read the downstream image override configmap, err: %w", err)
 		}
 
-		defer os.Remove(imageStreamFile.Name())
+		imageStreamCMData[util.HypershiftDownstreamOverride] = string(im)
 
-		args = append(args, "--image-refs", imageStreamFile.Name())
+		hypershiftImage = getHyperShiftOperatorImage(im)
+		args = append(args, "--image-refs", filepath.Join(os.TempDir(), util.HypershiftDownstreamOverride))
 	} else {
-		args = append(args, "--hypershift-image", c.operatorImage)
+		args = append(args, "--hypershift-image", hypershiftImage)
 	}
 
-	c.log.Info(fmt.Sprintf("hypershift install args: %v", args))
-
-	items, err := c.runHypershiftRender(ctx, args)
+	job, err := c.runHyperShiftInstallJob(ctx, hypershiftImage, os.TempDir(), imageStreamCMData, args)
 	if err != nil {
 		return err
 	}
 
-	//TODO: @ianzhang366 fix the dependecy issue and use better way to inject the pull secret
-	for _, item := range items {
-		item := item
-		if item.GetKind() == "ServiceAccount" {
-			sa := &corev1.ServiceAccount{
-				ImagePullSecrets: []corev1.LocalObjectReference{
-					corev1.LocalObjectReference{Name: c.pullSecret},
-				},
-			}
-
-			sa.SetName(item.GetName())
-			sa.SetNamespace(item.GetNamespace())
-			sa.SetLabels(item.GetLabels())
-			sa.SetAnnotations(item.GetAnnotations())
-			sa.SetFinalizers(item.GetFinalizers())
-
-			if err := c.spokeUncachedClient.Create(ctx, sa); err != nil && !apierrors.IsAlreadyExists(err) {
-				c.log.Error(err, fmt.Sprintf("failed to create %s, %s", item.GetKind(), client.ObjectKeyFromObject(&item)))
-			}
-
-			continue
-		}
-
-		if item.GetKind() == "Deployment" {
-			a := item.GetAnnotations()
-			if len(a) == 0 {
-				a = map[string]string{}
-			}
-
-			a[util.HypershiftAddonAnnotationKey] = "hypershift-addon"
-
-			item.SetAnnotations(a)
-		}
-
-		itemBytes, err := item.MarshalJSON()
+	if jobSucceeded, err := c.isInstallJobSuccessful(ctx, job.Name); !jobSucceeded || err != nil {
 		if err != nil {
-			c.log.Error(err, fmt.Sprintf("failed to marshal json %s, %s", item.GetKind(), client.ObjectKeyFromObject(&item)))
-			continue
+			return err
 		}
 
-		if err := c.spokeUncachedClient.Patch(ctx,
-			&item,
-			client.RawPatch(types.ApplyPatchType, itemBytes),
-			client.ForceOwnership,
-			client.FieldOwner("hypershift")); err != nil {
-			c.log.Error(err, fmt.Sprintf("failed to apply %s, %s", item.GetKind(), client.ObjectKeyFromObject(&item)))
-			continue
-		}
-		c.log.Info(fmt.Sprintf("applied: %s at %s", item.GetKind(), client.ObjectKeyFromObject(&item)))
+		return fmt.Errorf("install HyperShift job failed")
 	}
+	c.log.Info(fmt.Sprintf("HyperShift install job: %s completed successfully", job.Name))
+
+	// Add label to Hypershift deployment
+	err = c.addAddonLabelToDeployment(ctx)
 
 	return nil
 }
@@ -450,7 +410,23 @@ func (c *UpgradeController) deploymentUpgradable(ctx context.Context) (error, bo
 	return nil, false
 }
 
-func (c *UpgradeController) readInDownstreamOverride() (*os.File, error) {
+func (c *UpgradeController) addAddonLabelToDeployment(ctx context.Context) error {
+	obj := &appsv1.Deployment{}
+
+	if err := c.spokeUncachedClient.Get(ctx, hypershiftOperatorKey, obj); err != nil {
+		return err
+	}
+
+	// Check if deployment is created by the addon
+	obj.Annotations[util.HypershiftAddonAnnotationKey] = util.AddonControllerName
+	if err := c.spokeUncachedClient.Update(ctx, obj); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *UpgradeController) readInDownstreamOverride() ([]byte, error) {
 	cm := &corev1.ConfigMap{}
 	cmKey := types.NamespacedName{Name: util.HypershiftDownstreamOverride, Namespace: c.addonNamespace}
 
@@ -478,19 +454,7 @@ func (c *UpgradeController) readInDownstreamOverride() (*os.File, error) {
 		return nil, fmt.Errorf("failed to get the image override configmap, err: %w", err)
 	}
 
-	file, err := ioutil.TempFile("", "hypershift-imagestream")
-	if err != nil { // likely a unrecoverable error, don't retry
-		return nil, fmt.Errorf("failed to create temp file for hoding aws credentials, err: %w", err)
-	}
-
-	f := file.Name()
-
-	c.log.Info(fmt.Sprintf("imagestream at: %s", f))
-	if err := ioutil.WriteFile(f, im, 0600); err != nil {
-		return nil, fmt.Errorf("failed to write to temp file for imagestream, err: %w", err)
-	}
-
-	return file, nil
+	return im, nil
 }
 
 func (c *UpgradeController) getUpdatedImageStream(im []byte, upgradeImagesMap map[string]string) ([]byte, error) {
@@ -519,4 +483,18 @@ func overrideImageInImageStream(imObj *imageapi.ImageStream, overrideImageName, 
 			break
 		}
 	}
+}
+
+func getHyperShiftOperatorImage(im []byte) string {
+	imObj := &imageapi.ImageStream{}
+	if err := yaml.Unmarshal(im, imObj); err != nil {
+		return ""
+	}
+
+	for _, tag := range imObj.Spec.Tags {
+		if tag.Name == util.ImageStreamHypershiftOperator {
+			return tag.From.Name
+		}
+	}
+	return ""
 }

--- a/pkg/install/install_job.go
+++ b/pkg/install/install_job.go
@@ -1,0 +1,119 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/stolostron/hypershift-addon-operator/pkg/util"
+	kbatch "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func (c *UpgradeController) runHyperShiftInstallJob(ctx context.Context, image, mountPath string, imageStreamCMData map[string]string, args []string) (*kbatch.Job, error) {
+	c.log.Info(fmt.Sprintf("HyperShift install args: %v", args))
+
+	jobPodSpec := corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:    util.ImageStreamHypershiftOperator,
+				Image:   image,
+				Command: []string{"hypershift", "install"},
+				Args:    args,
+			},
+		},
+		RestartPolicy:      "Never",
+		ServiceAccountName: util.HypershiftInstallJobServiceAccount,
+	}
+
+	if len(imageStreamCMData) > 0 {
+		imageStreamCM := &corev1.ConfigMap{
+			Data: imageStreamCMData,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      util.HypershiftInstallJobImageStream,
+				Namespace: c.addonNamespace,
+			},
+		}
+
+		mutateFunc := func(configmap *corev1.ConfigMap, data map[string]string) controllerutil.MutateFn {
+			return func() error {
+				configmap.Data = data
+				return nil
+			}
+		}
+
+		if _, err := controllerutil.CreateOrUpdate(ctx, c.spokeUncachedClient, imageStreamCM, mutateFunc(imageStreamCM, imageStreamCMData)); err != nil {
+			return nil, err
+		}
+
+		jobPodSpec.Volumes = []corev1.Volume{{Name: util.HypershiftInstallJobVolume,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: imageStreamCM.Name,
+					},
+				},
+			},
+		}}
+		jobPodSpec.Containers[0].VolumeMounts = []corev1.VolumeMount{{Name: util.HypershiftInstallJobVolume, MountPath: mountPath}}
+	}
+
+	backoffLimit := int32(3)
+	activeDeadlineSeconds := int64(600)
+	ttlSecondsAfterFinished := int32(300)
+	job := &kbatch.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: util.HypershiftInstallJobName,
+			Namespace:    c.addonNamespace,
+		},
+		Spec: kbatch.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: jobPodSpec,
+			},
+			BackoffLimit:            &backoffLimit,
+			ActiveDeadlineSeconds:   &activeDeadlineSeconds,
+			TTLSecondsAfterFinished: &ttlSecondsAfterFinished,
+		},
+	}
+	if err := c.spokeUncachedClient.Create(ctx, job); err != nil {
+		return nil, err
+	}
+
+	c.log.Info(fmt.Sprintf("created HyperShift install job: %s", job.Name))
+
+	return job, wait.PollImmediate(10*time.Second, 5*time.Minute, c.isInstallJobFinished(ctx, job.Name))
+}
+
+func (c *UpgradeController) isInstallJobSuccessful(ctx context.Context, jobName string) (bool, error) {
+	job := &kbatch.Job{}
+	jobKey := types.NamespacedName{Name: jobName, Namespace: c.addonNamespace}
+	if err := c.spokeUncachedClient.Get(ctx, jobKey, job); err != nil {
+		return false, err
+	}
+
+	if job.Status.Succeeded > 0 {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (c *UpgradeController) isInstallJobFinished(ctx context.Context, jobName string) wait.ConditionFunc {
+	return func() (bool, error) {
+		job := &kbatch.Job{}
+		jobKey := types.NamespacedName{Name: jobName, Namespace: c.addonNamespace}
+		if err := c.spokeUncachedClient.Get(ctx, jobKey, job); err != nil {
+			return false, err
+		}
+
+		if job.Status.Failed > 0 || job.Status.Succeeded > 0 {
+			return true, nil
+		}
+
+		return false, nil
+	}
+}

--- a/pkg/install/upgrade.go
+++ b/pkg/install/upgrade.go
@@ -3,7 +3,6 @@ package install
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -59,7 +58,7 @@ func (c *UpgradeController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	if upgradeRequired {
 		c.log.Info("image changes detected, upgrade the HyperShift operator")
-		if err := c.RunHypershiftCmdWithRetries(ctx, 3, time.Second*10, c.RunHypershiftInstall); err != nil {
+		if err := c.RunHypershiftInstall(ctx); err != nil {
 			c.log.Error(err, "failed to install hypershift Operator")
 			return ctrl.Result{}, err
 		}

--- a/pkg/manager/manifests/templates/clusterrole.yaml
+++ b/pkg/manager/manifests/templates/clusterrole.yaml
@@ -101,3 +101,9 @@ rules:
       - hostedclusters
     verbs:
       - '*'
+  - verbs:
+      - '*'
+    apiGroups:
+      - batch
+    resources:
+      - jobs

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -58,6 +58,12 @@ const (
 	HypershiftExternalDNSSecretName = "hypershift-operator-external-dns-credentials"
 	HypershiftDeploymentAnnoKey     = "cluster.open-cluster-management.io/hypershiftdeployment"
 	ManagedClusterAnnoKey           = "cluster.open-cluster-management.io/managedcluster-name"
+
+	// HyperShift install job
+	HypershiftInstallJobName           = "hypershift-install-job-"
+	HypershiftInstallJobServiceAccount = "hypershift-addon-agent-sa"
+	HypershiftInstallJobVolume         = "hypershift-imagestream-volume"
+	HypershiftInstallJobImageStream    = "hypershift-install-job-imagestream"
 )
 
 // GenerateClientConfigFromSecret generate a client config from a given secret


### PR DESCRIPTION
Signed-off-by: Philip Wu <phwu@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* A job is used to install the HyperShift operator. This container created from the job uses the HyperShift operator image specified in the imagestream, or the hypershift-override-images configmap if it exists. By using the HyperShift CLI from the target HyperShift operator image to install the HyperShift operator, all resources, including the CRDs, are upgraded to the level of the target HyperShift operator image.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  The previous implementation uses the templates output from HyperShift render function to upgrade the HyperShift operator. The resource templates, including CRDs, are specific to the version of HyperShift bundled with the HyperShift agent addon. As a result, there may be a mismatch between the HyperShift resources from the render function, and the image of the upgraded HyperShift operator.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-1720

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	12.007s	coverage: 61.6% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	92.381s	coverage: 83.9% of statements
```
