### PR TITLE
ACM-1824 detect changes and re-install hypershift operator

### DIFF
--- a/docs/upgrading_hypershift_operator.md
+++ b/docs/upgrading_hypershift_operator.md
@@ -2,7 +2,7 @@
 
 ## Overriding the hypershift operator image references
 
-Without upgrading MCE or ACM, you can create configmap called `hypershift-override-images` in `open-cluster-management-agent-addon` namespace on a hosting (management) cluster to upgrade the hypershift operator that was installed by the hypershift `ManagedClusterAddon`. The hypershift addon agent watches this specific configmap and determines whether to upgrade the hypershift operator. This action should not have impact on other running hosted contol planes.
+Without upgrading MCE or ACM, you can create configmap called `hypershift-override-images` in the managed (hosting) cluster namespace on the MCE or ACM hub cluster to upgrade the hypershift operator that was installed by the hypershift `ManagedClusterAddon` on that specific hosting cluster. The hypershift addon agent watches for changes in `hypershift-override-images` configmap and determines whether to upgrade the hypershift operator. This action should not have impact on other running hosted contol planes or the hypershift operator installed on other hosting clusters.
 
 This is a sample configmap YAML.
 
@@ -11,7 +11,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: hypershift-override-images
-  namespace: open-cluster-management-agent-addon
+  namespace: my-first-hosting-cluster
 data:
   apiserver-network-proxy: quay.io:443/acm-d/apiserver-network-proxy-rhel8@sha256:90af8dd96676f1b07d9420924628ffe91682971d377030fe752d1bae226c8ffe
   aws-encryption-provider: quay.io:443/acm-d/aws-encryption-provider-rhel8@sha256:b3256a9a917f0895bb0973a5ee690dc649b66b9c8e14da789e6fa352e2bece4c
@@ -21,35 +21,4 @@ data:
   cluster-api-provider-azure: quay.io:443/acm-d/cluster-api-provider-azure-rhel8@sha256:9f9061f05c1a794b6ece36b481b107646bafe411457cfdc73bcc64c102c12ae4
   cluster-api-provider-kubevirt: quay.io:443/acm-d/cluster-api-provider-kubevirt-rhel8@sha256:b76fc28b739b24a3b367000c47b973220252f5e8cd01a0243e54ba9aab79d298
   hypershift-operator: quay.io:443/acm-d/hypershift-rhel8-operator@sha256:eedb58e7b9c4d9e49c6c53d1b5b97dfddcdffe839bbffd4fb950760715d24244
