### PR TITLE
add cluster claims to indicate HC count above threshold or at zero

### DIFF
--- a/docs/provision_hosted_cluster_on_mce_local_cluster.md
+++ b/docs/provision_hosted_cluster_on_mce_local_cluster.md
@@ -236,7 +236,7 @@ Delete the hypershift-addon
     $ oc delete managedclusteraddon -n local-cluster hypershift-addon
     ```
 
-**NOTE:** Deleting the hypershift-addon will not destroy existing hosted clusters, nor the hypershift operator.
+**NOTE:** Deleting the hypershift-addon will remove only the hypershift addon agent from the managed cluster if there are hosted clusters. If there is no hosted cluster, deleting the hypershift-addon will also uninstall the hypershift operator on the managed cluster.
 
 ## Troubleshooting
 

--- a/docs/provision_hypershift_clusters_by_manifestwork.md
+++ b/docs/provision_hypershift_clusters_by_manifestwork.md
@@ -477,7 +477,7 @@ metadata:
   annotations:
     import.open-cluster-management.io/hosting-cluster-name: my-hosting-cluster
     import.open-cluster-management.io/klusterlet-deploy-mode: Hosted
-    addon.open-cluster-management.io/enable-hosted-mode: "true"
+    addon.open-cluster-management.io/enable-hosted-mode-addons: "true"
     open-cluster-management/created-via: other
   labels:
     cloud: auto-detect

--- a/docs/scheduling_hosted_cluster.md
+++ b/docs/scheduling_hosted_cluster.md
@@ -37,7 +37,7 @@ spec:
             purpose: production
         claimSelector:
           matchExpressions:
-            - key: hostedclustercount.full.hypershift.openshift.io
+            - key: full.hostedclustercount.hypershift.openshift.io
               operator: In
               values:
                 - "false"
@@ -54,7 +54,7 @@ spec:
 
 This placement considers managed hosting clusters that belong to `default` cluster set and selects only one cluster.
 
-With the predicates settings, this placement excludes managed clusters with clusterClaim `hostedclustercount.full.hypershift.openshift.io=true` and without label `purpose: production`. The hypershift addon agent sets the cluster claim to `"true"` when the number of hosted clusters on the hosting cluster has reached 80. With the label selector, you can easily take one or more hosting clusters out of placement consideration by removing the specified label from the managed clusters. Then with the prioritizerPolicy settings, this placement selects a hosting cluster with the least `hostedClustersCount` score which is contained in `AddOnPlacementScore` resource named `hosted-clusters-score` in the hosting cluster's namespace in the hub cluster. The hypershift addon agent constantly updates this `AddOnPlacementScore`. The score is multiplied by the weight and the cluster with the highest score gets selected. 
+With the predicates settings, this placement excludes managed clusters with clusterClaim `full.hostedclustercount.hypershift.openshift.io=true` and without label `purpose: production`. The hypershift addon agent sets the cluster claim to `"true"` when the number of hosted clusters on the hosting cluster has reached 80. With the label selector, you can easily take one or more hosting clusters out of placement consideration by removing the specified label from the managed clusters. Then with the prioritizerPolicy settings, this placement selects a hosting cluster with the least `hostedClustersCount` score which is contained in `AddOnPlacementScore` resource named `hosted-clusters-score` in the hosting cluster's namespace in the hub cluster. The hypershift addon agent constantly updates this `AddOnPlacementScore`. The score is multiplied by the weight and the cluster with the highest score gets selected. 
 
 This is a sample `AddOnPlacementScore` resource named `hosted-clusters-score` in the hosting cluster's namespace in the hub cluster.
 
@@ -83,7 +83,7 @@ status:
 This is a sample cluster claim that gets updated in the hosting cluster's `ManagedCluster` resource. The default maximum number of hosted clusters is 80.
 
 ```yaml
-  - name: hostedclustercount.full.hypershift.openshift.io
+  - name: full.hostedclustercount.hypershift.openshift.io
     value: "false"
 ```
 
@@ -119,7 +119,7 @@ status:
 This is a sample cluster claim that gets updated in the hosting cluster's `ManagedCluster` resource on the hub cluster. The value becomes `"true"` when there is no hosted cluster on the hosting managed cluster. You can use this cluster claim in a `Placement` to get the list of hosting clusters with no hosted cluster.
 
 ```yaml
