### PR TITLE
Add new addon status controller to check and set status based on Hypershift deployments statuses

### DIFF
--- a/hack/crds/managedclusteraddons.crd.yaml
+++ b/hack/crds/managedclusteraddons.crd.yaml
@@ -1,0 +1,246 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: managedclusteraddons.addon.open-cluster-management.io
+spec:
+  group: addon.open-cluster-management.io
+  names:
+    kind: ManagedClusterAddOn
+    listKind: ManagedClusterAddOnList
+    plural: managedclusteraddons
+    singular: managedclusteraddon
+  scope: Namespaced
+  preserveUnknownFields: false
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Available")].status
+          name: Available
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Degraded")].status
+          name: Degraded
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Progressing")].status
+          name: Progressing
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ManagedClusterAddOn is the Custom Resource object which holds the current state of an add-on. This object is used by add-on operators to convey their state. This resource should be created in the ManagedCluster namespace.
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds configuration that could apply to any operator.
+              type: object
+              properties:
+                configs:
+                  description: configs is a list of add-on configurations. In scenario where the current add-on has its own configurations. An empty list means there are no defautl configurations for add-on. The default is an empty list
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - resource
+                    properties:
+                      group:
+                        description: group of the add-on configuration.
+                        type: string
+                      name:
+                        description: name of the add-on configuration.
+                        type: string
+                        minLength: 1
+                      namespace:
+                        description: namespace of the add-on configuration. If this field is not set, the configuration is in the cluster scope.
+                        type: string
+                      resource:
+                        description: resource of the add-on configuration.
+                        type: string
+                        minLength: 1
+                installNamespace:
+                  description: installNamespace is the namespace on the managed cluster to install the addon agent. If it is not set, open-cluster-management-agent-addon namespace is used to install the addon agent.
+                  type: string
+                  default: open-cluster-management-agent-addon
+                  maxLength: 63
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+            status:
+              description: status holds the information about the state of an operator.  It is consistent with status information across the Kubernetes ecosystem.
+              type: object
+              properties:
+                addOnConfiguration:
+                  description: 'Deprecated: Use configReference instead addOnConfiguration is a reference to configuration information for the add-on. This resource is use to locate the configuration resource for the add-on.'
+                  type: object
+                  properties:
+                    crName:
+                      description: crName is the name of the CR used to configure instances of the managed add-on. This field should be configured if add-on CR have a consistent name across the all of the ManagedCluster instaces.
+                      type: string
+                    crdName:
+                      description: crdName is the name of the CRD used to configure instances of the managed add-on. This field should be configured if the add-on have a CRD that controls the configuration of the add-on.
+                      type: string
+                    lastObservedGeneration:
+                      description: lastObservedGeneration is the observed generation of the custom resource for the configuration of the addon.
+                      type: integer
+                      format: int64
+                addOnMeta:
+                  description: addOnMeta is a reference to the metadata information for the add-on. This should be same as the addOnMeta for the corresponding ClusterManagementAddOn resource.
+                  type: object
+                  properties:
+                    description:
+                      description: description represents the detailed description of the add-on.
+                      type: string
+                    displayName:
+                      description: displayName represents the name of add-on that will be displayed.
+                      type: string
+                conditions:
+                  description: conditions describe the state of the managed and monitored components for the operator.
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                configReferences:
+                  description: configReferences is a list of current add-on configuration references. This will be overridden by the clustermanagementaddon configuration references.
+                  type: array
+                  items:
+                    description: ConfigReference is a reference to the current add-on configuration. This resource is used to locate the configuration resource for the current add-on.
+                    type: object
+                    required:
+                      - name
+                      - resource
+                    properties:
+                      group:
+                        description: group of the add-on configuration.
+                        type: string
+                      lastObservedGeneration:
+                        description: lastObservedGeneration is the observed generation of the add-on configuration.
+                        type: integer
+                        format: int64
+                      name:
+                        description: name of the add-on configuration.
+                        type: string
+                        minLength: 1
+                      namespace:
+                        description: namespace of the add-on configuration. If this field is not set, the configuration is in the cluster scope.
+                        type: string
+                      resource:
+                        description: resource of the add-on configuration.
+                        type: string
+                        minLength: 1
+                healthCheck:
+                  description: healthCheck indicates how to check the healthiness status of the current addon. It should be set by each addon implementation, by default, the lease mode will be used.
+                  type: object
+                  properties:
+                    mode:
+                      description: mode indicates which mode will be used to check the healthiness status of the addon.
+                      type: string
+                      default: Lease
+                      enum:
+                        - Lease
+                        - Customized
+                registrations:
+                  description: registrations is the conifigurations for the addon agent to register to hub. It should be set by each addon controller on hub to define how the addon agent on managedcluster is registered. With the registration defined, The addon agent can access to kube apiserver with kube style API or other endpoints on hub cluster with client certificate authentication. A csr will be created per registration configuration. If more than one registrationConfig is defined, a csr will be created for each registration configuration. It is not allowed that multiple registrationConfigs have the same signer name. After the csr is approved on the hub cluster, the klusterlet agent will create a secret in the installNamespace for the registrationConfig. If the signerName is "kubernetes.io/kube-apiserver-client", the secret name will be "{addon name}-hub-kubeconfig" whose contents includes key/cert and kubeconfig. Otherwise, the secret name will be "{addon name}-{signer name}-client-cert" whose contents includes key/cert.
+                  type: array
+                  items:
+                    description: RegistrationConfig defines the configuration of the addon agent to register to hub. The Klusterlet agent will create a csr for the addon agent with the registrationConfig.
+                    type: object
+                    properties:
+                      signerName:
+                        description: signerName is the name of signer that addon agent will use to create csr.
+                        type: string
+                        maxLength: 571
+                        minLength: 5
+                      subject:
+                        description: "subject is the user subject of the addon agent to be registered to the hub. If it is not set, the addon agent will have the default subject \"subject\": { \t\"user\": \"system:open-cluster-management:addon:{addonName}:{clusterName}:{agentName}\", \t\"groups: [\"system:open-cluster-management:addon\", \"system:open-cluster-management:addon:{addonName}\", \"system:authenticated\"] }"
+                        type: object
+                        properties:
+                          groups:
+                            description: groups is the user group of the addon agent.
+                            type: array
+                            items:
+                              type: string
+                          organizationUnit:
+                            description: organizationUnit is the ou of the addon agent
+                            type: array
+                            items:
+                              type: string
+                          user:
+                            description: user is the user name of the addon agent.
+                            type: string
+                relatedObjects:
+                  description: 'relatedObjects is a list of objects that are "interesting" or related to this operator. Common uses are: 1. the detailed resource driving the operator 2. operator namespaces 3. operand namespaces 4. related ClusterManagementAddon resource'
+                  type: array
+                  items:
+                    description: ObjectReference contains enough information to let you inspect or modify the referred object.
+                    type: object
+                    required:
+                      - group
+                      - name
+                      - resource
+                    properties:
+                      group:
+                        description: group of the referent.
+                        type: string
+                      name:
+                        description: name of the referent.
+                        type: string
+                      namespace:
+                        description: namespace of the referent.
+                        type: string
+                      resource:
+                        description: resource of the referent.
+                        type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/agent/addon_status_controller.go
+++ b/pkg/agent/addon_status_controller.go
@@ -1,0 +1,183 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/stolostron/hypershift-addon-operator/pkg/util"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+var (
+	operatorDeploymentNsn    = types.NamespacedName{Namespace: util.HypershiftOperatorNamespace, Name: util.HypershiftOperatorName}
+	externalDNSDeploymentNsn = types.NamespacedName{Namespace: util.HypershiftOperatorNamespace, Name: util.HypershiftOperatorExternalDNSName}
+)
+
+// AddonStatusController reconciles Hypershift addon status
+type AddonStatusController struct {
+	spokeClient client.Client
+	hubClient   client.Client
+	log         logr.Logger
+	addonNsn    types.NamespacedName
+	clusterName string
+}
+
+// AddonStatusPredicateFunctions defines which Deployment this controller should watch
+var AddonStatusPredicateFunctions = predicate.Funcs{
+	CreateFunc: func(e event.CreateEvent) bool {
+		deployment := e.Object.(*appsv1.Deployment)
+		return containsHypershiftAddonDeployment(*deployment)
+	},
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		oldDeployment := e.ObjectOld.(*appsv1.Deployment)
+		newDeployment := e.ObjectNew.(*appsv1.Deployment)
+		return containsHypershiftAddonDeployment(*oldDeployment) && containsHypershiftAddonDeployment(*newDeployment)
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		deployment := e.Object.(*appsv1.Deployment)
+		return containsHypershiftAddonDeployment(*deployment)
+	},
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (c *AddonStatusController) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&appsv1.Deployment{}).
+		WithEventFilter(AddonStatusPredicateFunctions).
+		Complete(c)
+}
+
+// Reconcile updates the Hypershift addon status based on the Deployment status.
+func (c *AddonStatusController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	c.log.Info(fmt.Sprintf("reconciling Deployment %s", req))
+	defer c.log.Info(fmt.Sprintf("done reconcile Deployment %s", req))
+
+	checkExtDNS, err := c.shouldCheckExternalDNSDeployment(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	operatorDeployment, err := c.getDeployment(ctx, operatorDeploymentNsn)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	var externalDNSDeployment *appsv1.Deployment
+	if checkExtDNS {
+		externalDNSDeployment, err = c.getDeployment(ctx, externalDNSDeploymentNsn)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// generate addon status condition based on the deployments
+	addonCondition := checkDeployments(checkExtDNS, operatorDeployment, externalDNSDeployment)
+
+	// update the addon status
+	updated, err := c.updateStatus(
+		ctx, updateConditionFn(&addonCondition))
+	if err != nil {
+		c.log.Error(err, "failed to update the addon status")
+		return ctrl.Result{}, err
+	}
+
+	if updated {
+		c.log.Info("updated ManagedClusterAddOnStatus")
+	} else {
+		c.log.V(4).Info("skip updating updated ManagedClusterAddOnStatus")
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (c *AddonStatusController) shouldCheckExternalDNSDeployment(ctx context.Context) (bool, error) {
+	extDNSSecretKey := types.NamespacedName{Name: util.HypershiftExternalDNSSecretName, Namespace: c.clusterName}
+	sExtDNS := &corev1.Secret{}
+	err := c.hubClient.Get(ctx, extDNSSecretKey, sExtDNS)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			c.log.V(4).Info(fmt.Sprintf("external dns secret(%s) was not found", extDNSSecretKey))
+			return false, nil
+		}
+
+		c.log.Error(err, fmt.Sprintf("failed to get the external dns secret(%s)", extDNSSecretKey))
+		return false, err
+	}
+
+	c.log.Info(fmt.Sprintf("found external dns secret(%s)", extDNSSecretKey))
+	return true, nil
+}
+
+func (c *AddonStatusController) getDeployment(ctx context.Context, nsn types.NamespacedName) (
+	*appsv1.Deployment, error) {
+	deployment := &appsv1.Deployment{}
+	err := c.spokeClient.Get(ctx, nsn, deployment)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, err
+		}
+		return nil, nil
+	}
+
+	return deployment, nil
+}
+
+type UpdateStatusFunc func(status *addonv1alpha1.ManagedClusterAddOnStatus)
+
+func (c *AddonStatusController) updateStatus(ctx context.Context, updateFuncs ...UpdateStatusFunc) (
+	bool, error) {
+	updated := false
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		hypershiftAddon := &addonv1alpha1.ManagedClusterAddOn{}
+		err := c.hubClient.Get(ctx, c.addonNsn, hypershiftAddon)
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+
+		if err != nil {
+			return err
+		}
+
+		oldStatus := &hypershiftAddon.Status
+
+		newStatus := oldStatus.DeepCopy()
+		for _, update := range updateFuncs {
+			update(newStatus)
+		}
+
+		if equality.Semantic.DeepEqual(oldStatus, newStatus) {
+			return nil
+		}
+
+		hypershiftAddon.Status = *newStatus
+		err = c.hubClient.Status().Update(ctx, hypershiftAddon, &client.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+
+		updated = err == nil
+
+		return err
+	})
+
+	return updated, err
+}
+
+func updateConditionFn(cond *metav1.Condition) UpdateStatusFunc {
+	return func(oldStatus *addonv1alpha1.ManagedClusterAddOnStatus) {
+		meta.SetStatusCondition(&oldStatus.Conditions, *cond)
+	}
+}

