### PR TITLE
Update the manifestwork HC doc

### DIFF
--- a/docs/provision_hypershift_clusters_by_manifestwork.md
+++ b/docs/provision_hypershift_clusters_by_manifestwork.md
@@ -477,6 +477,7 @@ metadata:
   annotations:
     import.open-cluster-management.io/hosting-cluster-name: my-hosting-cluster
     import.open-cluster-management.io/klusterlet-deploy-mode: Hosted
+    addon.open-cluster-management.io/enable-hosted-mode: "true"
     open-cluster-management/created-via: other
   labels:
     cloud: auto-detect
@@ -488,6 +489,8 @@ spec:
   hubAcceptsClient: true
   leaseDurationSeconds: 60
 ```
+
+**NOTE:** The following three annotations in the `ManagedCluster` causes the work manager and policy managed cluster addons to be enabled in hosted mode running along side with the OpenShift hosted control plane and all other managed cluster addons to be disabled.
 
 The name of the managed cluster is the `infra ID` of the hosted cluster. `hubAcceptsClient: true` means that the ACM hub accepts or approves this managed cluster.
 


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Update the manifestwork HostedCluster deployment doc to add an additional annotation to enable only work and policy addons in hosted mode.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* 

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
