### PR TITLE
fix incorrect usage of controllerutil.CreateOrUpdate()

### DIFF
--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -374,12 +374,15 @@ func (c *UpgradeController) createSpokeSecret(ctx context.Context, hubSecret *co
 			Name:      hubSecret.Name,
 			Namespace: hypershiftOperatorKey.Namespace,
 		},
-		Data: map[string][]byte{
-			"credentials": hubSecret.Data["credentials"],
-		},
 	}
 	c.log.Info(fmt.Sprintf("createorupdate the the secret (%s/%s) on cluster %s", hypershiftOperatorKey.Namespace, hubSecret.Name, hubSecret.Namespace))
-	_, err := controllerutil.CreateOrUpdate(ctx, c.spokeUncachedClient, spokeSecret, func() error { return nil })
+	_, err := controllerutil.CreateOrUpdate(ctx, c.spokeUncachedClient, spokeSecret, func() error {
+		spokeSecret.Data = map[string][]byte{
+			"credentials": hubSecret.Data["credentials"],
+		}
+
+		return nil
+	})
 
 	return err
 }


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* fix incorrect usage of controllerutil.CreateOrUpdate()
* This was preventing changes to hypershift secret in the hub to be propagated to spoke clusters
* https://issues.redhat.com/browse/ACM-2056

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
* to fix https://issues.redhat.com/browse/ACM-2056

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-2056

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
