### PR TITLE
fix enabling RHOBS on hypershift operator

### DIFF
--- a/docs/enable_hypershift_operator_RHOBS.md
+++ b/docs/enable_hypershift_operator_RHOBS.md
@@ -53,10 +53,10 @@ In the hub cluster, the status section of the hypershift-addon `ManagedClusterAd
     resource: addondeploymentconfigs
 ```
 
-In the hosting cluster, check the `hypershift-addon-agent` deployment in `open-cluster-management-agent-addon` namespace to ensure that the environment variable `ENABLE_RHOBS_MONITORING` is set to true.
+In the hosting cluster, check the `hypershift-addon-agent` deployment in `open-cluster-management-agent-addon` namespace to ensure that the environment variable `RHOBS_MONITORING` is set to true.
 
 ```
         env:
-        - name: ENABLE_RHOBS_MONITORING
+        - name: RHOBS_MONITORING
           value: "true"
 ```

--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -308,8 +308,8 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 	args = append(args, telemetryArgs...)
 
 	// Enable RHOBS
-	if strings.EqualFold(os.Getenv("ENABLE_RHOBS_MONITORING"), "true") {
-		c.log.Info("ENABLE_RHOBS_MONITORING=true, adding --rhobs-monitoring=true")
+	if strings.EqualFold(os.Getenv("RHOBS_MONITORING"), "true") {
+		c.log.Info("RHOBS_MONITORING=true, adding --rhobs-monitoring=true")
 		rhobsArgs := []string{
 			"--rhobs-monitoring",
 			"true",

--- a/pkg/install/hypershift_test.go
+++ b/pkg/install/hypershift_test.go
@@ -968,8 +968,8 @@ func TestRunHypershiftInstallEnableRHOBS(t *testing.T) {
 	aCtrl.hubClient.Create(ctx, dp)
 	defer aCtrl.hubClient.Delete(ctx, dp)
 
-	os.Setenv("ENABLE_RHOBS_MONITORING", "true")
-	defer os.Unsetenv("ENABLE_RHOBS_MONITORING")
+	os.Setenv("RHOBS_MONITORING", "true")
+	defer os.Unsetenv("RHOBS_MONITORING")
 
 	err := installHyperShiftOperator(t, ctx, aCtrl, false)
 	defer deleteAllInstallJobs(ctx, aCtrl.spokeUncachedClient, aCtrl.addonNamespace)
@@ -988,8 +988,8 @@ func TestRunHypershiftInstallEnableRHOBS(t *testing.T) {
 				"--hypershift-image", "my-test-image",
 			}
 			assert.Equal(t, expectArgs, installJob.Spec.Template.Spec.Containers[0].Args, "mismatched container arguments")
-			assert.Equal(t, "ENABLE_RHOBS_MONITORING", installJob.Spec.Template.Spec.Containers[0].Env[0].Name, "ENABLE_RHOBS_MONITORING environment variable should exist")
-			assert.Equal(t, "1", installJob.Spec.Template.Spec.Containers[0].Env[0].Value, "ENABLE_RHOBS_MONITORING environment variable value should be 1")
+			assert.Equal(t, "RHOBS_MONITORING", installJob.Spec.Template.Spec.Containers[0].Env[0].Name, "RHOBS_MONITORING environment variable should exist")
+			assert.Equal(t, "1", installJob.Spec.Template.Spec.Containers[0].Env[0].Value, "RHOBS_MONITORING environment variable value should be 1")
 		}
 	}
 

--- a/pkg/install/install_job.go
+++ b/pkg/install/install_job.go
@@ -34,10 +34,10 @@ func (c *UpgradeController) runHyperShiftInstallJob(ctx context.Context, image, 
 	}
 
 	// Enable RHOBS
-	if strings.EqualFold(os.Getenv("ENABLE_RHOBS_MONITORING"), "true") {
+	if strings.EqualFold(os.Getenv("RHOBS_MONITORING"), "true") {
 		jobPodSpec.Containers[0].Env = []corev1.EnvVar{
 			{
-				Name:  "ENABLE_RHOBS_MONITORING",
+				Name:  "RHOBS_MONITORING",
 				Value: "1",
 			},
 		}

--- a/pkg/manager/manifests/templates/deployment.yaml
+++ b/pkg/manager/manifests/templates/deployment.yaml
@@ -80,7 +80,7 @@ spec:
           containerPort: 8383
 {{- end }}
 {{- if .enableRHOBSMonitoring }}
-        - name: ENABLE_RHOBS_MONITORING
+        - name: RHOBS_MONITORING
           value: "{{ .enableRHOBSMonitoring }}"
 {{- end }}
         volumeMounts:


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* The addon agent used wrong environment variable ENABLE_RHOBS_MONITORING which caused the hypershift operator installation to fail in SD environment.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-2492

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
