### PR TITLE
External managed kubeconfig secret support for custom api server port

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -51,8 +51,9 @@ func TestReconcile(t *testing.T) {
 		secData := map[string][]byte{}
 		secData["kubeconfig"] = []byte(`apiVersion: v1
 clusters:
-- name: cluster
-  server: https://kube-apiserver.ocm-dev-1sv4l4ldnr6rd8ni12ndo4vtiq2gd7a4-sbarouti267.svc.cluster.local:6443
+- cluster:
+    server: https://kube-apiserver.ocm-dev-1sv4l4ldnr6rd8ni12ndo4vtiq2gd7a4-sbarouti267.svc.cluster.local:7443
+  name: cluster
 contexts:
 - context:
     cluster: cluster
@@ -91,7 +92,7 @@ kind: Config`)
 
 	kubeconfig, err := clientcmd.Load(secret.Data["kubeconfig"])
 	assert.Nil(t, err, "is nil when kubeconfig data can be loaded")
-	assert.Equal(t, kubeconfig.Clusters["cluster"].Server, "https://kube-apiserver."+hc.Namespace+"-"+hc.Name+".svc.cluster.local:6443")
+	assert.Equal(t, kubeconfig.Clusters["cluster"].Server, "https://kube-apiserver."+hc.Namespace+"-"+hc.Name+".svc.cluster.local:7443")
 
 	// Delete hosted cluster and reconcile
 	aCtrl.hubClient.Delete(ctx, hc)
@@ -128,8 +129,9 @@ func TestReconcileWithAnnotation(t *testing.T) {
 		secData := map[string][]byte{}
 		secData["kubeconfig"] = []byte(`apiVersion: v1
 clusters:
-- name: cluster
-  server: https://kube-apiserver.ocm-dev-1sv4l4ldnr6rd8ni12ndo4vtiq2gd7a4-sbarouti267.svc.cluster.local:6443
+- cluster:
+    server: https://kube-apiserver.ocm-dev-1sv4l4ldnr6rd8ni12ndo4vtiq2gd7a4-sbarouti267.svc.cluster.local:6443
+  name: cluster	
 contexts:
 - context:
     cluster: cluster


### PR DESCRIPTION
Signed-off-by: Philip Wu <phwu@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* The external managed kubeconfig secret's server URL is currently hardcoded to use port 6443. Instead, it should use the same port in the admin-kubconfig secret's server URL.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  This change will support the scenario for the apiserver to use the non-default port of 6443.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-2311

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	19.557s	coverage: 72.7% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	137.138s	coverage: 86.6% of statements

```
