### PR TITLE
Switch the default ManagedCluster name from InfraID to HostedCluster.…

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -270,7 +270,7 @@ func (c *agentController) generateExtManagedKubeconfigSecret(ctx context.Context
 	secret.SetName("external-managed-kubeconfig")
 	managedClusterAnnoValue, ok := hc.GetAnnotations()[util.ManagedClusterAnnoKey]
 	if !ok || len(managedClusterAnnoValue) == 0 {
-		managedClusterAnnoValue = hc.Spec.InfraID
+		managedClusterAnnoValue = hc.Name
 	}
 	secret.SetNamespace("klusterlet-" + managedClusterAnnoValue)
 	kubeconfigData := secretData["kubeconfig"]
@@ -397,7 +397,7 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		managedClusterAnnoValue, ok := hc.GetAnnotations()[util.ManagedClusterAnnoKey]
 		if !ok || len(managedClusterAnnoValue) == 0 {
 			c.log.Info("did not find managed cluster's name annotation from hosted cluster, using infra-id")
-			managedClusterAnnoValue = hc.Spec.InfraID
+			managedClusterAnnoValue = hc.Name
 			ok = true
 		}
 


### PR DESCRIPTION
…Name
* Add a test for with and without the annotation

Signed-off-by: Joshua Packer <jpacker@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Change the default assumption(expectation) for the ManagedCluster name from `HostedCluster.Spec.InfraID` to `HostedCluster.Name`

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  This simplifies import for users, they just need to name the ManagedCluster and HostedCluster the same.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* Current issue: https://issues.redhat.com/browse/MGMT-12631
* Related issue: https://issues.redhat.com/browse/ACM-1922
* Fix for Cluster Service: https://issues.redhat.com/browse/SDA-6897

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
--- PASS: TestAPIs (4.61s)
PASS
coverage: 71.0% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	10.402s	coverage: 71.0% of statements
```
