### PR TITLE
Set node affinity for HS cli deployment to infra node role

### DIFF
--- a/pkg/manager/manifests/cli/deployment.yaml
+++ b/pkg/manager/manifests/cli/deployment.yaml
@@ -31,6 +31,12 @@ spec:
                 - ppc64le
                 - s390x
                 - arm64
+          preferredDuringSchedulingIgnoredDuringExecution: 
+          - weight: 1
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/infra
+                operator: Exists                     
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - podAffinityTerm:


### PR DESCRIPTION
Signed-off-by: Philip Wu <phwu@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Set the preferred node affinity for the hypershift-cli-deployment so that the pod is deployed on the infra nodes

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  The hypershift-cli-deployment could be deployed on any worker node without the preferred node affinity. The deployment spec has a toleration for the infra node role, however, this requires the node to have a corresponding taint.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-2402

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
