### PR TITLE
Add support for the ManagedCluster-name annotation,

### DIFF
--- a/docs/provision_hosted_cluster_on_mce_local_cluster.md
+++ b/docs/provision_hosted_cluster_on_mce_local_cluster.md
@@ -207,8 +207,8 @@ Note: This command will also perform what `hypershift create infra` and `hypersh
 7. Edit the `hosted-cluster-cr-render.yaml` above by adding this annotation to the HostedCluster CR:
 
 ```yaml
-        annotations:
-                cluster.open-cluster-management.io/hypershiftdeployment: default/local-cluster
+  annotations:
+    cluster.open-cluster-management.io/managedcluster-name: CLUSTER_NAME
 ```
 
 8. Now we can apply the CR to the hub:
@@ -231,15 +231,15 @@ metadata:
 labels:    
   cloud: auto-detect    
   cluster.open-cluster-management.io/clusterset: default    
-  name: $INFRA_ID    
+  name: $CLUSTER_NAME   
   vendor: OpenShift  
-name: $INFRA_ID
+name: $CLUSTER_NAME
 spec:  
   hubAcceptsClient: true  
   leaseDurationSeconds: 60
 EOF
 ```
-Note: the name listed here will be the infra-id of your hosted cluster.  If you want to use a `ManagedCluster` name other than `$INFRA_ID`, use the name you want, and include the following annotation on the HostedCluster `cluster.open-cluster-management.io/managedcluster-name: $MANAGED_CLUSTER_NAME`
+Note: the name listed here will be the CLUSTER_NAME of your hosted cluster.  The name provided in the `HostedCluster` annotation `cluster.open-cluster-management.io/managedcluster-name` must match the name given to the `ManagedCluster` resource.
 
 10. Check the status of your hosted cluster via:
 

--- a/docs/provision_hosted_cluster_on_mce_local_cluster.md
+++ b/docs/provision_hosted_cluster_on_mce_local_cluster.md
@@ -22,21 +22,21 @@ You must have the following prerequisites to configure a hosting service cluster
 
 - MCE has at least one managed OCP cluster. We will make this OCP managed cluster a hypershift management cluster. In this example, we will use the MCE hub cluster as the hypershift management cluster. This requires importing the hub cluster as an OCP managed cluster called `local-cluster`:
 
-```bash
-$ oc apply -f - <<EOF
-apiVersion: cluster.open-cluster-management.io/v1
-kind: ManagedCluster
-metadata:
-  labels:
-    local-cluster: "true"
-    cloud: auto-detect
-    vendor: auto-detect
-  name: local-cluster
-spec:
-  hubAcceptsClient: true
-  leaseDurationSeconds: 60
-EOF
-```
+  ```bash
+  $ oc apply -f - <<EOF
+  apiVersion: cluster.open-cluster-management.io/v1
+  kind: ManagedCluster
+  metadata:
+    labels:
+      local-cluster: "true"
+      cloud: auto-detect
+      vendor: auto-detect
+    name: local-cluster
+  spec:
+    hubAcceptsClient: true
+    leaseDurationSeconds: 60
+  EOF
+  ```
 
 ### Configuring the hosting service cluster
 
@@ -81,33 +81,33 @@ $ oc create secret generic hypershift-operator-external-dns-credentials --from-l
 
 Add the special label to the `hypershift-operator-external-dns-credentials` secret so that the secret is backed up for disaster recovery.
 
-```bash
-$ oc label secret hypershift-operator-external-dns-credentials -n local-cluster cluster.open-cluster-management.io/backup=true
-```
+  ```bash
+  $ oc label secret hypershift-operator-external-dns-credentials -n local-cluster cluster.open-cluster-management.io/backup=true
+  ```
 
 ### Enable on a HostedCluster
 
 1. Install the HyperShift add-on. The cluster that hosts the HyperShift operator is the management cluster. This step uses the `ManagedClusterAddon` hypershift-addon to install the HyperShift operator on a managed cluster. The namespace will be the managed cluster on which you want to install the HyperShift operator on. In this case, we will use the MCE hub cluster, so we'll set `local-cluster` for this value:
   