-  - name: hostedclustercount.zero.hypershift.openshift.io
+  - name: zero.hostedclustercount.hypershift.openshift.io
     value: "true"
 ```
 
@@ -141,7 +141,7 @@ spec:
             purpose: production
         claimSelector:
           matchExpressions:
-            - key: hostedclustercount.zero.hypershift.openshift.io
+            - key: zero.hostedclustercount.hypershift.openshift.io
               operator: In
               values:
                 - "true"
@@ -152,7 +152,7 @@ spec:
 This is a sample cluster claim that gets updated in the hosting cluster's `ManagedCluster` resource on the hub cluster. The value becomes `"true"` when the number of hosted clusters on the hosting managed cluster exceeds (>=) the threshold number. The default threshold is 60 hosted clusters. You can use this cluster claim in a `Placement` to get the list of hosting clusters that either have or have not exceeded the threshold.
 
 ```yaml
-  - name: hostedclustercount.above.threshold.hypershift.openshift.io
+  - name: above.threshold.hostedclustercount.hypershift.openshift.io
     value: "true"
 ```
 
@@ -174,7 +174,7 @@ spec:
             purpose: production
         claimSelector:
           matchExpressions:
-            - key: hostedclustercount.above.threshold.hypershift.openshift.io
+            - key: above.threshold.hostedclustercount.hypershift.openshift.io
               operator: In
               values:
                 - "false"

--- a/docs/scheduling_hosted_cluster.md
+++ b/docs/scheduling_hosted_cluster.md
@@ -1,5 +1,7 @@
 # Placing a hosted cluster
 
+## Selecting one hosting cluster with the least number of hosted clusters
+
 As documented [here](https://github.com/stolostron/hypershift-addon-operator/blob/main/docs/provision_hypershift_clusters_by_manifestwork.md), you can use a `manifestwork` to create a hosted cluster on a remote managed hosting cluster. If you have multiple remote managed hosting clusters and you want to find a hosting cluster with the least number of hosted clusters in order to evenly distribute hosted clusters among hosting clusters, you can use the following `placement`.
 
 This example assumes that all hosting clusters belong to managed cluster set called `default` and the `placement` is created in `default` namespace.
@@ -78,7 +80,7 @@ status:
     value: 2
 ```
 
-This is a sample cluster claim that gets updated in the hosting cluster's `ManagedCluster` resource.
+This is a sample cluster claim that gets updated in the hosting cluster's `ManagedCluster` resource. The default maximum number of hosted clusters is 80.
 
 ```yaml
   - name: hostedclustercount.full.hypershift.openshift.io
@@ -112,3 +114,129 @@ status:
     reason: ""
 ```
 