--- a/pkg/agent/addon_status_controller_test.go
+++ b/pkg/agent/addon_status_controller_test.go
@@ -1,0 +1,188 @@
+package agent
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stolostron/hypershift-addon-operator/pkg/util"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+)
+
+var _ = Describe("Hypershift ManagedClusterAddon Status controller", func() {
+	ctx := context.Background()
+	Context("When Hypershift operator deployment is created/updated/deleted", func() {
+		It("Should update Hypershift ManagedClusterAddon Status", func() {
+			By("Creating the hypershift namespace")
+			hypershiftNs := corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: util.HypershiftOperatorNamespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, &hypershiftNs)).Should(Succeed())
+
+			By("Creating the local-cluster ManagedCluster namespace")
+			managedClusterNs := corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: localClusterName,
+				},
+			}
+			Expect(k8sClient.Create(ctx, &managedClusterNs)).Should(Succeed())
+
+			By("Creating the Hypershift ManagedClusterAddon")
+			addon := addonv1alpha1.ManagedClusterAddOn{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: localClusterName,
+					Name:      util.AddonControllerName,
+				},
+			}
+			Expect(k8sClient.Create(ctx, &addon)).Should(Succeed())
+
+			By("Creating the Hypershift operator deployment")
+			operatorDeployment := appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      util.HypershiftOperatorName,
+					Namespace: util.HypershiftOperatorNamespace,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "hypershift"}},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"app": "hypershift"},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "hypershift", Image: "nginx:1.14.2"}}, // fake deployment
+						},
+					},
+				},
+			}
+			operatorDeployment.Spec.Replicas = new(int32)
+			*operatorDeployment.Spec.Replicas = 1
+			Expect(k8sClient.Create(ctx, &operatorDeployment)).Should(Succeed())
+
+			operatorDeployment = appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx,
+				types.NamespacedName{Namespace: util.HypershiftOperatorNamespace, Name: util.HypershiftOperatorName},
+				&operatorDeployment)).Should(Succeed())
+
+			operatorDeployment.Status.AvailableReplicas = 1
+			operatorDeployment.Status.ReadyReplicas = 1
+			operatorDeployment.Status.Replicas = 1
+			Expect(k8sClient.Status().Update(ctx, &operatorDeployment)).Should(Succeed())
+
+			addon = addonv1alpha1.ManagedClusterAddOn{}
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx,
+					types.NamespacedName{Namespace: localClusterName, Name: util.AddonControllerName},
+					&addon); err != nil {
+					return false
+				}
+				if len(addon.Status.Conditions) == 0 {
+					return false
+				}
+				return addon.Status.Conditions[0].Reason == degradedReasonHypershiftDeployed
+			}).Should(BeTrue())
+
+			By("Creating the external dns secret")
+			secret := corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      util.HypershiftExternalDNSSecretName,
+					Namespace: localClusterName,
+				},
+			}
+			Expect(k8sClient.Create(ctx, &secret)).Should(Succeed())
+
+			operatorDeployment.Status.AvailableReplicas = 0
+			operatorDeployment.Status.ReadyReplicas = 0
+			Expect(k8sClient.Status().Update(ctx, &operatorDeployment)).Should(Succeed())
+
+			addon = addonv1alpha1.ManagedClusterAddOn{}
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx,
+					types.NamespacedName{Namespace: localClusterName, Name: util.AddonControllerName},
+					&addon); err != nil {
+					return false
+				}
+				if len(addon.Status.Conditions) == 0 {
+					return false
+				}
+				return addon.Status.Conditions[0].Reason == degradedReasonOperatorNotAllAvailableReplicas+","+degradedReasonExternalDNSNotFound
+			}).Should(BeTrue())
+
+			By("Creating the Hypershift external dns deployment")
+			externalDNSDeployment := appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      util.HypershiftOperatorExternalDNSName,
+					Namespace: util.HypershiftOperatorNamespace,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "hypershift"}},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"app": "hypershift"},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "hypershift", Image: "nginx:1.14.2"}}, // fake deployment
+						},
+					},
+				},
+			}
+			externalDNSDeployment.Spec.Replicas = new(int32)
+			*externalDNSDeployment.Spec.Replicas = 3
+			Expect(k8sClient.Create(ctx, &externalDNSDeployment)).Should(Succeed())
+
+			externalDNSDeployment = appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx,
+				types.NamespacedName{Namespace: util.HypershiftOperatorNamespace, Name: util.HypershiftOperatorExternalDNSName},
+				&externalDNSDeployment)).Should(Succeed())
+
+			externalDNSDeployment.Status.AvailableReplicas = 2
+			externalDNSDeployment.Status.ReadyReplicas = 2
+			externalDNSDeployment.Status.Replicas = 3
+			Expect(k8sClient.Status().Update(ctx, &externalDNSDeployment)).Should(Succeed())
+
+			addon = addonv1alpha1.ManagedClusterAddOn{}
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx,
+					types.NamespacedName{Namespace: localClusterName, Name: util.AddonControllerName},
+					&addon); err != nil {
+					return false
+				}
+				if len(addon.Status.Conditions) == 0 {
+					return false
+				}
+				return addon.Status.Conditions[0].Reason == degradedReasonOperatorNotAllAvailableReplicas+","+degradedReasonExternalDNSNotAllAvailableReplicas
+			}).Should(BeTrue())
+
+			By("Adding finalizers to the Hypershift operator and external dns deployments")
+			operatorDeployment.Finalizers = []string{"hypershift.io/hypershift"}
+			Expect(k8sClient.Update(ctx, &operatorDeployment)).Should(Succeed())
+			externalDNSDeployment.Finalizers = []string{"hypershift.io/hypershift"}
+			Expect(k8sClient.Update(ctx, &externalDNSDeployment)).Should(Succeed())
+
+			By("Deleting the Hypershift operator and external dns deployments")
+
+			Expect(k8sClient.Delete(ctx, &operatorDeployment)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, &externalDNSDeployment)).Should(Succeed())
+
+			addon = addonv1alpha1.ManagedClusterAddOn{}
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx,
+					types.NamespacedName{Namespace: localClusterName, Name: util.AddonControllerName},
+					&addon); err != nil {
+					return false
+				}
+				if len(addon.Status.Conditions) == 0 {
+					return false
+				}
+				return addon.Status.Conditions[0].Reason == degradedReasonOperatorDeleted+","+degradedReasonExternalDNSDeleted
+			}).Should(BeTrue())
+		})
+	})
+})

