### PR TITLE
Change cleanup of Hypershift operator install job to 48 hrs

### DIFF
--- a/pkg/install/install_job.go
+++ b/pkg/install/install_job.go
@@ -77,7 +77,7 @@ func (c *UpgradeController) runHyperShiftInstallJob(ctx context.Context, image, 
 
 	backoffLimit := int32(3)
 	activeDeadlineSeconds := int64(600)
-	ttlSecondsAfterFinished := int32(300)
+	ttlSecondsAfterFinished := int32(172800) // 48 hrs
 	job := &kbatch.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: util.HypershiftInstallJobName,


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* The installation job and pods were automatically cleaned-up after 5 mins. This time is extended to 48 hrs with the latest change.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Users may need more time to investigate the failure, but the installation logs may be cleaned-up already. Extending the time to 48 hrs will give users more time to investigate.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-2680

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
Signed-off-by: Philip Wu <phwu@redhat.com>

