### PR TITLE
enable RHOBS monitoring and fix api server port

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/clientcmd"
 	clustercsfake "open-cluster-management.io/api/client/cluster/clientset/versioned/fake"
 	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
@@ -71,9 +72,34 @@ kind: Config`)
 		defer aCtrl.hubClient.Delete(ctx, sec)
 	}
 
+	apiService := &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-apiserver",
+			Namespace: "clusters-hd-1",
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:     "https",
+					Port:     443,
+					Protocol: "TCP",
+					TargetPort: intstr.IntOrString{
+						IntVal: 6443,
+					},
+				},
+			},
+		},
+	}
+	err := aCtrl.hubClient.Create(ctx, apiService)
+	assert.Nil(t, err, "err nil when kube-apiserver service is created successfully")
+
 	// Create hosted cluster
 	hc := getHostedCluster(hcNN)
-	err := aCtrl.hubClient.Create(ctx, hc)
+	err = aCtrl.hubClient.Create(ctx, hc)
 	assert.Nil(t, err, "err nil when hosted cluster is created successfully")
 
 	// Create klusterlet namespace
@@ -106,7 +132,7 @@ kind: Config`)
 
 	kubeconfig, err := clientcmd.Load(secret.Data["kubeconfig"])
 	assert.Nil(t, err, "is nil when kubeconfig data can be loaded")
-	assert.Equal(t, kubeconfig.Clusters["cluster"].Server, "https://kube-apiserver."+hc.Namespace+"-"+hc.Name+".svc.cluster.local:7443")
+	assert.Equal(t, kubeconfig.Clusters["cluster"].Server, "https://kube-apiserver."+hc.Namespace+"-"+hc.Name+".svc.cluster.local:443")
 
 	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.KubeconfigSecretCopyFailureCount))
 	assert.Equal(t, float64(1), testutil.ToFloat64(metrics.TotalHostedClusterGauge))

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -96,6 +96,7 @@ kind: Config`)
 	}
 	err := aCtrl.hubClient.Create(ctx, apiService)
 	assert.Nil(t, err, "err nil when kube-apiserver service is created successfully")
+	defer aCtrl.hubClient.Delete(ctx, apiService)
 
 	// Create hosted cluster
 	hc := getHostedCluster(hcNN)
@@ -189,9 +190,35 @@ kind: Config`)
 		defer aCtrl.hubClient.Delete(ctx, sec)
 	}
 
+	apiService := &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-apiserver",
+			Namespace: "clusters-hd-1",
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:     "https",
+					Port:     443,
+					Protocol: "TCP",
+					TargetPort: intstr.IntOrString{
+						IntVal: 6443,
+					},
+				},
+			},
+		},
+	}
+	err := aCtrl.hubClient.Create(ctx, apiService)
+	assert.Nil(t, err, "err nil when kube-apiserver service is created successfully")
+	defer aCtrl.hubClient.Delete(ctx, apiService)
+
 	// Create hosted cluster
 	hc := getHostedCluster(hcNN)
-	err := aCtrl.hubClient.Create(ctx, hc)
+	err = aCtrl.hubClient.Create(ctx, hc)
 	assert.Nil(t, err, "err nil when hosted cluster is created successfully")
 
 	// Reconcile with annotation
@@ -247,10 +274,36 @@ kind: Config`)
 		defer aCtrl.hubClient.Delete(ctx, sec)
 	}
 
+	apiService := &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-apiserver",
+			Namespace: "clusters-hd-1",
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:     "https",
+					Port:     443,
+					Protocol: "TCP",
+					TargetPort: intstr.IntOrString{
+						IntVal: 6443,
+					},
+				},
+			},
+		},
+	}
+	err := aCtrl.hubClient.Create(ctx, apiService)
+	assert.Nil(t, err, "err nil when kube-apiserver service is created successfully")
+	defer aCtrl.hubClient.Delete(ctx, apiService)
+
 	// Create hosted cluster
 	hc := getHostedCluster(hcNN)
 	hc.Annotations = map[string]string{util.ManagedClusterAnnoKey: "infra-abcdef"}
-	err := aCtrl.hubClient.Create(ctx, hc)
+	err = aCtrl.hubClient.Create(ctx, hc)
 	assert.Nil(t, err, "err nil when hosted cluster is created successfully")
 
 	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.PlacementScoreFailureCount))
@@ -292,7 +345,7 @@ kind: Config`)
 
 	kubeconfig, err := clientcmd.Load(secret.Data["kubeconfig"])
 	assert.Nil(t, err, "is nil when kubeconfig data can be loaded")