--- a/pkg/agent/addon_status_helper.go
+++ b/pkg/agent/addon_status_helper.go
@@ -1,0 +1,104 @@
+package agent
+
+import (
+	"fmt"
+
+	"github.com/stolostron/hypershift-addon-operator/pkg/util"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+)
+
+const (
+	degradedReasonHypershiftDeployed                 = "HypershiftDeployed"
+	degradedReasonHypershiftDeployedMessage          = "Hypershift is deployed on managed cluster."
+	degradedReasonOperatorNotFound                   = "OperatorNotFound"
+	degradedReasonOperatorDeleted                    = "OperatorDeleted"
+	degradedReasonOperatorNotAllAvailableReplicas    = "OperatorNotAllAvailableReplicas"
+	degradedReasonExternalDNSNotFound                = "ExternalDNSNotFound"
+	degradedReasonExternalDNSDeleted                 = "ExternalDNSDeleted"
+	degradedReasonExternalDNSNotAllAvailableReplicas = "ExternalDNSNotAllAvailableReplicas"
+)
+
+var (
+	degradedReasonOperatorNotFoundMessage                   = fmt.Sprintf("The %s deployment does not exist", util.HypershiftOperatorName)
+	degradedReasonOperatorDeletedMessage                    = fmt.Sprintf("The %s deployment is being deleted", util.HypershiftOperatorName)
+	degradedReasonOperatorNotAllAvailableReplicasMessage    = fmt.Sprintf("There are no %s replica available", util.HypershiftOperatorName)
+	degradedReasonExternalDNSNotFoundMessage                = fmt.Sprintf("The %s deployment does not exist", util.HypershiftOperatorExternalDNSName)
+	degradedReasonExternalDNSDeletedMessage                 = fmt.Sprintf("The %s deployment is being deleted", util.HypershiftOperatorExternalDNSName)
+	degradedReasonExternalDNSNotAllAvailableReplicasMessage = fmt.Sprintf("There are no %s replica available", util.HypershiftOperatorExternalDNSName)
+)
+
+func containsHypershiftAddonDeployment(deployment appsv1.Deployment) bool {
+	if len(deployment.Name) == 0 || len(deployment.Namespace) == 0 {
+		return false
+	}
+
+	if deployment.Namespace != util.HypershiftOperatorNamespace {
+		return false
+	}
+
+	return deployment.Name == util.HypershiftOperatorName ||
+		deployment.Name == util.HypershiftOperatorExternalDNSName
+}
+
+func checkDeployments(checkExtDNSDeploy bool,
+	operatorDeployment, externalDNSDeployment *appsv1.Deployment) metav1.Condition {
+	reason := ""
+	message := ""
+
+	if operatorDeployment == nil {
+		reason = degradedReasonOperatorNotFound
+		message = degradedReasonOperatorNotFoundMessage
+	} else if !operatorDeployment.GetDeletionTimestamp().IsZero() {
+		reason = degradedReasonOperatorDeleted
+		message = degradedReasonOperatorDeletedMessage
+	} else if operatorDeployment.Status.AvailableReplicas == 0 ||
+		(operatorDeployment.Spec.Replicas != nil && *operatorDeployment.Spec.Replicas != operatorDeployment.Status.AvailableReplicas) {
+		reason = degradedReasonOperatorNotAllAvailableReplicas
+		message = degradedReasonOperatorNotAllAvailableReplicasMessage
+	}
+
+	if checkExtDNSDeploy {
+		isReasonPopulated := len(reason) > 0
+		if externalDNSDeployment == nil {
+			if isReasonPopulated {
+				reason += ","
+				message += "\n"
+			}
+			reason += degradedReasonExternalDNSNotFound
+			message += degradedReasonExternalDNSNotFoundMessage
+		} else if !externalDNSDeployment.GetDeletionTimestamp().IsZero() {
+			if isReasonPopulated {
+				reason += ","
+				message += "\n"
+			}
+			reason += degradedReasonExternalDNSDeleted
+			message += degradedReasonExternalDNSDeletedMessage
+		} else if externalDNSDeployment.Status.AvailableReplicas == 0 ||
+			(externalDNSDeployment.Spec.Replicas != nil && *externalDNSDeployment.Spec.Replicas != externalDNSDeployment.Status.AvailableReplicas) {
+			if isReasonPopulated {
+				reason += ","
+				message += "\n"
+			}
+			reason += degradedReasonExternalDNSNotAllAvailableReplicas
+			message += degradedReasonExternalDNSNotAllAvailableReplicasMessage
+		}
+	}
+
+	if len(reason) != 0 {
+		return metav1.Condition{
+			Type:    addonv1alpha1.ManagedClusterAddOnConditionDegraded,
+			Status:  metav1.ConditionTrue,
+			Reason:  reason,
+			Message: message,
+		}
+	}
+
+	return metav1.Condition{
+		Type:    addonv1alpha1.ManagedClusterAddOnConditionDegraded,
+		Status:  metav1.ConditionFalse,
+		Reason:  degradedReasonHypershiftDeployed,
+		Message: degradedReasonHypershiftDeployedMessage,
+	}
+}

