### PR TITLE
Acm 2052

### DIFF
--- a/docs/provision_hosted_cluster_on_mce_local_cluster.md
+++ b/docs/provision_hosted_cluster_on_mce_local_cluster.md
@@ -69,7 +69,9 @@ The secret must contain 3 fields:
 
 - `provider`: DNS provider that manages the service-level DNS zone (example: aws)
 - `domain-filter`: The service-level domain
-- `credentials`: A credentials file appropriate for the specified DNS provider
+- `credentials`: *(Optional, only when using aws keys) - For all external DNS types, a credential file is supported
+- `aws-access-key-id`: *OPTIONAL* - When using AWS DNS service, credential access key id
+- `aws-secret-access-key`: *OPTIONAL* - When using AWS DNS service, credential access key secret
 
 For details, please check: [HyperShift Project Documentation](https://hypershift-docs.netlify.app/how-to/external-dns/). For convenience, you can create this secret using the CLI by:
 


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Users should be able to provide external DNS credentials through `credentials` field or `aws-secret-access-key` and `aws-access-key-id` fields if the DNS provider is AWS.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-2052

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
Running tool: /usr/local/go/bin/go test -timeout 180s -coverprofile=/var/folders/6m/zwb5lxd157bgxp_wm4bv95fc0000gn/T/vscode-goEd8Foq/go-code-cover -run ^TestRunHypershiftInstallExternalDNSDifferentSecret$ github.com/stolostron/hypershift-addon-operator/pkg/install

ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	10.770s	coverage: 42.4% of statements
```
