### PR TITLE
Rename CLI to hypershift

### DIFF
--- a/docs/installing_hypershift_cli.md
+++ b/docs/installing_hypershift_cli.md
@@ -4,7 +4,7 @@
 
 The Hypershift Hosted Control Plane command-line interface (CLI) is an `oc` command-line [plugin](https://docs.openshift.com/container-platform/4.11/cli_reference/openshift_cli/extending-cli-plugins.html), that allows you to create OpenShift hosted control plane clusters and manage them.
 
-## Installing the Hosted Control Plane CLI
+## Installing the Hypershift Hosted Control Plane CLI
 
 1. [Enable the Hypershift hosted control plane feature](https://github.com/stolostron/hypershift-addon-operator/blob/main/docs/provision_hosted_cluster_on_mce_local_cluster.md#configuring-the-hosting-service-cluster)
 
@@ -16,19 +16,22 @@ The Hypershift Hosted Control Plane command-line interface (CLI) is an `oc` comm
     $ tar xvzf hypershift.tar.gz
 ```
 
-4. Rename `hypershift` to `oc-hcp` to make it an `oc` command-line [plugin](https://docs.openshift.com/container-platform/4.11/cli_reference/openshift_cli/extending-cli-plugins.html). `hcp` stands for `Hosted Control Plane`.
+4. Copy the `hypershift` CLI binary file to a directory in your PATH.
 
 ```
-    $ sudo mv hypershift oc-hcp
+    $ chmod +x hypershift
+    $ sudo mv hypershift /usr/local/bin/.
 ```
 
-5. Follow the [oc plugin instructions](https://docs.openshift.com/container-platform/4.11/cli_reference/openshift_cli/extending-cli-plugins.html#cli-installing-plugins_cli-extend-plugins) to bind the `oc-hcp` plugin to a directory in your PATH.
+After you install the Hypershift Hosted Control Plane CLI, you can start using the `hypershift create cluster` command to create and manage hosted clusters. For more information on the CLI usage, see [this](https://hypershift-docs.netlify.app/getting-started/#create-a-hostedcluster/)
+
 
 ```
-    $ chmod +x oc-hcp
-    $ sudo mv oc-hcp /usr/local/bin/.
+hypershift create cluster aws --name $CLUSTER_NAME --namespace $NAMESPACE --node-pool-replicas=3 --secret-creds $SECRET_CREDS --region $REGION
 ```
 
-After you install the Hypershift Hosted Control Plane CLI, you can start using the `oc hcp ...` command. For more information on the CLI usage, see [this](https://hypershift-docs.netlify.app/getting-started/)
+For all available parameters and their descriptions, run
 
-**Note: `oc hcp` is the command. For example, `oc hcp create cluster ...`
+```
+hypershift create cluster aws --help
+```

--- a/pkg/manager/cli_download_install.go
+++ b/pkg/manager/cli_download_install.go
@@ -270,23 +270,23 @@ func getConsoleDownload(routeUrl string, log logr.Logger) (*consolev1.ConsoleCLI
 	links := []consolev1.CLIDownloadLink{
 		{
 			Href: "https://" + routeUrl + "/linux/amd64/hypershift.tar.gz",
-			Text: "Download oc hcp for Linux for x86_64",
+			Text: "Download hypershift CLI for Linux for x86_64",
 		},
 		{
 			Href: "https://" + routeUrl + "/darwin/amd64/hypershift.tar.gz",
-			Text: "Download oc hcp for Mac for x86_64",
+			Text: "Download hypershift CLI for Mac for x86_64",
 		},
 		{
 			Href: "https://" + routeUrl + "/windows/amd64/hypershift.tar.gz",
-			Text: "Download oc hcp for Windows for x86_64",
+			Text: "Download hypershift CLI for Windows for x86_64",
 		},
 		{
 			Href: "https://" + routeUrl + "/linux/arm64/hypershift.tar.gz",
-			Text: "Download oc hcp for Linux for ARM 64",
+			Text: "Download hypershift CLI for Linux for ARM 64",
 		},
 		{
 			Href: "https://" + routeUrl + "/darwin/arm64/hypershift.tar.gz",
-			Text: "Download oc hcp for Mac for ARM 64",
+			Text: "Download hypershift CLI for Mac for ARM 64",
 		},
 	}
 	cliDownload.Spec.Links = links

--- a/pkg/manager/manifests/cli/consoledownload.yaml
+++ b/pkg/manager/manifests/cli/consoledownload.yaml
@@ -7,4 +7,4 @@ spec:
     With the Hosted Openshift Control Plane command line interface, you can create and manage hosted OpenShift control planes.
 
 
-  displayName: oc hcp - Hosted Openshift Control Plane (HyperShift) Command Line Interface (CLI)
+  displayName: hypershift - Hosted Openshift Control Plane (HyperShift) Command Line Interface (CLI)


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Renaming the CLI name from `oc hcp` to `hypershift` to be consistent with upstream documentation and command line help.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Consistency

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* 

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