--- a/pkg/agent/addon_status_helper_test.go
+++ b/pkg/agent/addon_status_helper_test.go
@@ -1,0 +1,372 @@
+package agent
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stolostron/hypershift-addon-operator/pkg/util"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+)
+
+var defaultReplicas *int32 = new(int32)
+var multipleReplicas *int32 = new(int32)
+
+func Test_containsHypershiftAddonDeployment(t *testing.T) {
+	type args struct {
+		deployment appsv1.Deployment
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "operator name",
+			args: args{
+				appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      util.HypershiftOperatorName,
+						Namespace: util.HypershiftOperatorNamespace,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "external dns name",
+			args: args{
+				appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      util.HypershiftOperatorExternalDNSName,
+						Namespace: util.HypershiftOperatorNamespace,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "not operator name",
+			args: args{
+				appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "not" + util.HypershiftOperatorName,
+						Namespace: util.HypershiftOperatorNamespace,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "not external dns name",
+			args: args{
+				appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "not" + util.HypershiftOperatorExternalDNSName,
+						Namespace: util.HypershiftOperatorNamespace,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "empty deployment name",
+			args: args{
+				appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "",
+						Namespace: util.HypershiftOperatorNamespace,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "empty deployment namespace",
+			args: args{
+				appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      util.HypershiftOperatorName,
+						Namespace: "",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "invalid deployment namespace",
+			args: args{
+				appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      util.HypershiftOperatorName,
+						Namespace: "not" + util.HypershiftOperatorNamespace,
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := containsHypershiftAddonDeployment(tt.args.deployment); got != tt.want {
+				t.Errorf("containsHypershiftAddonDeployment() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_checkDeployments(t *testing.T) {
+	*defaultReplicas = 1
+	*multipleReplicas = 3
+	type args struct {
+		checkExtDNSDeploy     bool
+		operatorDeployment    *appsv1.Deployment
+		externalDNSDeployment *appsv1.Deployment
+	}
+	tests := []struct {
+		name string
+		args args
+		want metav1.Condition
+	}{
+		{
+			name: "hypershift deployed with external dns",
+			args: args{
+				checkExtDNSDeploy: true,
+				operatorDeployment: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: util.HypershiftOperatorName,
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: defaultReplicas,
+					},
+					Status: appsv1.DeploymentStatus{
+						AvailableReplicas: 1,
+					},
+				},
+				externalDNSDeployment: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: util.HypershiftOperatorExternalDNSName,
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: defaultReplicas,
+					},
+					Status: appsv1.DeploymentStatus{
+						AvailableReplicas: 1,
+					},
+				},
+			},
+			want: metav1.Condition{
+				Type:    addonv1alpha1.ManagedClusterAddOnConditionDegraded,
+				Status:  metav1.ConditionFalse,
+				Reason:  degradedReasonHypershiftDeployed,
+				Message: degradedReasonHypershiftDeployedMessage,
+			},
+		},
+		{
+			name: "hypershift deployed without external dns",
+			args: args{
+				checkExtDNSDeploy: false,
+				operatorDeployment: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: util.HypershiftOperatorName,
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: defaultReplicas,
+					},
+					Status: appsv1.DeploymentStatus{
+						AvailableReplicas: 1,
+					},
+				},
+			},
+			want: metav1.Condition{
+				Type:    addonv1alpha1.ManagedClusterAddOnConditionDegraded,
+				Status:  metav1.ConditionFalse,
+				Reason:  degradedReasonHypershiftDeployed,
+				Message: degradedReasonHypershiftDeployedMessage,
+			},
+		},
+		{
+			name: "no operator and no external dns deployments with check external dns",
+			args: args{
+				checkExtDNSDeploy: true,
+			},
+			want: metav1.Condition{
+				Type:    addonv1alpha1.ManagedClusterAddOnConditionDegraded,
+				Status:  metav1.ConditionTrue,
+				Reason:  degradedReasonOperatorNotFound + "," + degradedReasonExternalDNSNotFound,
+				Message: degradedReasonOperatorNotFoundMessage + "\n" + degradedReasonExternalDNSNotFoundMessage,
+			},
+		},
+		{
+			name: "no operator without check external dns",
+			args: args{
+				checkExtDNSDeploy: false,
+			},
+			want: metav1.Condition{
+				Type:    addonv1alpha1.ManagedClusterAddOnConditionDegraded,
+				Status:  metav1.ConditionTrue,
+				Reason:  degradedReasonOperatorNotFound,
+				Message: degradedReasonOperatorNotFoundMessage,
+			},
+		},
+		{
+			name: "deleted operator and deleted external dns deployments with check external dns",
+			args: args{
+				checkExtDNSDeploy: true,
+				operatorDeployment: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              util.HypershiftOperatorName,
+						DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					},
+				},
+				externalDNSDeployment: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              util.HypershiftOperatorExternalDNSName,
+						DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					},
+				},
+			},
+			want: metav1.Condition{
+				Type:    addonv1alpha1.ManagedClusterAddOnConditionDegraded,
+				Status:  metav1.ConditionTrue,
+				Reason:  degradedReasonOperatorDeleted + "," + degradedReasonExternalDNSDeleted,
+				Message: degradedReasonOperatorDeletedMessage + "\n" + degradedReasonExternalDNSDeletedMessage,
+			},
+		},
+		{
+			name: "deleted operator and deleted external dns deployments without check external dns",
+			args: args{
+				checkExtDNSDeploy: false,
+				operatorDeployment: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              util.HypershiftOperatorName,
+						DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					},
+				},
+				externalDNSDeployment: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              util.HypershiftOperatorExternalDNSName,
+						DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					},
+				},
+			},
+			want: metav1.Condition{
+				Type:    addonv1alpha1.ManagedClusterAddOnConditionDegraded,
+				Status:  metav1.ConditionTrue,
+				Reason:  degradedReasonOperatorDeleted,
+				Message: degradedReasonOperatorDeletedMessage,
+			},
+		},
+		{
+			name: "not all available operator and external dns deployments with check external dns",
+			args: args{
+				checkExtDNSDeploy: true,
+				operatorDeployment: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: util.HypershiftOperatorName,
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: defaultReplicas,
+					},
+					Status: appsv1.DeploymentStatus{
+						AvailableReplicas: 0,
+					},
+				},
+				externalDNSDeployment: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: util.HypershiftOperatorExternalDNSName,
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: multipleReplicas,
+					},
+					Status: appsv1.DeploymentStatus{
+						AvailableReplicas: 2,
+					},
+				},
+			},
+			want: metav1.Condition{
+				Type:    addonv1alpha1.ManagedClusterAddOnConditionDegraded,
+				Status:  metav1.ConditionTrue,
+				Reason:  degradedReasonOperatorNotAllAvailableReplicas + "," + degradedReasonExternalDNSNotAllAvailableReplicas,
+				Message: degradedReasonOperatorNotAllAvailableReplicasMessage + "\n" + degradedReasonExternalDNSNotAllAvailableReplicasMessage,
+			},
+		},
+		{
+			name: "not all available operator and external dns deployments without check external dns",
+			args: args{
+				checkExtDNSDeploy: false,
+				operatorDeployment: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: util.HypershiftOperatorName,
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: defaultReplicas,
+					},
+					Status: appsv1.DeploymentStatus{
+						AvailableReplicas: 0,
+					},
+				},
+				externalDNSDeployment: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: util.HypershiftOperatorExternalDNSName,
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: multipleReplicas,
+					},
+					Status: appsv1.DeploymentStatus{
+						AvailableReplicas: 2,
+					},
+				},
+			},
+			want: metav1.Condition{
+				Type:    addonv1alpha1.ManagedClusterAddOnConditionDegraded,
+				Status:  metav1.ConditionTrue,
+				Reason:  degradedReasonOperatorNotAllAvailableReplicas,
+				Message: degradedReasonOperatorNotAllAvailableReplicasMessage,
+			},
+		},
+		{
+			name: "available operator but not external dns deployments with check external dns",
+			args: args{
+				checkExtDNSDeploy: true,
+				operatorDeployment: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: util.HypershiftOperatorName,
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: defaultReplicas,
+					},
+					Status: appsv1.DeploymentStatus{
+						AvailableReplicas: 1,
+					},
+				},
+				externalDNSDeployment: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: util.HypershiftOperatorExternalDNSName,
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: multipleReplicas,
+					},
+					Status: appsv1.DeploymentStatus{
+						AvailableReplicas: 2,
+					},
+				},
+			},
+			want: metav1.Condition{
+				Type:    addonv1alpha1.ManagedClusterAddOnConditionDegraded,
+				Status:  metav1.ConditionTrue,
+				Reason:  degradedReasonExternalDNSNotAllAvailableReplicas,
+				Message: degradedReasonExternalDNSNotAllAvailableReplicasMessage,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := checkDeployments(tt.args.checkExtDNSDeploy, tt.args.operatorDeployment, tt.args.externalDNSDeployment); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("checkDeployments() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -188,6 +188,18 @@ func (o *AgentOptions) runControllerManager(ctx context.Context) error {
 		return fmt.Errorf("unable to create agent controller: %s, err: %w", util.AddonControllerName, err)
 	}
 
+	addonStatusController := &AddonStatusController{
+		spokeClient: spokeKubeClient,
+		hubClient:   hubClient,
+		log:         o.Log.WithName("addon-status-controller"),
+		addonNsn:    types.NamespacedName{Namespace: o.SpokeClusterName, Name: util.AddonControllerName},
+		clusterName: o.SpokeClusterName,
+	}
+
+	if err = addonStatusController.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create agent status controller: %s, err: %w", util.AddonStatusControllerName, err)
+	}
+
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		return fmt.Errorf("unable to set up health check, err: %w", err)
 	}

