### PR TITLE
Added clusterclaim to filter clusters with >= 80 hosted clusters

### DIFF
--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -72,6 +72,8 @@ const (
 	HostedClusterScoresResourceName = "hosted-clusters-score"
 	// AddOnPlacementScore score name
 	HostedClusterScoresScoreName = "hostedClustersCount"
+
+	HostedClusterPlacementThreshhold = 80
 )
 
 // GenerateClientConfigFromSecret generate a client config from a given secret


### PR DESCRIPTION
Signed-off-by: Omar Farag <ofarag@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Added clusterclaim to filter clusters with >= 80 hosted clusters

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Requested to update use case

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-1540


