### PR TITLE
set hypershift metrics set differently for RHOBS

### DIFF
--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -309,10 +309,12 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 
 	// Enable RHOBS
 	if strings.EqualFold(os.Getenv("RHOBS_MONITORING"), "true") {
-		c.log.Info("RHOBS_MONITORING=true, adding --rhobs-monitoring=true")
+		c.log.Info("RHOBS_MONITORING=true, adding --rhobs-monitoring true --metrics-set SRE")
 		rhobsArgs := []string{
 			"--rhobs-monitoring",
 			"true",
+			"--metrics-set",
+			"SRE",
 		}
 		args = append(args, rhobsArgs...)
 	}

--- a/pkg/install/hypershift_test.go
+++ b/pkg/install/hypershift_test.go
@@ -985,6 +985,7 @@ func TestRunHypershiftInstallEnableRHOBS(t *testing.T) {
 				"--enable-uwm-telemetry-remote-write",
 				"--platform-monitoring", "OperatorOnly",
 				"--rhobs-monitoring", "true",
+				"--metrics-set", "SRE",
 				"--hypershift-image", "my-test-image",
 			}
 			assert.Equal(t, expectArgs, installJob.Spec.Template.Spec.Containers[0].Args, "mismatched container arguments")


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Set this when RHOBS monitoring is enabled to expose more metrics in SD environment.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-2676

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
