### PR TITLE
fix ACM-1923 so that addon restart does not reinstall the hypershift …

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -158,7 +158,7 @@ func (o *AgentOptions) runControllerManager(ctx context.Context) error {
 		o.HypershiftOperatorImage, o.PullSecretName, o.WithOverride, ctx)
 
 	// retry 3 times, in case something wrong with creating the hypershift install job
-	if err := uCtrl.RunHypershiftInstall(ctx, true); err != nil {
+	if err := uCtrl.RunHypershiftOperatorInstallOnAgentStartup(ctx); err != nil {
 		log.Error(err, "failed to install hypershift Operator")
 		return err
 	}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -158,7 +158,7 @@ func (o *AgentOptions) runControllerManager(ctx context.Context) error {
 		o.HypershiftOperatorImage, o.PullSecretName, o.WithOverride, ctx)
 
 	// retry 3 times, in case something wrong with creating the hypershift install job
-	if err := uCtrl.RunHypershiftInstall(ctx); err != nil {
+	if err := uCtrl.RunHypershiftInstall(ctx, true); err != nil {
 		log.Error(err, "failed to install hypershift Operator")
 		return err
 	}

--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -156,7 +156,7 @@ func (c *UpgradeController) RunHypershiftOperatorInstallOnAgentStartup(ctx conte
 
 func (c *UpgradeController) RunHypershiftOperatorUpdate(ctx context.Context) error {
 	c.log.Info("enter RunHypershiftOperatorUpdate")
-	defer c.log.Info("exit RunHypershiftOperatoRunHypershiftOperatorUpdateInstallOnAgentStartup")
+	defer c.log.Info("exit RunHypershiftOperatorUpdate")
 
 	return c.runHypershiftInstall(ctx, false)
 }

--- a/pkg/install/hypershift_test.go
+++ b/pkg/install/hypershift_test.go
@@ -544,7 +544,7 @@ func TestRunHypershiftInstall(t *testing.T) {
 
 	// Install hypershift job failed
 	go updateHsInstallJobToFailed(ctx, aCtrl.spokeUncachedClient, aCtrl.addonNamespace)
-	err = aCtrl.RunHypershiftInstall(ctx, false)
+	err = aCtrl.RunHypershiftOperatorUpdate(ctx)
 	assert.NotNil(t, err, "is nil if install HyperShift is sucessful")
 	assert.Equal(t, "install HyperShift job failed", err.Error())
 	if err := deleteAllInstallJobs(ctx, aCtrl.spokeUncachedClient, aCtrl.addonNamespace); err != nil {
@@ -1116,14 +1116,14 @@ func TestSkipHypershiftInstallWithNoChange(t *testing.T) {
 		return err == nil
 	}, 10*time.Second, 1*time.Second, "The test operator deployment was created successfully")
 
-	// Run the hypershift operator installation code controllerStartup=true to simulate addon agent startup
-	err = aCtrl.RunHypershiftInstall(ctx, true)
+	// Run the hypershift operator installation to simulate addon agent startup
+	err = aCtrl.RunHypershiftOperatorInstallOnAgentStartup(ctx)
 	assert.Nil(t, err, "there was no error in calling HyperShift installation")
 	// All images in the hypershift operator deployment are the same as what is in the image override configmap
 	// All secrets data from the hub is the same as those saved locally on the agent side
 	// expect no install job
 	noInstallJob, err := noInstallJobs(ctx, aCtrl.spokeUncachedClient, aCtrl.addonNamespace)
-	assert.Nil(t, err, "there should be no error in RunHypershiftInstall")
+	assert.Nil(t, err, "there should be no error in RunHypershiftOperatorInstallOnAgentStartup")
 	assert.True(t, noInstallJob, "there should be no hypershift installation job")
 }
 
@@ -1193,7 +1193,7 @@ func getHostedCluster(hcNN types.NamespacedName) *hyperv1alpha1.HostedCluster {
 
 func installHyperShiftOperator(t *testing.T, ctx context.Context, aCtrl *UpgradeController, deleteJobs bool) error {
 	go updateHsInstallJobToSucceeded(ctx, aCtrl.spokeUncachedClient, aCtrl.addonNamespace)
-	err := aCtrl.RunHypershiftInstall(ctx, false)
+	err := aCtrl.RunHypershiftOperatorUpdate(ctx)
 
 	if deleteJobs {
 		if err := deleteAllInstallJobs(ctx, aCtrl.spokeUncachedClient, aCtrl.addonNamespace); err != nil {

--- a/pkg/install/hypershift_test.go
+++ b/pkg/install/hypershift_test.go
@@ -696,7 +696,6 @@ func TestRunHypershiftInstallPrivateLinkExternalDNS(t *testing.T) {
 		operatorImage:             "my-test-image",
 		clusterName:               "cluster1",
 		pullSecret:                "pull-secret",
-		withOverride:              true,
 		hypershiftInstallExecutor: &HypershiftTestCliExecutor{},
 	}
 
@@ -889,6 +888,7 @@ func TestSkipHypershiftInstallWithNoChange(t *testing.T) {
 		operatorImage:             "my-test-image",
 		clusterName:               "cluster1",
 		pullSecret:                "pull-secret",
+		withOverride:              true,
 		hypershiftInstallExecutor: &HypershiftTestCliExecutor{},
 	}
 

--- a/pkg/install/upgrade.go
+++ b/pkg/install/upgrade.go
@@ -67,7 +67,7 @@ func (c *UpgradeController) Start() {
 		if c.installOptionsChanged() || c.upgradeImageCheck() {
 			c.reinstallNeeded = true
 			c.log.Info("change has been detected to require hypershift operator re-installation")
-			if err := c.RunHypershiftInstall(c.ctx, false); err != nil {
+			if err := c.RunHypershiftOperatorUpdate(c.ctx); err != nil {
 				c.log.Error(err, "failed to install hypershift operator")
 			}
 		}

--- a/pkg/install/upgrade.go
+++ b/pkg/install/upgrade.go
@@ -67,7 +67,7 @@ func (c *UpgradeController) Start() {
 		if c.installOptionsChanged() || c.upgradeImageCheck() {
 			c.reinstallNeeded = true
 			c.log.Info("change has been detected to require hypershift operator re-installation")
-			if err := c.RunHypershiftInstall(c.ctx); err != nil {
+			if err := c.RunHypershiftInstall(c.ctx, false); err != nil {
 				c.log.Error(err, "failed to install hypershift operator")
 			}
 		}

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -55,6 +55,15 @@ const (
 	HypershiftInstallJobServiceAccount = "hypershift-addon-agent-sa"
 	HypershiftInstallJobVolume         = "hypershift-imagestream-volume"
 	HypershiftInstallJobImageStream    = "hypershift-install-job-imagestream"
+
+	// Hypershift Operator Deployment env vars for images
+	HypershiftEnvVarImageAwsCapiProvider      = "IMAGE_AWS_CAPI_PROVIDER"
+	HypershiftEnvVarImageAzureCapiProvider    = "IMAGE_AZURE_CAPI_PROVIDER"
+	HypershiftEnvVarImageKubevertCapiProvider = "IMAGE_KUBEVIRT_CAPI_PROVIDER"
+	HypershiftEnvVarImageKonnectivity         = "IMAGE_KONNECTIVITY"
+	HypershiftEnvVarImageAwsEncyptionProvider = "IMAGE_AWS_ENCRYPTION_PROVIDER"
+	HypershiftEnvVarImageClusterApi           = "IMAGE_CLUSTER_API"
+	HypershiftEnvVarImageAgentCapiProvider    = "IMAGE_AGENT_CAPI_PROVIDER"
 )
 
 // GenerateClientConfigFromSecret generate a client config from a given secret


### PR DESCRIPTION
…operator unneccessarily

Signed-off-by: Roke Jung <roke@redhat.com>

# Description of the change(s):
* When the hypershift addon pod restarts, do not re-install the hypershift operator if there is no change in hypershift operator images or any of the secrets that are used as input to the hypershift operator installation.

## Why do we need this PR:
*  Prevent unnecessary operator reinstallation which might cause a brief disruption in hosted cluster provisioning. 

## Issue reference: 
* https://issues.redhat.com/browse/ACM-1923

## Test API/Unit - Success

Tested that:

- Initial addon startup installs the operator
- Addon pod restart does not re-install the operator
- Image override still works
- Secret change detection and reinstallation still works
- Addon pod restart with image stream changes reinstalls the operator (MCE upgrade case)
- Deleting the addon uninstalls the operator