-	assert.Equal(t, kubeconfig.Clusters["cluster"].Server, "https://kube-apiserver."+hc.Namespace+"-"+hc.Name+".svc.cluster.local:6443")
+	assert.Equal(t, kubeconfig.Clusters["cluster"].Server, "https://kube-apiserver."+hc.Namespace+"-"+hc.Name+".svc.cluster.local:443")
 
 	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.PlacementScoreFailureCount))
 	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.PlacementClusterClaimsFailureCount.WithLabelValues(util.MetricsLabelFullClusterClaim)))

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -28,6 +28,7 @@ import (
 
 	consolev1 "github.com/openshift/api/console/v1"
 	routev1 "github.com/openshift/api/route/v1"
+	"github.com/openshift/hypershift/support/rhobsmonitoring"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stolostron/hypershift-addon-operator/pkg/util"
@@ -56,6 +57,7 @@ func init() {
 	utilruntime.Must(appsv1.AddToScheme(genericScheme))
 	utilruntime.Must(rbacv1.AddToScheme(genericScheme))
 	utilruntime.Must(monitoringv1.AddToScheme(genericScheme))
+	utilruntime.Must(rhobsmonitoring.AddToScheme(genericScheme))
 }
 
 const (

--- a/pkg/manager/manifests/templates/metrics-servicemonitor.yaml
+++ b/pkg/manager/manifests/templates/metrics-servicemonitor.yaml
@@ -1,9 +1,17 @@
 {{- if ne .disableMetrics "true" }}
+  {{- if eq .enableRHOBSMonitoring "true" }}
+apiVersion: monitoring.rhobs/v1
+  {{- else }}
 apiVersion: monitoring.coreos.com/v1
+  {{- end }}
 kind: ServiceMonitor
 metadata:
   name: acm-{{ .AddonName }}-metrics
+  {{- if eq .enableRHOBSMonitoring "true" }}
+  namespace: {{ .AddonInstallNamespace }}
+  {{- else }}
   namespace: openshift-monitoring
+  {{- end }}
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/pkg/manager/manifests/templates/work-agent-clusterrole-rhobs.yaml
+++ b/pkg/manager/manifests/templates/work-agent-clusterrole-rhobs.yaml
@@ -1,0 +1,10 @@
+{{- if eq .enableRHOBSMonitoring "true" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: open-cluster-management:klusterlet-work:rhobs-role
+rules:
+  - apiGroups: ["monitoring.rhobs"]
+    resources: ["servicemonitors"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+{{- end }}

--- a/pkg/manager/manifests/templates/work-agent-clusterrolebinding-rhobs.yaml
+++ b/pkg/manager/manifests/templates/work-agent-clusterrolebinding-rhobs.yaml
@@ -1,0 +1,14 @@
+{{- if eq .enableRHOBSMonitoring "true" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: open-cluster-management:klusterlet-work:rhobs-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: open-cluster-management:klusterlet-work:rhobs-role
+subjects:
+  - kind: ServiceAccount
+    name: klusterlet-work-sa
+    namespace: open-cluster-management-agent
+{{- end }}


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Add option to enable RHOBS monitoring
* Fix API server port number in external-managed-kubeconfig

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* API server port issue https://issues.redhat.com/browse/ACM-2632

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