-```bash
-$ oc apply -f - <<EOF
-apiVersion: addon.open-cluster-management.io/v1alpha1
-kind: ManagedClusterAddOn
-metadata:
-  name: hypershift-addon
-  namespace: local-cluster
-spec:
-  installNamespace: open-cluster-management-agent-addon
-EOF
-```
+    ```bash
+    $ oc apply -f - <<EOF
+    apiVersion: addon.open-cluster-management.io/v1alpha1
+    kind: ManagedClusterAddOn
+    metadata:
+      name: hypershift-addon
+      namespace: local-cluster
+    spec:
+      installNamespace: open-cluster-management-agent-addon
+    EOF
+    ```
 
 2. Confirm that the `hypershift-addon` is installed by running the following command:
   
-```bash
-$ oc get managedclusteraddons -n local-cluster hypershift-addon
-NAME               AVAILABLE   DEGRADED   PROGRESSING
-hypershift-addon   True
-```
+    ```bash
+    $ oc get managedclusteraddons -n local-cluster hypershift-addon
+    NAME               AVAILABLE   DEGRADED   PROGRESSING
+    hypershift-addon   True
+    ```
 
 Your HyperShift add-on is installed and the management cluster is available to manage HyperShift hosted clusters.
 
@@ -117,142 +117,147 @@ After installing the HyperShift operator and enabling an existing cluster as a h
 
 1. Set the following environment variables
 
-```bash
-export REGION=us-east-1
-export CLUSTER_NAME=clc-dhu-hs1
-export INFRA_ID=clc-dhu-hs1
-export BASE_DOMAIN=dev09.red-chesterfield.com
-export AWS_CREDS=$HOME/dhu-aws
-export PULL_SECRET=/Users/dhuynh/dhu-pull-secret.txt
-export BUCKET_NAME=acmqe-hypershift
-export BUCKET_REGION=us-east-1
-export INFRA_OUTPUT_FILE=$HOME/hostedcluster_infra.json
-export IAM_OUTPUT_FILE=$HOME/hostedcluster_iam.json
-```
-Note: in order for the cluster to show correctly in the MCE console UI, it is recommended to keep the `CLUSTER_NAME` and `INFRA_ID` the same.
+    ```bash
+    export REGION=us-east-1
+    export CLUSTER_NAME=clc-dhu-hs1
+    export INFRA_ID=clc-dhu-hs1
+    export BASE_DOMAIN=dev09.red-chesterfield.com
+    export AWS_CREDS=$HOME/dhu-aws
+    export PULL_SECRET=/Users/dhuynh/dhu-pull-secret.txt
+    export BUCKET_NAME=acmqe-hypershift
+    export BUCKET_REGION=us-east-1
+    export INFRA_OUTPUT_FILE=$HOME/hostedcluster_infra.json
+    export IAM_OUTPUT_FILE=$HOME/hostedcluster_iam.json
+    ```
+    <b>Note:</b> <i>in order for the cluster to show correctly in the MCE console UI, it is recommended to keep the `CLUSTER_NAME` and `INFRA_ID` the same.</i>
 
 2. Ensure you are logged into your hub cluster.
 
 3. If you do not want to create the infrastructure and IAM pieces separately, skip to step 6. Otherwise run the following command to create the infrastructure first:
 
-```bash
-$ hypershift create infra aws --name $CLUSTER_NAME \
-    --aws-creds $AWS_CREDS \
-    --base-domain $BASE_DOMAIN \
-    --infra-id $CLUSTER_NAME \
-    --region $REGION \
-    --output-file $INFRA_OUTPUT_FILE
-```
+    ```bash
+    $ hypershift create infra aws --name $CLUSTER_NAME \
+        --aws-creds $AWS_CREDS \
+        --base-domain $BASE_DOMAIN \
+        --infra-id $CLUSTER_NAME \
+        --region $REGION \
+        --output-file $INFRA_OUTPUT_FILE
+    ```
 
 4. In order to create the related IAM pieces, we'll need some info from the infra output.
 
