### PR TITLE
Use the addon image pull secret for the install job

### DIFF
--- a/pkg/install/install_job.go
+++ b/pkg/install/install_job.go
@@ -28,6 +28,7 @@ func (c *UpgradeController) runHyperShiftInstallJob(ctx context.Context, image, 
 		},
 		RestartPolicy:      "Never",
 		ServiceAccountName: util.HypershiftInstallJobServiceAccount,
+		ImagePullSecrets:   []corev1.LocalObjectReference{{Name: c.pullSecret}},
 	}
 
 	if len(imageStreamCMData) > 0 {


### PR DESCRIPTION
Signed-off-by: Philip Wu <phwu@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* The hypershift install job on managed clusters may fail with ImagePullError if the image pull secret is in the MCE, and not in the openshift default pull-secret. This change uses the image pull secret of the addon when creating the install job.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  The hypershift install job on managed clusters may fail.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-1912

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	21.648s	coverage: 70.2% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	137.472s	coverage: 85.9% of statements

```
