### PR TITLE
Gh 26383

### DIFF
--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -238,6 +238,9 @@ func (c *UpgradeController) RunHypershiftInstall(ctx context.Context) error {
 			"--external-dns-provider", string(sExtDNS.Data["provider"]),
 		}
 		args = append(args, awsArgs...)
+		if txtOwnerId, exists := sExtDNS.Data["txt-owner-id"]; exists {
+			args = append(args, "--external-dns-txt-owner-id", string(txtOwnerId))
+		}
 	} else {
 		c.log.Info(fmt.Sprintf("external dns secret(%s) was not found", extDNSSecretKey))
 	}


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Fixes the addon hypershift operator code to set external-dns-txt-owner-id for the external-dns operator

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Backporting https://github.com/stolostron/hypershift-addon-operator/pull/88 to MCE 2.1.2

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://github.com/stolostron/backlog/issues/26383

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