-```bash
-$ cat $INFRA_OUTPUT_FILE                                                                                          
-{
-  "region": "us-east-1",
-  "zone": "",
-  "infraID": "clc-dhu-hs1",
-  "machineCIDR": "10.0.0.0/16",
-  "vpcID": "vpc-07541ba034d5a26a1",
-  "zones": [
+    ```bash
+    $ cat $INFRA_OUTPUT_FILE                                                                                          
     {
-      "name": "us-east-1a",
-      "subnetID": "subnet-0e17ee93963c8bf34"
+      "region": "us-east-1",
+      "zone": "",
+      "infraID": "clc-dhu-hs1",
+      "machineCIDR": "10.0.0.0/16",
+      "vpcID": "vpc-07541ba034d5a26a1",
+      "zones": [
+        {
+          "name": "us-east-1a",
+          "subnetID": "subnet-0e17ee93963c8bf34"
+        }
+      ],
+      "securityGroupID": "sg-0da668fbe75efeb43",
+      "Name": "clc-dhu-hs1",
+      "baseDomain": "dev09.red-chesterfield.com",
+      "publicZoneID": "Z00953301HRDK0M0YKQGE",
+      "privateZoneID": "Z02815081BZYZVASX5HII",
+      "localZoneID": "Z01446842N9Z8MWQL967F",
+      "proxyAddr": ""
     }
-  ],
-  "securityGroupID": "sg-0da668fbe75efeb43",
-  "Name": "clc-dhu-hs1",
-  "baseDomain": "dev09.red-chesterfield.com",
-  "publicZoneID": "Z00953301HRDK0M0YKQGE",
-  "privateZoneID": "Z02815081BZYZVASX5HII",
-  "localZoneID": "Z01446842N9Z8MWQL967F",
-  "proxyAddr": ""
-}
-```
+    ```
 Specically, we'll need the `publicZoneID`, `privateZoneID`, and `localZoneID`
 
 5. Create the IAM:
 
-```bash
-$ hypershift create iam aws --infra-id $CLUSTER_NAME \
-    --aws-creds $AWS_CREDS \
-    --oidc-storage-provider-s3-bucket-name $BUCKET_NAME \
-    --oidc-storage-provider-s3-region $BUCKET_REGION \
-    --region $REGION \
-    --public-zone-id Z00953301HRDK0M0YKQGE \
-    --private-zone-id Z02815081BZYZVASX5HII \
-    --local-zone-id Z01446842N9Z8MWQL967F \
-    --output-file $IAM_OUTPUT_FILE
-```
+    ```bash
+    $ hypershift create iam aws --infra-id $CLUSTER_NAME \
+        --aws-creds $AWS_CREDS \
+        --oidc-storage-provider-s3-bucket-name $BUCKET_NAME \
+        --oidc-storage-provider-s3-region $BUCKET_REGION \
+        --region $REGION \
+        --public-zone-id Z00953301HRDK0M0YKQGE \
+        --private-zone-id Z02815081BZYZVASX5HII \
+        --local-zone-id Z01446842N9Z8MWQL967F \
+        --output-file $IAM_OUTPUT_FILE
+    ```
 
 6. We can use the `hypershift create cluster aws` command to create our hosted cluster. If you created the infrastructure and IAM pieces separately, we can specify them as arguments via `--infra-json` and `--iam-json`:
 
-```bash
-$ hypershift create cluster aws \
-    --name $CLUSTER_NAME \
-    --infra-id $INFRA_ID \
-    --infra-json $INFRA_OUTPUT_FILE \
-    --iam-json $IAM_OUTPUT_FILE \
-    --aws-creds $AWS_CREDS \
-    --pull-secret $PULL_SECRET \
-    --region $REGION \
-    --generate-ssh \
-    --node-pool-replicas 3 \
-    --namespace local-cluster \
-    --render > hosted-cluster-cr-render.yaml
-```
+    ```bash
+    $ hypershift create cluster aws \
+        --name $CLUSTER_NAME \
+        --infra-id $INFRA_ID \
+        --infra-json $INFRA_OUTPUT_FILE \
+        --iam-json $IAM_OUTPUT_FILE \
+        --aws-creds $AWS_CREDS \
+        --pull-secret $PULL_SECRET \
+        --region $REGION \
+        --generate-ssh \
+        --node-pool-replicas 3 \
+        --namespace local-cluster \
+        --render > hosted-cluster-cr-render.yaml
+    ```
 
 Note: This command will also perform what `hypershift create infra` and `hypershift create iam` does if those fields are not specified, however we'll also need to provide the required arguments for those portions (such as the S3 bucket name)
 
 7. Edit the `hosted-cluster-cr-render.yaml` above by adding this annotation to the HostedCluster CR:
 
