### PR TITLE
requeue reconcile for klusterlet secrets

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -303,11 +303,12 @@ func (c *agentController) generateExtManagedKubeconfigSecret(ctx context.Context
 	kubeconfigData := secretData["kubeconfig"]
 
 	klusterletNamespace := &corev1.Namespace{}
-	klusterletNamespaceNN := types.NamespacedName{Name: "klusterlet-" + managedClusterAnnoValue}
+	klusterletNamespaceNsn := types.NamespacedName{Name: "klusterlet-" + managedClusterAnnoValue}
 
-	err := c.spokeClient.Get(context.TODO(), klusterletNamespaceNN, klusterletNamespace)
+	err := c.spokeClient.Get(ctx, klusterletNamespaceNsn, klusterletNamespace)
 	if err != nil {
-		return fmt.Errorf("failed to find the klusterlet namespace: %s", klusterletNamespaceNN.Name)
+		c.log.Error(err, "failed to find the klusterlet namespace: %s", klusterletNamespaceNsn.Name)
+		return err
 	}
 
 	if kubeconfigData == nil {
@@ -425,7 +426,7 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	}
 
 	if !hc.GetDeletionTimestamp().IsZero() {
-		c.log.Info(fmt.Sprintf("hostedcluster %s has deletionTimestamp %s. Skip reconciling klusterlet secrets", hc.Name, hc.GetDeletionTimestamp()))
+		c.log.Info(fmt.Sprintf("hostedcluster %s has deletionTimestamp %s. Skip reconciling klusterlet secrets", hc.Name, hc.GetDeletionTimestamp().String()))
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -307,8 +307,8 @@ func (c *agentController) generateExtManagedKubeconfigSecret(ctx context.Context
 
 	err := c.spokeClient.Get(ctx, klusterletNamespaceNsn, klusterletNamespace)
 	if err != nil {
-		c.log.Error(err, "failed to find the klusterlet namespace: %s", klusterletNamespaceNsn.Name)
-		return err
+		c.log.Error(err, fmt.Sprintf("failed to find the klusterlet namespace: %s ", klusterletNamespaceNsn.Name))
+		return fmt.Errorf("failed to find the klusterlet namespace: %s", klusterletNamespaceNsn.Name)
 	}
 
 	if kubeconfigData == nil {
@@ -318,17 +318,17 @@ func (c *agentController) generateExtManagedKubeconfigSecret(ctx context.Context
 	kubeconfig, err := clientcmd.Load(kubeconfigData)
 
 	if err != nil {
-		c.log.Error(err, "failed to load kubeconfig from secret: %s", secret.GetName())
+		c.log.Error(err, fmt.Sprintf("failed to load kubeconfig from secret: %s", secret.GetName()))
 		return fmt.Errorf("failed to load kubeconfig from secret: %s", secret.GetName())
 	}
 
 	if len(kubeconfig.Clusters) == 0 {
-		c.log.Error(err, "there is no cluster in kubeconfig from secret: %s", secret.GetName())
+		c.log.Error(err, fmt.Sprintf("there is no cluster in kubeconfig from secret: %s", secret.GetName()))
 		return fmt.Errorf("there is no cluster in kubeconfig from secret: %s", secret.GetName())
 	}
 
 	if kubeconfig.Clusters["cluster"] == nil {
-		c.log.Error(err, "failed to get a cluster from kubeconfig in secret: %s", secret.GetName())
+		c.log.Error(err, fmt.Sprintf("failed to get a cluster from kubeconfig in secret: %s", secret.GetName()))
 		return fmt.Errorf("failed to get a cluster from kubeconfig in secret: %s", secret.GetName())
 	}
 
@@ -347,7 +347,7 @@ func (c *agentController) generateExtManagedKubeconfigSecret(ctx context.Context
 	newKubeconfig, err := clientcmd.Write(*kubeconfig)
 
 	if err != nil {
-		c.log.Error(err, "failed to write new kubeconfig to secret: %s", secret.GetName())
+		c.log.Error(err, fmt.Sprintf("failed to write new kubeconfig to secret: %s", secret.GetName()))
 		return fmt.Errorf("failed to write new kubeconfig to secret: %s", secret.GetName())
 	}
 
@@ -387,7 +387,7 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			},
 		})
 		if err != nil {
-			c.log.Error(err, "failed to convert label to get secrets on hub for hostedCluster: %s", req)
+			c.log.Error(err, fmt.Sprintf("failed to convert label to get secrets on hub for hostedCluster: %s", req))
 			return err
 		}
 
@@ -397,7 +397,7 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		hcHubSecretList := &corev1.SecretList{}
 		err = c.hubClient.List(ctx, hcHubSecretList, listopts)
 		if err != nil {
-			c.log.Error(err, "failed to get secrets on hub for hostedCluster: %s", req)
+			c.log.Error(err, fmt.Sprintf("failed to get secrets on hub for hostedCluster: %s", req))
 			return err
 		}
 

--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -650,7 +650,7 @@ func (c *UpgradeController) operatorImagesUpdated(im []byte, operatorDeployment 
 
 	imObj := &imageapi.ImageStream{}
 	if err := yaml.Unmarshal(im, imObj); err != nil {
-		c.log.Error(err, "failed to get image stream content: ", err.Error())
+		c.log.Error(err, "failed to get image stream content")
 		return false
 	}
 
@@ -717,7 +717,7 @@ func (c *UpgradeController) secretDataUpdated(secretName string, secret corev1.S
 	secretKey := types.NamespacedName{Name: secretName, Namespace: c.addonNamespace}
 	localSecret := &corev1.Secret{}
 	if err := c.spokeUncachedClient.Get(context.TODO(), secretKey, localSecret); err != nil && !apierrors.IsNotFound(err) {
-		c.log.Error(err, "failed to find secret: ", err.Error()) // just log and continue
+		c.log.Error(err, "failed to find secret:") // just log and continue
 	}
 
 	if !reflect.DeepEqual(localSecret.Data, secret.Data) { // compare only the secret data


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* When the agent reconcile fails to create external-managed-kubeconfig secret in the hosted cluster's klusterlet namespace or hub mirror secret, requeue the reconcile until it succeeds.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
* This fixes the current assumption that the klusterlet is available when the hosted control plane becomes available.
* This fixes the current assumption that a managed cluster is created before a hosted cluster. 

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-2208

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
KUBEBUILDER_ASSETS="/Users/rokej/Library/Application Support/io.kubebuilder.envtest/k8s/1.22.1-darwin-amd64" go test github.com/stolostron/hypershift-addon-operator/cmd github.com/stolostron/hypershift-addon-operator/pkg/agent github.com/stolostron/hypershift-addon-operator/pkg/install github.com/stolostron/hypershift-addon-operator/pkg/manager github.com/stolostron/hypershift-addon-operator/pkg/metrics github.com/stolostron/hypershift-addon-operator/pkg/util -coverprofile cover.out
?   	github.com/stolostron/hypershift-addon-operator/cmd	[no test files]
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	15.990s	coverage: 71.6% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	147.267s	coverage: 86.3% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	1.341s	coverage: 56.0% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	0.541s	coverage: 100.0% of statements
?   	github.com/stolostron/hypershift-addon-operator/pkg/util	[no test files]

```