+## Getting a list of hosting clusters with zero hosted cluster
+
+This is a sample cluster claim that gets updated in the hosting cluster's `ManagedCluster` resource on the hub cluster. The value becomes `"true"` when there is no hosted cluster on the hosting managed cluster. You can use this cluster claim in a `Placement` to get the list of hosting clusters with no hosted cluster.
+
+```yaml
+  - name: hostedclustercount.zero.hypershift.openshift.io
+    value: "true"
+```
+
+This sample placement YAML selects all hosting clusters from the `default` cluster set that has label `purpose=production` and do not have any hosted cluster.
+
+```yaml
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: clusters-with-no-hosted-cluster
+  namespace: default
+spec:
+  clusterSets:
+    - default
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            purpose: production
+        claimSelector:
+          matchExpressions:
+            - key: hostedclustercount.zero.hypershift.openshift.io
+              operator: In
+              values:
+                - "true"
+```
+
+## Getting a list of hosting clusters that have not reached the threshold number of hosted clusters
+
+This is a sample cluster claim that gets updated in the hosting cluster's `ManagedCluster` resource on the hub cluster. The value becomes `"true"` when the number of hosted clusters on the hosting managed cluster exceeds (>=) the threshold number. The default threshold is 60 hosted clusters. You can use this cluster claim in a `Placement` to get the list of hosting clusters that either have or have not exceeded the threshold.
+
+```yaml
+  - name: hostedclustercount.above.threshold.hypershift.openshift.io
+    value: "true"
+```
+
+This sample placement YAML selects all hosting clusters from the `default` cluster set that has label `purpose=production` and have exceeded the threshold. You can use operartor `NotIn` or values `"false"` to get different results.
+
+```yaml
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: clusters-with-no-hosted-cluster
+  namespace: default
+spec:
+  clusterSets:
+    - default
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            purpose: production
+        claimSelector:
+          matchExpressions:
+            - key: hostedclustercount.above.threshold.hypershift.openshift.io
+              operator: In
+              values:
+                - "false"
+```
+
+## Overriding the maximum and threshold number of hosted clusters
+
+The default maximum number of hosted clusters is 80 and threshold number is 60. If you want to override these values for all hosting clusters, update the `AddOnDeploymentConfig` named `hypershift-addon-deploy-config` in `multicluster-engine` namespace on the hub cluster.
+
+```bash
+$ oc edit addondeploymentconfig hypershift-addon-deploy-config -n multicluster-engine
+```
+
+Edit the values and save.
+
+```yaml
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnDeploymentConfig
+metadata:
+  name: hypershift-addon-deploy-config
+  namespace: multicluster-engine
+spec:
+  customizedVariables:
+  - name: hcMaxNumber
+    value: "80"
+  - name: hcThresholdNumber
+    value: "60"
+```
+
+The hypershift addon agent on all hosting clusters will automatically restart with the new settings. If the values are invalid such as invalid numbers or hcMaxNumber < hcThresholdNumber, the change will not be effective and the default values will be enforced.
+
+If you want to have different different settings per hosting cluster, create a different `AddOnDeploymentConfig` in the hosting cluster's namespace on the hub cluster.
+
+```yaml
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnDeploymentConfig
+metadata:
+  name: hosting-cluster-1-hypershift-addon-deploy-config
+  namespace: hosting-cluster-1
+spec:
+  customizedVariables:
+  - name: hcMaxNumber
+    value: "100"
+  - name: hcThresholdNumber
+    value: "80"
+```
+
+And reference it in the hypershift-addon `ManagedClusterAddon`.
+
+```yaml
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ManagedClusterAddOn
+metadata:
+  name: hypershift-addon
+  namespace: hosting-cluster-1
+spec:
+  installNamespace: open-cluster-management-agent-addon
+  configs:
+  - group: addon.open-cluster-management.io
+    resource: addondeploymentconfigs
+    name: hosting-cluster-1-hypershift-addon-deploy-config
+    namespace: hosting-cluster-1
+```
+
+The hypershift addon agent on the hosting cluster will automatically restart with the new settings. If the values are invalid such as invalid numbers or hcMaxNumber < hcThresholdNumber, the change will not be effective and the default values will be enforced.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -526,10 +526,11 @@ func (c *agentController) SyncAddOnPlacementScore(ctx context.Context) error {
 			return err
 		}
 	} else {
+		hcCount := len(hcList.Items)
 		scores := []clusterv1alpha1.AddOnPlacementScoreItem{
 			{
 				Name:  util.HostedClusterScoresScoreName,
-				Value: int32(len(hcList.Items)),
+				Value: int32(hcCount),
 			},
 		}
 
@@ -548,20 +549,20 @@ func (c *agentController) SyncAddOnPlacementScore(ctx context.Context) error {
 			return err
 		}
 
-		c.log.Info(fmt.Sprintf("updated the addOnPlacementScore for %s: %v", c.clusterName, len(hcList.Items)))
+		c.log.Info(fmt.Sprintf("updated the addOnPlacementScore for %s: %v", c.clusterName, hcCount))
 
 		// Based on the new HC count, update the zero, threshold, full cluster claim values.
-		if err := c.createHostedClusterFullClusterClaim(ctx, len(hcList.Items)); err != nil {
+		if err := c.createHostedClusterFullClusterClaim(ctx, hcCount); err != nil {
 			c.log.Error(err, "failed to create or update hosted cluster full cluster claim")
 			return err
 		}
 
-		if err = c.createHostedClusterThresholdClusterClaim(ctx, len(hcList.Items)); err != nil {
+		if err = c.createHostedClusterThresholdClusterClaim(ctx, hcCount); err != nil {
 			c.log.Error(err, "failed to create or update hosted cluster threshold cluster claim")
 			return err
 		}
 
-		if err = c.createHostedClusterZeroClusterClaim(ctx, len(hcList.Items)); err != nil {
+		if err = c.createHostedClusterZeroClusterClaim(ctx, hcCount); err != nil {
 			c.log.Error(err, "failed to create hosted cluster zero cluster claim")
 			return err
 		}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -153,12 +153,6 @@ func (o *AgentOptions) runControllerManager(ctx context.Context) error {
 		spokeClustersClient: spokeClusterClient,
 	}
 
-	maxHCNum, thresholdHCNum := aCtrl.getMaxAndThresholdHCCount()
-	aCtrl.maxHostedClusterCount = maxHCNum
-	aCtrl.thresholdHostedClusterCount = thresholdHCNum
-	log.Info("the maximum hosted cluster count set to " + strconv.Itoa(aCtrl.maxHostedClusterCount))
-	log.Info("the threshold hosted cluster count set to " + strconv.Itoa(aCtrl.thresholdHostedClusterCount))
-
 	o.Log = o.Log.WithName("agent-reconciler")
 	aCtrl.plugInOption(o)
 
@@ -189,6 +183,12 @@ func (o *AgentOptions) runControllerManager(ctx context.Context) error {
 	if err := aCtrl.createManagementClusterClaim(ctx); err != nil {
 		return fmt.Errorf("unable to create management cluster claim, err: %w", err)
 	}
+
+	maxHCNum, thresholdHCNum := aCtrl.getMaxAndThresholdHCCount()
+	aCtrl.maxHostedClusterCount = maxHCNum
+	aCtrl.thresholdHostedClusterCount = thresholdHCNum
+	log.Info("the maximum hosted cluster count set to " + strconv.Itoa(aCtrl.maxHostedClusterCount))
+	log.Info("the threshold hosted cluster count set to " + strconv.Itoa(aCtrl.thresholdHostedClusterCount))
 
 	err = aCtrl.SyncAddOnPlacementScore(ctx)
 	if err != nil {

--- a/pkg/agent/clusterclaim.go
+++ b/pkg/agent/clusterclaim.go
@@ -24,9 +24,9 @@ const (
 
 	hypershiftManagementClusterClaimKey             = "hostingcluster.hypershift.openshift.io"
 	hypershiftHostedClusterClaimKey                 = "hostedcluster.hypershift.openshift.io"
-	hostedClusterCountFullClusterClaimKey           = "hostedclustercount.full.hypershift.openshift.io"
-	hostedClusterCountAboveThresholdClusterClaimKey = "hostedclustercount.above.threshold.hypershift.openshift.io"
-	hostedClusterCountZeroClusterClaimKey           = "hostedclustercount.zero.hypershift.openshift.io"
+	hostedClusterCountFullClusterClaimKey           = "full.hostedclustercount.hypershift.openshift.io"
+	hostedClusterCountAboveThresholdClusterClaimKey = "above.threshold.hostedclustercount.hypershift.openshift.io"
+	hostedClusterCountZeroClusterClaimKey           = "zero.hostedclustercount.hypershift.openshift.io"
 )
 
 func newClusterClaim(name, value string) *clusterv1alpha1.ClusterClaim {
@@ -129,7 +129,7 @@ func generateClusterClientFromSecret(secret *corev1.Secret) (clusterclientset.In
 // Both max and threshold numbers should be valid positive integer numbers and max >= threshold.
 // If not, they default to 80 max and 60 threshold.
 func (c *agentController) getMaxAndThresholdHCCount() (int, int) {
-	maxNum := 80
+	maxNum := util.DefaultMaxHostedClusterCount
 	envMax := os.Getenv("HC_MAX_NUMBER")
 	if envMax == "" {
 		c.log.Info("env variable HC_MAX_NUMBER not found, defaulting to 80")
@@ -138,15 +138,15 @@ func (c *agentController) getMaxAndThresholdHCCount() (int, int) {
 	maxNum, err := strconv.Atoi(envMax)
 	if err != nil {
 		c.log.Error(nil, fmt.Sprintf("failed to convert env variable HC_MAX_NUMBER %s to integer, defaulting to 80", envMax))
-		maxNum = 80
+		maxNum = util.DefaultMaxHostedClusterCount
 	}
 
 	if maxNum < 1 {
 		c.log.Error(nil, fmt.Sprintf("invalid HC_MAX_NUMBER %s, defaulting to 80", envMax))
-		maxNum = 80
+		maxNum = util.DefaultMaxHostedClusterCount
 	}
 
-	thresholdNum := 60
+	thresholdNum := util.DefaultThresholdHostedClusterCount
 	envThreshold := os.Getenv("HC_THRESHOLD_NUMBER")
 	if envThreshold == "" {
 		c.log.Info("env variable HC_THRESHOLD_NUMBER not found, defaulting to 60")
@@ -155,20 +155,20 @@ func (c *agentController) getMaxAndThresholdHCCount() (int, int) {
 	thresholdNum, err = strconv.Atoi(envThreshold)
 	if err != nil {
 		c.log.Error(nil, fmt.Sprintf("failed to convert env variable HC_THRESHOLD_NUMBER %s to integer, defaulting to 60", envThreshold))
-		thresholdNum = 60
+		thresholdNum = util.DefaultThresholdHostedClusterCount
 	}
 
 	if thresholdNum < 1 {
 		c.log.Error(nil, fmt.Sprintf("invalid HC_MAX_NUMBER %s, defaulting to 60", envThreshold))
-		thresholdNum = 60
+		thresholdNum = util.DefaultThresholdHostedClusterCount
 	}
 
 	if maxNum < thresholdNum {
 		c.log.Error(nil, fmt.Sprintf(
 			"invalid HC_MAX_NUMBER %s HC_THRESHOLD_NUMBER %s: HC_MAX_NUMBER must be equal or bigger than HC_THRESHOLD_NUMBER, defaulting to 80 and 60 for max and threshold counts",
 			envMax, envThreshold))
-		maxNum = 80
-		thresholdNum = 60
+		maxNum = util.DefaultMaxHostedClusterCount
+		thresholdNum = util.DefaultThresholdHostedClusterCount
 	}
 
 	return maxNum, thresholdNum

--- a/pkg/agent/clusterclaim.go
+++ b/pkg/agent/clusterclaim.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
 
@@ -21,9 +22,11 @@ const (
 	// labelExcludeBackup is true for the local-cluster will not be backed up into velero
 	labelExcludeBackup = "velero.io/exclude-from-backup"
 
-	hypershiftManagementClusterClaimKey   = "hostingcluster.hypershift.openshift.io"
-	hypershiftHostedClusterClaimKey       = "hostedcluster.hypershift.openshift.io"
-	hostedClusterCountFullClusterClaimKey = "hostedclustercount.full.hypershift.openshift.io"
+	hypershiftManagementClusterClaimKey             = "hostingcluster.hypershift.openshift.io"
+	hypershiftHostedClusterClaimKey                 = "hostedcluster.hypershift.openshift.io"
+	hostedClusterCountFullClusterClaimKey           = "hostedclustercount.full.hypershift.openshift.io"
+	hostedClusterCountAboveThresholdClusterClaimKey = "hostedclustercount.above.threshold.hypershift.openshift.io"
+	hostedClusterCountZeroClusterClaimKey           = "hostedclustercount.zero.hypershift.openshift.io"
 )
 
 func newClusterClaim(name, value string) *clusterv1alpha1.ClusterClaim {
@@ -55,6 +58,7 @@ func createOrUpdate(ctx context.Context, client clusterclientset.Interface, newC
 			return fmt.Errorf("unable to update ClusterClaim %q: %w", oldClaim.Name, err)
 		}
 	}
+
 	return nil
 }
 
@@ -63,14 +67,24 @@ func (c *agentController) createManagementClusterClaim(ctx context.Context) erro
 	return createOrUpdate(ctx, c.spokeClustersClient, managementClaim)
 }
 
-func (c *agentController) createHostedClusterCountClusterClaim(ctx context.Context, count int) error {
-	if count >= util.MaxHostedClusterCount {
-		c.log.Info(fmt.Sprintf("ATTENTION: the hosted cluster count has reached the maximum %s.", strconv.Itoa(util.MaxHostedClusterCount)))
+func (c *agentController) createHostedClusterFullClusterClaim(ctx context.Context, count int) error {
+	if count >= c.maxHostedClusterCount {
+		c.log.Info(fmt.Sprintf("ATTENTION: the hosted cluster count has reached the maximum %s.", strconv.Itoa(c.maxHostedClusterCount)))
 	} else {
-		c.log.Info(fmt.Sprintf("the hosted cluster count has not reached the maximum %s yet. current count is %s", strconv.Itoa(util.MaxHostedClusterCount), strconv.Itoa(count)))
+		c.log.Info(fmt.Sprintf("the hosted cluster count has not reached the maximum %s yet. current count is %s", strconv.Itoa(c.maxHostedClusterCount), strconv.Itoa(count)))
 	}
-	managementClaim := newClusterClaim(hostedClusterCountFullClusterClaimKey, strconv.FormatBool(count >= util.MaxHostedClusterCount))
-	return createOrUpdate(ctx, c.spokeClustersClient, managementClaim)
+	hcFullClaim := newClusterClaim(hostedClusterCountFullClusterClaimKey, strconv.FormatBool(count >= c.maxHostedClusterCount))
+	return createOrUpdate(ctx, c.spokeClustersClient, hcFullClaim)
+}
+
+func (c *agentController) createHostedClusterThresholdClusterClaim(ctx context.Context, count int) error {
+	hcThresholdClaim := newClusterClaim(hostedClusterCountAboveThresholdClusterClaimKey, strconv.FormatBool(count >= c.thresholdHostedClusterCount))
+	return createOrUpdate(ctx, c.spokeClustersClient, hcThresholdClaim)
+}
+
+func (c *agentController) createHostedClusterZeroClusterClaim(ctx context.Context, count int) error {
+	hcZeroClaim := newClusterClaim(hostedClusterCountZeroClusterClaimKey, strconv.FormatBool(count == 0))
+	return createOrUpdate(ctx, c.spokeClustersClient, hcZeroClaim)
 }
 
 func (c *agentController) createHostedClusterClaim(ctx context.Context, secretKey types.NamespacedName,
@@ -106,4 +120,56 @@ func generateClusterClientFromSecret(secret *corev1.Secret) (clusterclientset.In
 	}
 
 	return clusterClient, nil
+}
+
+// As the number of hosted cluster count reaches the max and threshold hosted cluster counts
+// are used to generate two cluster claims:
+// "hostedclustercount.above.threshold.hypershift.openshift.io" = true when the count > threshold
+// "hostedclustercount.full.hypershift.openshift.io" = true when the count >= max
+// Both max and threshold numbers should be valid positive integer numbers and max >= threshold.
+// If not, they default to 80 max and 60 threshold.
+func (c *agentController) getMaxAndThresholdHCCount() (int, int) {
+	maxNum := 80
+	envMax := os.Getenv("HC_MAX_NUMBER")
+	if envMax == "" {
+		c.log.Info("env variable HC_MAX_NUMBER not found, defaulting to 80")
+	}
+
+	maxNum, err := strconv.Atoi(envMax)
+	if err != nil {
+		c.log.Error(nil, fmt.Sprintf("failed to convert env variable HC_MAX_NUMBER %s to integer, defaulting to 80", envMax))
+		maxNum = 80
+	}
+
+	if maxNum < 1 {
+		c.log.Error(nil, fmt.Sprintf("invalid HC_MAX_NUMBER %s, defaulting to 80", envMax))
+		maxNum = 80
+	}
+
+	thresholdNum := 60
+	envThreshold := os.Getenv("HC_THRESHOLD_NUMBER")
+	if envThreshold == "" {
+		c.log.Info("env variable HC_THRESHOLD_NUMBER not found, defaulting to 60")
+	}
+
+	thresholdNum, err = strconv.Atoi(envThreshold)
+	if err != nil {
+		c.log.Error(nil, fmt.Sprintf("failed to convert env variable HC_THRESHOLD_NUMBER %s to integer, defaulting to 60", envThreshold))
+		thresholdNum = 60
+	}
+
+	if thresholdNum < 1 {
+		c.log.Error(nil, fmt.Sprintf("invalid HC_MAX_NUMBER %s, defaulting to 60", envThreshold))
+		thresholdNum = 60
+	}
+
+	if maxNum < thresholdNum {
+		c.log.Error(nil, fmt.Sprintf(
+			"invalid HC_MAX_NUMBER %s HC_THRESHOLD_NUMBER %s: HC_MAX_NUMBER must be equal or bigger than HC_THRESHOLD_NUMBER, defaulting to 80 and 60 for max and threshold counts",
+			envMax, envThreshold))
+		maxNum = 80
+		thresholdNum = 60
+	}
+
+	return maxNum, thresholdNum
 }

--- a/pkg/agent/clusterclaim.go
+++ b/pkg/agent/clusterclaim.go
@@ -124,8 +124,8 @@ func generateClusterClientFromSecret(secret *corev1.Secret) (clusterclientset.In
 
 // As the number of hosted cluster count reaches the max and threshold hosted cluster counts
 // are used to generate two cluster claims:
-// "hostedclustercount.above.threshold.hypershift.openshift.io" = true when the count > threshold
-// "hostedclustercount.full.hypershift.openshift.io" = true when the count >= max
+// "above.threshold.hostedclustercount.hypershift.openshift.io" = true when the count > threshold
+// "full.hostedclustercount.hypershift.openshift.io" = true when the count >= max
 // Both max and threshold numbers should be valid positive integer numbers and max >= threshold.
 // If not, they default to 80 max and 60 threshold.
 func (c *agentController) getMaxAndThresholdHCCount() (int, int) {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -125,12 +125,12 @@ func NewManagerCommand(componentName string, log logr.Logger) *cobra.Command {
 			os.Exit(1)
 		}
 
-		/*err = EnableHypershiftCLIDownload(hubClient, log)
+		err = EnableHypershiftCLIDownload(hubClient, log)
 		if err != nil {
 			// unable to install HypershiftCLIDownload is not critical.
 			// log and continue
 			log.Error(err, "failed to enable hypershift CLI download")
-		}*/
+		}
 
 		<-ctx.Done()
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -125,12 +125,12 @@ func NewManagerCommand(componentName string, log logr.Logger) *cobra.Command {
 			os.Exit(1)
 		}
 
-		err = EnableHypershiftCLIDownload(hubClient, log)
+		/*err = EnableHypershiftCLIDownload(hubClient, log)
 		if err != nil {
 			// unable to install HypershiftCLIDownload is not critical.
 			// log and continue
 			log.Error(err, "failed to enable hypershift CLI download")
-		}
+		}*/
 
 		<-ctx.Done()
 

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -73,8 +73,10 @@ const (
 	// AddOnPlacementScore score name
 	HostedClusterScoresScoreName = "hostedClustersCount"
 
-	// Maximum hosted cluster count on a hosting cluster
-	MaxHostedClusterCount = 80
+	// Default xaximum hosted cluster count on a hosting cluster
+	DefaultMaxHostedClusterCount = 80
+	// Default threshold hosted cluster count on a hosting cluster
+	DefaultThresholdHostedClusterCount = 60
 )
 
 // GenerateClientConfigFromSecret generate a client config from a given secret


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Cluster claim `hostedclustercount.above.threshold.hypershift.openshift.io` was added to indicate that the number of HCs on a hosting cluster exceeding the threshold number
*  Cluster claim `hostedclustercount.zero.hypershift.openshift.io` was added to indicate that there is no hosted cluster on a hosting cluster
* The max and threshold numbers are configurable
* Documented these
* This PR goes with https://github.com/stolostron/backplane-operator/pull/356

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Better scheduling of a hosted cluster

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-2266

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?   	github.com/stolostron/hypershift-addon-operator/cmd	[no test files]
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	20.603s	coverage: 72.5% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	137.432s	coverage: 85.9% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	0.572s	coverage: 48.8% of statements
?   	github.com/stolostron/hypershift-addon-operator/pkg/util	[no test files]

```
