### PR TITLE
Plumb in `--external-dns-txt-owner-id`

### DIFF
--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -238,6 +238,9 @@ func (c *UpgradeController) RunHypershiftInstall(ctx context.Context) error {
 			"--external-dns-provider", string(sExtDNS.Data["provider"]),
 		}
 		args = append(args, awsArgs...)
+		if txtOwnerId, exists := sExtDNS.Data["txt-owner-id"]; exists {
+			args = append(args, "--external-dns-txt-owner-id", string(txtOwnerId))
+		}
 	} else {
 		c.log.Info(fmt.Sprintf("external dns secret(%s) was not found", extDNSSecretKey))
 	}

--- a/pkg/install/hypershift_test.go
+++ b/pkg/install/hypershift_test.go
@@ -722,6 +722,7 @@ func TestRunHypershiftInstallPrivateLinkExternalDNS(t *testing.T) {
 			"provider":      []byte(`aws`),
 			"credentials":   []byte(`private_secret`),
 			"domain-filter": []byte(`my.house.com`),
+			"txt-owner-id":  []byte(`the-owner`),
 		},
 	}
 
@@ -810,6 +811,7 @@ func TestRunHypershiftInstallPrivateLinkExternalDNS(t *testing.T) {
 				"--external-dns-secret", "hypershift-operator-external-dns-credentials",
 				"--external-dns-domain-filter", "my.house.com",
 				"--external-dns-provider", "aws",
+				"--external-dns-txt-owner-id", "the-owner",
 				"--enable-uwm-telemetry-remote-write",
 				"--platform-monitoring", "OperatorOnly",
 				"--hypershift-image", "my-test-image",

--- a/pkg/install/hypershift_test.go
+++ b/pkg/install/hypershift_test.go
@@ -19,7 +19,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -51,7 +50,7 @@ func initClient() ctrlClient.Client {
 
 func initDeployObj() *appsv1.Deployment {
 	return &appsv1.Deployment{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      util.HypershiftOperatorName,
 			Namespace: util.HypershiftOperatorNamespace,
 		},
@@ -72,7 +71,7 @@ func initDeployAddonImageDiffObj() *appsv1.Deployment {
 		util.HypershiftAddonAnnotationKey: util.AddonControllerName,
 	}
 	deploy.Spec.Template.Spec.Containers = []corev1.Container{
-		corev1.Container{Image: "testimage"},
+		{Image: "testimage"},
 	}
 	return deploy
 }
@@ -147,8 +146,8 @@ func (c *HypershiftTestCliExecutor) Execute(ctx context.Context, args []string) 
 			for _, tag := range ims.Spec.Tags {
 				if tag.Name == hsOperatorImage {
 					dp.Spec.Template.Spec.Containers[0].Image = tag.From.Name
+					break
 				}
-				break
 			}
 
 			break
@@ -482,10 +481,11 @@ func TestRunHypershiftInstall(t *testing.T) {
 	ims := &imageapi.ImageStream{}
 	ims.Spec.Tags = tr
 	imb, err := yaml.Marshal(ims)
+	assert.Nil(t, err, "expected Marshal to succeed: %s", err)
 
 	// Run hypershift install again with image override
 	overrideCM := &corev1.ConfigMap{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      util.HypershiftDownstreamOverride,
 			Namespace: aCtrl.addonNamespace,
 		},
@@ -500,7 +500,7 @@ func TestRunHypershiftInstall(t *testing.T) {
 
 	// Run hypershift install again with image override using image upgrade configmap
 	imageUpgradeCM := &corev1.ConfigMap{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      util.HypershiftOverrideImagesCM,
 			Namespace: aCtrl.addonNamespace,
 		},
@@ -590,7 +590,7 @@ func TestReadDownstreamOverride(t *testing.T) {
 	assert.NotNil(t, err, "is not nil when read downstream image override fails")
 
 	overrideCM := &corev1.ConfigMap{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      util.HypershiftDownstreamOverride,
 			Namespace: aCtrl.addonNamespace,
 		},


### PR DESCRIPTION
# Description of the change(s):
* Add support for a new key in the external DNS secret, `txt-owner-id`. If set, its value is plumbed into the `--external-dns-txt-owner-id` argument to the install job.


<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
* Allows service delivery to support external DNS when installing hypershift via the addon.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* #86

closes: #86

## Test API/Unit - Success
```script
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	5.784s	coverage: 61.6% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	91.645s	coverage: 84.0% of statements
```
