### PR TITLE
Fix manifestwork doc

### DIFF
--- a/docs/provision_hypershift_clusters_by_manifestwork.md
+++ b/docs/provision_hypershift_clusters_by_manifestwork.md
@@ -464,7 +464,7 @@ spec:
 
 The payload resources are under `spec.workload.manifests`. Once these resources are created on the hosting cluster, the hypershift operator reconciles with these resources to create the specified hosted cluster. This manifestwork CR is the delivery or placement mechanism for a hosted cluster.
 
-**NOTE: You must set the `HostedCluster.spec.clusterID` with an UUID to avoid a race condition between the manifestwork controller and the hypershift operator on this causing the HostedCluster and cluster version operator deployment to have a high and increasing .generation number. You can use an online UUID generator tool or programming language specific UUID API to generate one. 
+**Important:** You must set the `HostedCluster.spec.clusterID` with an UUID to avoid a race condition between the manifestwork controller and the hypershift operator on this causing the HostedCluster and cluster version operator deployment to have a high and increasing .generation number. You can use an online UUID generator tool or programming language specific UUID API to generate one. 
 
 ## How a hosted cluster is automatically imported into ACM hub cluster as a managed cluster
 

--- a/docs/provision_hypershift_clusters_by_manifestwork.md
+++ b/docs/provision_hypershift_clusters_by_manifestwork.md
@@ -314,6 +314,7 @@ spec:
         namespace: clusters
       spec:
         autoscaling: {}
+        clusterID: some-UUID
         controllerAvailabilityPolicy: SingleReplica
         dns:
           baseDomain: base.domain.com
@@ -462,6 +463,8 @@ spec:
 ```
 
 The payload resources are under `spec.workload.manifests`. Once these resources are created on the hosting cluster, the hypershift operator reconciles with these resources to create the specified hosted cluster. This manifestwork CR is the delivery or placement mechanism for a hosted cluster.
+
+**NOTE: You must set the `HostedCluster.spec.clusterID` with an UUID to avoid a race condition between the manifestwork controller and the hypershift operator on this causing the HostedCluster and cluster version operator deployment to have a high and increasing .generation number. You can use an online UUID generator tool or programming language specific UUID API to generate one. 
 
 ## How a hosted cluster is automatically imported into ACM hub cluster as a managed cluster
 


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* A missing field in the manifestwork example which caused a continuous race condition reconciles between the manifestwork controller and the hypershift operator.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* 

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
