### PR TITLE
Placement score

### DIFF
--- a/docs/upgrading_hypershift_operator.md
+++ b/docs/upgrading_hypershift_operator.md
@@ -1,4 +1,4 @@
-# Upgrading the hypershift operator on a remote hosting cluster
+# Upgrading the hypershift operator in one remote hosting cluster
 
 ## Overriding the hypershift operator image references
 
@@ -21,4 +21,77 @@ data:
   cluster-api-provider-azure: quay.io:443/acm-d/cluster-api-provider-azure-rhel8@sha256:9f9061f05c1a794b6ece36b481b107646bafe411457cfdc73bcc64c102c12ae4
   cluster-api-provider-kubevirt: quay.io:443/acm-d/cluster-api-provider-kubevirt-rhel8@sha256:b76fc28b739b24a3b367000c47b973220252f5e8cd01a0243e54ba9aab79d298
   hypershift-operator: quay.io:443/acm-d/hypershift-rhel8-operator@sha256:eedb58e7b9c4d9e49c6c53d1b5b97dfddcdffe839bbffd4fb950760715d24244
+```
+
+# Upgrading the hypershift operator in all remote hosting clusters
+
+## Overriding the hypershift operator image references
+
+Without upgrading ACM, you can create a config map based on an image override JSON file on the ACM hub cluster to upgrade the hypershift operator that was installed by the hypershift `ManagedClusterAddon` on all hosting clusters.
+
+1. Create an image override JSON file in the following format. The JSON file can contain a subset of these or all depending on which image you want to override. `image-remote` is the image repository, `image-name` is the image name in the image repository and `image-tag` is the image tag to be used. **NOTE:** Do not update the `image-key` values. Only these image keys are known by the ACM installer.
+
+```
+[
+  {
+    "image-name": "apiserver-network-proxy",
+    "image-tag": "sha256:c0725b90e19b151340a9abe821b9431d8ab903ad8f3ae93edb0550b0f2486756",
+    "image-remote": "quay.io/stolostron",
+    "image-key": "apiserver_network_proxy"
+  },
+  {
+    "image-name": "aws-encryption-provider",
+    "image-tag": "sha256:c0725b90e19b151340a9abe821b9431d8ab903ad8f3ae93edb0550b0f2486756",
+    "image-remote": "quay.io/stolostron",
+    "image-key": "aws_encryption_provider"
+  },
+  {
+    "image-name": "cluster-api",
+    "image-tag": "sha256:c0725b90e19b151340a9abe821b9431d8ab903ad8f3ae93edb0550b0f2486756",
+    "image-remote": "quay.io/stolostron",
+    "image-key": "cluster_api"
+  },
+  {
+    "image-name": "cluster-api-provider-agent",
+    "image-tag": "sha256:c0725b90e19b151340a9abe821b9431d8ab903ad8f3ae93edb0550b0f2486756",
+    "image-remote": "quay.io/stolostron",
+    "image-key": "cluster_api_provider_agent"
+  },
+  {
+    "image-name": "cluster-api-provider-aws",
+    "image-tag": "sha256:c0725b90e19b151340a9abe821b9431d8ab903ad8f3ae93edb0550b0f2486756",
+    "image-remote": "quay.io/stolostron",
+    "image-key": "cluster_api_provider_aws"
+  },
+  {
+    "image-name": "cluster-api-provider-azure",
+    "image-tag": "sha256:c0725b90e19b151340a9abe821b9431d8ab903ad8f3ae93edb0550b0f2486756",
+    "image-remote": "quay.io/stolostron",
+    "image-key": "cluster_api_provider_azure"
+  },
+  {
+    "image-name": "cluster-api-provider-kubevirt",
+    "image-tag": "sha256:c0725b90e19b151340a9abe821b9431d8ab903ad8f3ae93edb0550b0f2486756",
+    "image-remote": "quay.io/stolostron",
+    "image-key": "cluster_api_provider_kubevirt"
+  },
+  {
+    "image-name": "hypershift-operator",
+    "image-tag": "sha256:c0725b90e19b151340a9abe821b9431d8ab903ad8f3ae93edb0550b0f2486756",
+    "image-remote": "quay.io/stolostron",
+    "image-key": "hypershift_operator"
+  }
+]
+```
+
+2. Create a configmap based on the JSON file. The configmap must be created in `multicluster-engine` namespace.
+
+```
+  kubectl create configmap <my-config> --from-file=docs/examples/image-override.json -n multicluster-engine
+```
+
+3. For this image override configmap to be effective, annotation MCE with this configmap.
+
+```
+  kubectl annotate mce $(kubectl get mce) --overwrite imageOverridesCM=<my-config>
 ```

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -577,5 +577,47 @@ func (o *AgentOptions) runCleanup(ctx context.Context, uCtrl *install.UpgradeCon
 		return err
 	}
 
+	/*if err := o.DeleteAddOnPlacementScore(); err != nil {
+		log.Error(err, "failed to clean up addOnPlacementScore")
+		return err
+	}*/
+
 	return nil
 }
+
+// To be enabled after https://github.com/stolostron/backlog/issues/26908 is fixed
+/*func (o *AgentOptions) DeleteAddOnPlacementScore() error {
+	log := o.Log.WithName("hypershift-addon-cleanup")
+
+	hubConfig, err := clientcmd.BuildConfigFromFlags("", o.HubKubeconfigFile)
+	if err != nil {
+		log.Error(err, "failed to create hubConfig from flag")
+		return fmt.Errorf("failed to create hubConfig from flag, err: %w", err)
+	}
+
+	hubClient, err := client.New(hubConfig, client.Options{Scheme: scheme})
+	if err != nil {
+		log.Error(err, "failed to create hubClient")
+		return fmt.Errorf("failed to create hubClient, err: %w", err)
+	}
+
+	addOnPlacementScore := &clusterv1alpha1.AddOnPlacementScore{}
+	addOnPlacementScoreKey := &types.NamespacedName{Name: util.HostedClusterScoresResourceName, Namespace: o.SpokeClusterName}
+
+	err = hubClient.Get(context.TODO(), *addOnPlacementScoreKey, addOnPlacementScore)
+
+	if err == nil {
+		log.Info("found AddOnPlacementScore for "+o.SpokeClusterName, ". Deleting ...")
+
+		err2 := hubClient.Delete(context.TODO(), addOnPlacementScore)
+		if err2 != nil {
+			log.Error(err2, fmt.Sprintf("failed to delete the addOnPlacementScore resource from %s", o.SpokeClusterName))
+			return err2
+		}
+
+		log.Info(fmt.Sprintf("deleted the addOnPlacementScore resource from %s", o.SpokeClusterName))
+	} else {
+		log.Error(err, "failed to find AddOnPlacementScore")
+	}
+	return err
+}*/

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -463,8 +463,7 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 func (c *agentController) isHostedControlPlaneAvailable(status hyperv1alpha1.HostedClusterStatus) bool {
 	for _, condition := range status.Conditions {
-		c.log.Info("condition.Reason: " + condition.Reason + ",  condition.Status: " + string(condition.Status))
-		if condition.Reason == "HostedClusterAsExpected" && condition.Status == metav1.ConditionTrue {
+		if condition.Reason == hyperv1alpha1.HostedClusterAsExpectedReason && condition.Status == metav1.ConditionTrue && condition.Type == string(hyperv1alpha1.HostedClusterAvailable) {
 			return true
 		}
 	}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -577,47 +577,5 @@ func (o *AgentOptions) runCleanup(ctx context.Context, uCtrl *install.UpgradeCon
 		return err
 	}
 
-	/*if err := o.DeleteAddOnPlacementScore(); err != nil {
-		log.Error(err, "failed to clean up addOnPlacementScore")
-		return err
-	}*/
-
 	return nil
 }
-
-// To be enabled after https://github.com/stolostron/backlog/issues/26908 is fixed
-/*func (o *AgentOptions) DeleteAddOnPlacementScore() error {
-	log := o.Log.WithName("hypershift-addon-cleanup")
-
-	hubConfig, err := clientcmd.BuildConfigFromFlags("", o.HubKubeconfigFile)
-	if err != nil {
-		log.Error(err, "failed to create hubConfig from flag")
-		return fmt.Errorf("failed to create hubConfig from flag, err: %w", err)
-	}
-
-	hubClient, err := client.New(hubConfig, client.Options{Scheme: scheme})
-	if err != nil {
-		log.Error(err, "failed to create hubClient")
-		return fmt.Errorf("failed to create hubClient, err: %w", err)
-	}
-
-	addOnPlacementScore := &clusterv1alpha1.AddOnPlacementScore{}
-	addOnPlacementScoreKey := &types.NamespacedName{Name: util.HostedClusterScoresResourceName, Namespace: o.SpokeClusterName}
-
-	err = hubClient.Get(context.TODO(), *addOnPlacementScoreKey, addOnPlacementScore)
-
-	if err == nil {
-		log.Info("found AddOnPlacementScore for "+o.SpokeClusterName, ". Deleting ...")
-
-		err2 := hubClient.Delete(context.TODO(), addOnPlacementScore)
-		if err2 != nil {
-			log.Error(err2, fmt.Sprintf("failed to delete the addOnPlacementScore resource from %s", o.SpokeClusterName))
-			return err2
-		}
-
-		log.Info(fmt.Sprintf("deleted the addOnPlacementScore resource from %s", o.SpokeClusterName))
-	} else {
-		log.Error(err, "failed to find AddOnPlacementScore")
-	}
-	return err
-}*/

--- a/pkg/manager/manifests/permission/role.yaml
+++ b/pkg/manager/manifests/permission/role.yaml
@@ -13,3 +13,6 @@ rules:
   - apiGroups: ["addon.open-cluster-management.io"]
     resources: ["managedclusteraddons/status"]
     verbs: ["patch", "update"]
+  - apiGroups: ["cluster.open-cluster-management.io"]
+    resources: ["addonplacementscores", "addonplacementscores/status"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", patch]

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -71,7 +71,7 @@ const (
 	// AddOnPlacementScore resource name
 	HostedClusterScoresResourceName = "hosted-clusters-score"
 	// AddOnPlacementScore score name
-	HostedClusterScoresScoreName = "hosted-clusters-score"
+	HostedClusterScoresScoreName = "hostedClustersCount"
 )
 
 // GenerateClientConfigFromSecret generate a client config from a given secret

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -67,6 +67,11 @@ const (
 	HypershiftEnvVarImageAwsEncyptionProvider = "IMAGE_AWS_ENCRYPTION_PROVIDER"
 	HypershiftEnvVarImageClusterApi           = "IMAGE_CLUSTER_API"
 	HypershiftEnvVarImageAgentCapiProvider    = "IMAGE_AGENT_CAPI_PROVIDER"
+
+	// AddOnPlacementScore resource name
+	HostedClusterScoresResourceName = "hosted-clusters-score"
+	// AddOnPlacementScore score name
+	HostedClusterScoresScoreName = "hosted-clusters-score"
 )
 
 // GenerateClientConfigFromSecret generate a client config from a given secret


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Whenever the hypershift agent reconciles hosted clusters, it should generate addOnPlacementScore with the number of hosted clusters as a score value in the hosting cluster's namespace on the hub.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Hosted cluster placement scheduler can use the addOnPlacementScore to determine the least used hosting cluster and place a new hosted cluster.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-2162

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
Running tool: /usr/local/go/bin/go test -timeout 180s -coverprofile=/var/folders/6m/zwb5lxd157bgxp_wm4bv95fc0000gn/T/vscode-goEd8Foq/go-code-cover -run ^TestReconcile$ github.com/stolostron/hypershift-addon-operator/pkg/agent

ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	0.743s	coverage: 28.6% of statements

```