-```yaml
-  annotations:
-    cluster.open-cluster-management.io/managedcluster-name: CLUSTER_NAME
-```
+    ```yaml
+      annotations:
+        cluster.open-cluster-management.io/managedcluster-name: CLUSTER_NAME
+    ```
 If not included, the name used when importing the cluster is the `InfraID` value.
 
 8. Now we can apply the CR to the hub:
 
-```bash
-$ oc apply -f hosted-cluster-cr-render.yaml
-```
+    ```bash
+    $ oc apply -f hosted-cluster-cr-render.yaml
+    ```
 
 9. In order to complete the import process, we also need to create the managed cluster resource:
+    ## How to name your ManagedCluster
+    * The CLUSTER_NAME listed below will be the registred name of your hosted cluster in ACM/MCE.  
+    * When the name is provided in the `HostedCluster` annotation `cluster.open-cluster-management.io/managedcluster-name`, it must match CLUSTER_NAME when creating the `ManagedCluster` resource.
+    * When the annotation is not present, the CLUSTER_NAME for the `ManagedCluster` must be the `InfraID` of the `HostedCluster`.
+    * If the annotation and `ManagedCluster` name do not match, the console will display the cluster as `Pending import`, and it can not be used by ACM/MCE. The same state will occur when the annotation is not present and the `ManagedCluster` name does not equal the `HostedCluster` Infra-ID value.
+    
+    ```bash
+    $ cat <<EOF | oc apply -f -
+    apiVersion: cluster.open-cluster-management.io/v1
+    kind: ManagedCluster
+    metadata:  
+      annotations:    
+        import.open-cluster-management.io/hosting-cluster-name: local-cluster    
+        import.open-cluster-management.io/klusterlet-deploy-mode: Hosted
+        open-cluster-management/created-via: other  
+    labels:    
+      cloud: auto-detect    
+      cluster.open-cluster-management.io/clusterset: default    
+      name: $CLUSTER_NAME   
+      vendor: OpenShift  
+    name: $CLUSTER_NAME
+    spec:  
+      hubAcceptsClient: true  
+      leaseDurationSeconds: 60
+    EOF
+    ```
 
-```bash
-$ cat <<EOF | oc apply -f -
-apiVersion: cluster.open-cluster-management.io/v1
-kind: ManagedCluster
-metadata:  
-  annotations:    
-    import.open-cluster-management.io/hosting-cluster-name: local-cluster    
-    import.open-cluster-management.io/klusterlet-deploy-mode: Hosted
-    open-cluster-management/created-via: other  
-labels:    
-  cloud: auto-detect    
-  cluster.open-cluster-management.io/clusterset: default    
-  name: $CLUSTER_NAME   
-  vendor: OpenShift  
-name: $CLUSTER_NAME
-spec:  
-  hubAcceptsClient: true  
-  leaseDurationSeconds: 60
-EOF
-```
-Note: the name listed here will be the registred name of your hosted cluster in ACM/MCE.  The name provided in the `HostedCluster` annotation `cluster.open-cluster-management.io/managedcluster-name` must match the name given to the `ManagedCluster` resource. If the annotation is not present, the `ManagedCluster.Name` must be the `InfraID` of the `HostedCluster`. If the annotation and `ManagedCluster.Name` do not match, the console will display the cluster as `Pending import`, and can not be utilized by ACM/MCE.
 
 10. Check the status of your hosted cluster via:
 