-```
-
-## Using manifestwork from the service cluster (MCE/ACM hub cluster) to upgrade the hypershift operator
-
-You can put `hypershift-upgrade-images` configmap as a payload of a `manifestwork` in the hosting managed cluster's namespace on the service cluster (MCE hub cluster). This will create create configmap called `hypershift-override-images` in `open-cluster-management-agent-addon` namespace on a hosting (management) cluster to trigger the hypershift operator upgrade on the hosting cluster.
-
-This is a sample manifestwork YAML.
-
-```YAML
-apiVersion: work.open-cluster-management.io/v1
-kind: ManifestWork
-metadata:
-  name: hypershift-operator-upgrade
-  namespace: my-hosting-cluster
-spec:
-  workload:
-    manifests:
-    - apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: hypershift-override-images
-        namespace: open-cluster-management-agent-addon
-      data:
-        apiserver-network-proxy: quay.io:443/acm-d/apiserver-network-proxy-rhel8@sha256:90af8dd96676f1b07d9420924628ffe91682971d377030fe752d1bae226c8ffe
-        aws-encryption-provider: quay.io:443/acm-d/aws-encryption-provider-rhel8@sha256:b3256a9a917f0895bb0973a5ee690dc649b66b9c8e14da789e6fa352e2bece4c
-        cluster-api: quay.io:443/acm-d/cluster-api-rhel8@sha256:b3edf4e95efc5dd749b938d85be63fc7b927f7c7b6d088fae3a4700f756f7c6f
-        cluster-api-provider-agent: quay.io:443/acm-d/cluster-api-provider-agent-rhel8@sha256:b02c207a1fc77da4d5e33b5cadf5f79da445a6656f26004b186a7cadbf19a74d
-        cluster-api-provider-aws: quay.io:443/acm-d/cluster-api-provider-aws-rhel8@sha256:065bf16f8a18a6de58ed522e4bbcdc2b744a9f89d73a39bdd36dcc297c493c39
-        cluster-api-provider-azure: quay.io:443/acm-d/cluster-api-provider-azure-rhel8@sha256:9f9061f05c1a794b6ece36b481b107646bafe411457cfdc73bcc64c102c12ae4
-        cluster-api-provider-kubevirt: quay.io:443/acm-d/cluster-api-provider-kubevirt-rhel8@sha256:b76fc28b739b24a3b367000c47b973220252f5e8cd01a0243e54ba9aab79d298
-        hypershift-operator: quay.io:443/acm-d/hypershift-rhel8-operator@sha256:eedb58e7b9c4d9e49c6c53d1b5b97dfddcdffe839bbffd4fb950760715d24244
 ```

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -164,6 +164,10 @@ func (o *AgentOptions) runControllerManager(ctx context.Context) error {
 		return err
 	}
 
+	// After the initial hypershift operator installation, start the process to continuously check
+	// if the hypershift operator re-installation is needed
+	uCtrl.Start()
+
 	leaseClient, err := kubernetes.NewForConfig(spokeConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create lease client, err: %w", err)
@@ -187,11 +191,6 @@ func (o *AgentOptions) runControllerManager(ctx context.Context) error {
 	//+kubebuilder:scaffold:builder
 	if err = aCtrl.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create agent controller: %s, err: %w", util.AddonControllerName, err)
-	}
-
-	//+kubebuilder:scaffold:builder
-	if err = uCtrl.SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create image upgrade controller: %s, err: %w", util.ImageUpgradeControllerName, err)
 	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -296,7 +296,11 @@ func (c *UpgradeController) RunHypershiftInstall(ctx context.Context) error {
 	c.log.Info(fmt.Sprintf("HyperShift install job: %s completed successfully", job.Name))
 
 	// Add label to Hypershift deployment
-	c.addAddonLabelToDeployment(ctx)
+	err = c.addAddonLabelToDeployment(ctx)
+
+	if err != nil {
+		c.log.Error(err, "failed to add addon label to the hypershift operator deployment")
+	}
 
 	return nil
 }

--- a/pkg/install/upgrade.go
+++ b/pkg/install/upgrade.go
@@ -3,15 +3,14 @@ package install
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"time"
 
 	"github.com/go-logr/logr"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	ctrl "sigs.k8s.io/controller-runtime"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -29,6 +28,13 @@ type UpgradeController struct {
 	pullSecret                string
 	withOverride              bool
 	hypershiftInstallExecutor HypershiftInstallExecutorInterface
+	stopch                    chan struct{}
+	ctx                       context.Context
+	bucketSecret              corev1.Secret
+	extDnsSecret              corev1.Secret
+	privateLinkSecret         corev1.Secret
+	imageOverrideConfigmap    corev1.ConfigMap
+	reinstallNeeded           bool // this is used only for code test
 }
 
 func NewUpgradeController(hubClient, spokeClient client.Client, logger logr.Logger, addonName, addonNamespace, clusterName, operatorImage,
@@ -47,129 +53,96 @@ func NewUpgradeController(hubClient, spokeClient client.Client, logger logr.Logg
 	}
 }
 
-func (c *UpgradeController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	c.log.Info(fmt.Sprintf("Reconciling hypershift update images configmap %s", req))
-	defer c.log.Info(fmt.Sprintf("Done hypershift update images configmap %s", req))
-
-	upgradeRequired, err := c.upgradeImageCheck()
-	if err != nil {
-		return ctrl.Result{}, err
+func (c *UpgradeController) Start() {
+	// do nothing if already started
+	if c.stopch != nil {
+		return
 	}
 
-	if upgradeRequired {
-		c.log.Info("image changes detected, upgrade the HyperShift operator")
-		if err := c.RunHypershiftInstall(ctx); err != nil {
-			c.log.Error(err, "failed to install hypershift Operator")
-			return ctrl.Result{}, err
+	c.stopch = make(chan struct{})
+
+	go wait.Until(func() {
+		c.reinstallNeeded = false
+		if c.installOptionsChanged() || c.upgradeImageCheck() {
+			c.reinstallNeeded = true
+			c.log.Info("change has been detected to require hypershift operator re-installation")
+			if err := c.RunHypershiftInstall(c.ctx); err != nil {
+				c.log.Error(err, "failed to install hypershift operator")
+			}
+
+		} else {
+			c.log.Info("hypershift operator installation options have not changed")
 		}
-	}
-
-	return ctrl.Result{}, nil
+	}, 2*time.Minute, c.stopch) // Connect to the hub every 2 minutes to check for any changes
 }
 
-func (c *UpgradeController) upgradeImageCheck() (bool, error) {
-	hsOperatorKey := types.NamespacedName{
-		Name:      util.HypershiftOperatorName,
-		Namespace: util.HypershiftOperatorNamespace,
-	}
+func (c *UpgradeController) Stop() {
+	close(c.stopch)
 
-	hsOperator := &appsv1.Deployment{}
-	if err := c.spokeUncachedClient.Get(context.TODO(), hsOperatorKey, hsOperator); err != nil {
-		return false, fmt.Errorf("failed to get the hypershift operator deployment, err: %w", err)
-	}
-
-	if len(hsOperator.Spec.Template.Spec.Containers) != 1 {
-		c.log.Info("no containers found for HyperShift operator deployment, skip upgrade")
-		return false, nil
-	}
-
-	if hsOperator.Annotations[util.HypershiftAddonAnnotationKey] != util.AddonControllerName {
-		c.log.Info("HyperShift operator deployment not deployed by the HyperShift addon, skip upgrade")
-		return false, nil
-	}
-
-	imageOverrideMap, err := c.getImageOverrideMap()
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			c.log.Info("image override configmap is deleted, re-install HyperShift operator using imagestream images")
-			return true, nil
-		}
-
-		return false, fmt.Errorf("failed to get the image override configmap, err: %w", err)
-	}
-
-	hsOperatorContainer := hsOperator.Spec.Template.Spec.Containers[0]
-	for k, v := range imageOverrideMap {
-		switch k {
-		case util.ImageStreamAgentCapiProvider:
-			if v != getContainerEnvVar(hsOperatorContainer.Env, util.HypershiftEnvVarImageAgentCapiProvider) {
-				return true, nil
-			}
-		case util.ImageStreamAwsCapiProvider:
-			if v != getContainerEnvVar(hsOperatorContainer.Env, util.HypershiftEnvVarImageAwsCapiProvider) {
-				return true, nil
-			}
-		case util.ImageStreamAwsEncyptionProvider:
-			if v != getContainerEnvVar(hsOperatorContainer.Env, util.HypershiftEnvVarImageAwsEncyptionProvider) {
-				return true, nil
-			}
-		case util.ImageStreamAzureCapiProvider:
-			if v != getContainerEnvVar(hsOperatorContainer.Env, util.HypershiftEnvVarImageAzureCapiProvider) {
-				return true, nil
-			}
-		case util.ImageStreamClusterApi:
-			if v != getContainerEnvVar(hsOperatorContainer.Env, util.HypershiftEnvVarImageClusterApi) {
-				return true, nil
-			}
-		case util.ImageStreamKonnectivity:
-			if v != getContainerEnvVar(hsOperatorContainer.Env, util.HypershiftEnvVarImageKonnectivity) {
-				return true, nil
-			}
-		case util.ImageStreamKubevertCapiProvider:
-			if v != getContainerEnvVar(hsOperatorContainer.Env, util.HypershiftEnvVarImageKubevertCapiProvider) {
-				return true, nil
-			}
-		case util.ImageStreamHypershiftOperator:
-			if v != hsOperatorContainer.Image {
-				return true, nil
-			}
-		}
-	}
-
-	return false, nil
+	c.stopch = nil
 }
 
-func (c *UpgradeController) SetupWithManager(mgr ctrl.Manager) error {
-	filterByCM := func(obj client.Object) bool {
-		if obj.GetName() == util.HypershiftOverrideImagesCM && obj.GetNamespace() == c.addonNamespace {
-			return true
-		}
-
-		return false
+func (c *UpgradeController) installOptionsChanged() bool {
+	// check for changes in AWS S3 bucket secret
+	newBucketSecret := c.getSecretFromHub(util.HypershiftBucketSecretName)
+	if c.secretDataChanged(newBucketSecret, c.bucketSecret, util.HypershiftBucketSecretName) {
+		c.bucketSecret = newBucketSecret // save the new secret for the next cycle of comparison
+		return true
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&corev1.ConfigMap{}).
-		WithEventFilter(predicate.NewPredicateFuncs(filterByCM)).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
-		Complete(c)
+	// check for changes in external DNS secret
+	newExtDnsSecret := c.getSecretFromHub(util.HypershiftExternalDNSSecretName)
+	if c.secretDataChanged(newExtDnsSecret, c.extDnsSecret, util.HypershiftExternalDNSSecretName) {
+		c.extDnsSecret = newExtDnsSecret // save the new secret for the next cycle of comparison
+		return true
+	}
+
+	// check for changes in AWS private link secret
+	newPrivateLinkSecret := c.getSecretFromHub(util.HypershiftPrivateLinkSecretName)
+	if c.secretDataChanged(newPrivateLinkSecret, c.privateLinkSecret, util.HypershiftPrivateLinkSecretName) {
+		c.privateLinkSecret = newPrivateLinkSecret // save the new secret for the next cycle of comparison
+		return true
+	}
+
+	return false
 }
 
-func (c *UpgradeController) getImageOverrideMap() (map[string]string, error) {
+func (c *UpgradeController) getSecretFromHub(secretName string) corev1.Secret {
+	secretKey := types.NamespacedName{Name: secretName, Namespace: c.clusterName}
+	newSecret := &corev1.Secret{}
+	if err := c.hubClient.Get(c.ctx, secretKey, newSecret); err != nil && !errors.IsNotFound(err) {
+		c.log.Error(err, "failed to get secret from the hub: ")
+	}
+	return *newSecret
+}
+
+func (c *UpgradeController) secretDataChanged(oldSecret, newSecret corev1.Secret, secretName string) bool {
+	if !reflect.DeepEqual(oldSecret.Data, newSecret.Data) { // compare only the secret data
+		c.log.Info(fmt.Sprintf("secret(%s) has changed", secretName))
+		return true
+	}
+	return false
+}
+
+func (c *UpgradeController) upgradeImageCheck() bool {
+	// Get the image override configmap from the hub and compare it to the controller's cached image override configmap
+	newImageOverrideConfigmap := c.getImageOverrideMapFromHub()
+
+	// If changed, we want to re-install the operator
+	if !reflect.DeepEqual(c.imageOverrideConfigmap.Data, newImageOverrideConfigmap.Data) {
+		c.log.Info(fmt.Sprintf("the image override configmap(%s) has changed", util.HypershiftOverrideImagesCM))
+		c.imageOverrideConfigmap = newImageOverrideConfigmap // save the new configmap for the next cycle of comparison
+		return true
+	}
+
+	return false
+}
+
+func (c *UpgradeController) getImageOverrideMapFromHub() corev1.ConfigMap {
 	overrideImagesCm := &corev1.ConfigMap{}
-	overrideImagesCmKey := types.NamespacedName{Name: util.HypershiftOverrideImagesCM, Namespace: c.addonNamespace}
-	if err := c.spokeUncachedClient.Get(context.TODO(), overrideImagesCmKey, overrideImagesCm); err != nil {
-		return nil, err
+	overrideImagesCmKey := types.NamespacedName{Name: util.HypershiftOverrideImagesCM, Namespace: c.clusterName}
+	if err := c.hubClient.Get(context.TODO(), overrideImagesCmKey, overrideImagesCm); err != nil && !errors.IsNotFound(err) {
+		c.log.Error(err, "failed to get configmap from the hub: ")
 	}
-
-	return overrideImagesCm.Data, nil
-}
-
-func getContainerEnvVar(envVars []corev1.EnvVar, imageName string) string {
-	for _, ev := range envVars {
-		if ev.Name == imageName {
-			return ev.Value
-		}
-	}
-	return ""
+	return *overrideImagesCm
 }

--- a/pkg/manager/manifests/permission/role.yaml
+++ b/pkg/manager/manifests/permission/role.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .ClusterName }}
 rules:
   - apiGroups: [""]
-    resources: ["secrets"]
+    resources: ["secrets", "configmaps"]
     verbs: ["get", "list", "watch", "create", "delete"]
   - apiGroups: ["addon.open-cluster-management.io"]
     resources: ["managedclusteraddons"]

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -34,15 +34,6 @@ const (
 	HypershiftHostingNamespaceLabel = "hypershiftdeployments.cluster.open-cluster-management.io/hosting-namespace"
 	HypershiftAddonAnnotationKey    = "hypershift.open-cluster-management.io/createBy"
 
-	// Hypershift Operator Deployment env vars for images
-	HypershiftEnvVarImageAwsCapiProvider      = "IMAGE_AWS_CAPI_PROVIDER"
-	HypershiftEnvVarImageAzureCapiProvider    = "IMAGE_AZURE_CAPI_PROVIDER"
-	HypershiftEnvVarImageKubevertCapiProvider = "IMAGE_KUBEVIRT_CAPI_PROVIDER"
-	HypershiftEnvVarImageKonnectivity         = "IMAGE_KONNECTIVITY"
-	HypershiftEnvVarImageAwsEncyptionProvider = "IMAGE_AWS_ENCRYPTION_PROVIDER"
-	HypershiftEnvVarImageClusterApi           = "IMAGE_CLUSTER_API"
-	HypershiftEnvVarImageAgentCapiProvider    = "IMAGE_AGENT_CAPI_PROVIDER"
-
 	// ImageStream image names
 	ImageStreamAwsCapiProvider      = "cluster-api-provider-aws"
 	ImageStreamAzureCapiProvider    = "cluster-api-provider-azure"


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Detect changes in the hypershift operator installation options such as S3 bucket secret, external DNS secret, private link secret and image override configmap and re-install the hypershift operator on the hosting cluster if change is detected.
* To check for changes, connect to the hub to compare secrets and configmap in the hosting cluster namespace
* Check every 2 minutes

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  When users need to rotate/update the secrets or have a new set of hypershift operator images, there is currently no easy way to trigger the hypershift operator re-installation from the hub.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-1824

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