--- a/pkg/agent/suite_test.go
+++ b/pkg/agent/suite_test.go
@@ -1,0 +1,94 @@
+package agent
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stolostron/hypershift-addon-operator/pkg/util"
+
+	"k8s.io/apimachinery/pkg/types"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	appsv1 "k8s.io/api/apps/v1"
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+)
+
+const localClusterName = "local-cluster"
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Controller Suite")
+}
+
+var _ = BeforeSuite(func() {
+	zapLogger := zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true))
+	logf.SetLogger(zapLogger)
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "hack", "crds")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: k8sscheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	err = addonv1alpha1.AddToScheme(k8sscheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = appsv1.AddToScheme(k8sscheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Register and start the Foo controller
+	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: k8sscheme.Scheme,
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	err = (&AddonStatusController{
+		spokeClient: k8sManager.GetClient(),
+		hubClient:   k8sManager.GetClient(),
+		log:         zapLogger.WithName("addon-status-controller-test"),
+		addonNsn:    types.NamespacedName{Namespace: localClusterName, Name: util.AddonControllerName},
+		clusterName: localClusterName,
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	go func() {
+		defer GinkgoRecover()
+		err = k8sManager.Start(ctx)
+		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
+	}()
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/pkg/manager/manifests/permission/role.yaml
+++ b/pkg/manager/manifests/permission/role.yaml
@@ -10,3 +10,6 @@ rules:
   - apiGroups: ["addon.open-cluster-management.io"]
     resources: ["managedclusteraddons"]
     verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["addon.open-cluster-management.io"]
+    resources: ["managedclusteraddons/status"]
+    verbs: ["patch", "update"]

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -22,12 +22,15 @@ const (
 	HypershiftDownstreamOverride = "hypershift-operator-imagestream"
 	HypershiftOverrideKey        = "imagestream"
 	AddonControllerName          = "hypershift-addon"
+	AddonStatusControllerName    = "hypershift-addon-status"
+	AgentDeploymentName          = "hypershift-addon-agent"
 
 	HypershiftOverrideImagesCM = "hypershift-override-images"
 	ImageUpgradeControllerName = "hypershift-image-upgrade"
 
-	HypershiftOperatorNamespace = "hypershift"
-	HypershiftOperatorName      = "operator"
+	HypershiftOperatorNamespace       = "hypershift"
+	HypershiftOperatorName            = "operator"
+	HypershiftOperatorExternalDNSName = "external-dns"
 
 	// Labels for resources to reference the Hosted Cluster
 	HypershiftClusterNameLabel      = "hypershiftdeployments.cluster.open-cluster-management.io/cluster-name"

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -64,7 +64,6 @@ func deleteOIDCProviderSecret(ctx context.Context, client kubernetes.Interface, 
 
 var _ = ginkgo.Describe("Install", func() {
 	var ctx context.Context
-	var agentDeploymentName = "hypershift-addon-agent"
 	ginkgo.BeforeEach(func() {
 		ctx = context.TODO()
 		err := createOIDCProviderSecret(ctx, kubeClient, defaultManagedCluster)
@@ -103,7 +102,7 @@ var _ = ginkgo.Describe("Install", func() {
 
 			ginkgo.By("Check the addon agent deletion")
 			gomega.Eventually(func() bool {
-				_, err := kubeClient.AppsV1().Deployments(defaultInstallNamespace).Get(ctx, agentDeploymentName, metav1.GetOptions{})
+				_, err := kubeClient.AppsV1().Deployments(defaultInstallNamespace).Get(ctx, util.AgentDeploymentName, metav1.GetOptions{})
 				return apierrors.IsNotFound(err)
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
 		})
@@ -111,7 +110,7 @@ var _ = ginkgo.Describe("Install", func() {
 		ginkgo.It("did not exist", func() {
 			ginkgo.By("Check the addon agent installation")
 			gomega.Eventually(func() bool {
-				deployment, err := kubeClient.AppsV1().Deployments(defaultInstallNamespace).Get(ctx, agentDeploymentName, metav1.GetOptions{})
+				deployment, err := kubeClient.AppsV1().Deployments(defaultInstallNamespace).Get(ctx, util.AgentDeploymentName, metav1.GetOptions{})
 				if err != nil {
 					return false
 				}


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Watch Hypershift operator and external dns deployments
* Update hub hypershift managedclusteraddon status degraded condition accordingly

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
* Allows hub cluster admin to have better visibility to managed cluster's hypershift operator deployment status

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-1684

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?   	github.com/stolostron/hypershift-addon-operator/cmd	[no test files]
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	19.382s	coverage: 70.2% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	126.431s	coverage: 86.0% of statements
?   	github.com/stolostron/hypershift-addon-operator/pkg/manager	[no test files]
?   	github.com/stolostron/hypershift-addon-operator/pkg/util	[no test files]
```

Build, deployed and tested on a CK cluster.