-```bash
-$ oc get hostedclusters -n local-cluster
-```
+    ```bash
+    $ oc get hostedclusters -n local-cluster
+    ```
 
 11.  After the hosted cluster is created, it will be imported to the hub automatically, you can check it with:
   
-```bash
-$ oc get managedcluster $INFRA_ID
-```
+      ```bash
+     $ oc get managedcluster $INFRA_ID
+     ```
 
 Your hosted cluster is now created and imported to MCE/ACM, which should also be visible from the MCE console.
 

--- a/docs/provision_hosted_cluster_on_mce_local_cluster.md
+++ b/docs/provision_hosted_cluster_on_mce_local_cluster.md
@@ -210,6 +210,7 @@ Note: This command will also perform what `hypershift create infra` and `hypersh
   annotations:
     cluster.open-cluster-management.io/managedcluster-name: CLUSTER_NAME
 ```
+If not included, the name used when importing the cluster is the `InfraID` value.
 
 8. Now we can apply the CR to the hub:
 
@@ -239,7 +240,7 @@ spec:
   leaseDurationSeconds: 60
 EOF
 ```
-Note: the name listed here will be the CLUSTER_NAME of your hosted cluster.  The name provided in the `HostedCluster` annotation `cluster.open-cluster-management.io/managedcluster-name` must match the name given to the `ManagedCluster` resource.
+Note: the name listed here will be the registred name of your hosted cluster in ACM/MCE.  The name provided in the `HostedCluster` annotation `cluster.open-cluster-management.io/managedcluster-name` must match the name given to the `ManagedCluster` resource. If the annotation is not present, the `ManagedCluster.Name` must be the `InfraID` of the `HostedCluster`. If the annotation and `ManagedCluster.Name` do not match, the console will display the cluster as `Pending import`, and can not be utilized by ACM/MCE.
 
 10. Check the status of your hosted cluster via:
 

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -110,7 +110,7 @@ func getHostedCluster(hcNN types.NamespacedName) *hyperv1alpha1.HostedCluster {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        hcNN.Name,
 			Namespace:   hcNN.Namespace,
-			Annotations: map[string]string{util.HypershiftDeploymentAnnoKey: "test-hd1"},
+			Annotations: map[string]string{util.ManagedClusterAnnoKey: "infra-abcdef"},
 		},
 		Spec: hyperv1alpha1.HostedClusterSpec{
 			Platform: hyperv1alpha1.PlatformSpec{

--- a/pkg/install/hypershift_test.go
+++ b/pkg/install/hypershift_test.go
@@ -877,7 +877,7 @@ func getHostedCluster(hcNN types.NamespacedName) *hyperv1alpha1.HostedCluster {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        hcNN.Name,
 			Namespace:   hcNN.Namespace,
-			Annotations: map[string]string{util.HypershiftDeploymentAnnoKey: "test-hd1"},
+			Annotations: map[string]string{util.ManagedClusterAnnoKey: "infra-abcdef"},
 		},
 		Spec: hyperv1alpha1.HostedClusterSpec{
 			Platform: hyperv1alpha1.PlatformSpec{


### PR DESCRIPTION
Signed-off-by: Joshua Packer <jpacker@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* When importing HostedClusters.
    * Currently you need the cluster.open-cluster-management.io/hypershiftdeployment, annotation (deprecated)
    * Then if you want to use a different cluster name you need the cluster.open-cluster-management.io/managedcluster-name
    * Modified the Addon controller to always produce an import secret regardless of the annotations.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  hypershiftdeployment has been deprecated and removed, so it shouldn't be referenced in the flow

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-1922

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?       github.com/stolostron/hypershift-addon-operator/cmd     [no test files]
ok      github.com/stolostron/hypershift-addon-operator/pkg/agent       9.101s  coverage: 61.4% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/install     118.468s        coverage: 85.3% of statements
?       github.com/stolostron/hypershift-addon-operator/pkg/manager     [no test files]
?       github.com/stolostron/hypershift-addon-operator/pkg/util        [no test files]
```
