### PR TITLE
Fix duplicate ImagePullSecret names being populated by the hypershift…

### DIFF
--- a/pkg/install/hypershift_test.go
+++ b/pkg/install/hypershift_test.go
@@ -599,6 +599,10 @@ func TestRunHypershiftInstall(t *testing.T) {
 	err = installHyperShiftOperator(t, ctx, aCtrl, true)
 	assert.Nil(t, err, "is nil if install HyperShift is sucessful")
 
+	// Run a second time to check the upgrade and make sure only one ImagePullSecret is present
+	err = installHyperShiftOperator(t, ctx, aCtrl, true)
+	assert.Nil(t, err, "is nil if install TWO of HyperShift is sucessful")
+
 	// Create hosted cluster
 	hcNN := types.NamespacedName{Name: "hd-1", Namespace: "clusters"}
 	hc := getHostedCluster(hcNN)
@@ -613,6 +617,10 @@ func TestRunHypershiftInstall(t *testing.T) {
 	// Check hypershift deployment is not deleted
 	err = aCtrl.spokeUncachedClient.Get(ctx, hypershiftOperatorKey, dp)
 	assert.Nil(t, err, "is nil if the hypershift deployment exists")
+
+	// Check for ImagePullSecret name duplicates
+	assert.Equal(t, 1, len(dp.Spec.Template.Spec.ImagePullSecrets),
+		"is 1, when ImagePullSecret array does not contain duplicates")
 
 	// Delete HC
 	err = aCtrl.spokeUncachedClient.Delete(ctx, hc)

--- a/pkg/metrics/hypershift-operator-health-metrics.go
+++ b/pkg/metrics/hypershift-operator-health-metrics.go
@@ -9,7 +9,7 @@ var IsHypershiftOperatorDegraded = prometheus.NewGauge(prometheus.GaugeOpts{
 
 var IsExtDNSOperatorDegraded = prometheus.NewGauge(prometheus.GaugeOpts{
 	Name: "mce_hs_addon_ext_dns_operator_degraded_bool",
-	Help: "External DNS operator degraded true (1) or false (0)",
+	Help: "External DNS operator degraded true (1) or false (0), not present (-1)",
 })
 
 var IsAWSS3BucketSecretConfigured = prometheus.NewGauge(prometheus.GaugeOpts{


### PR DESCRIPTION
…-add-operator install job

* Includes the fix
* Includes Tests

Signed-off-by: Joshua Packer <jpacker@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Fix duplicate ImagePullSecret name being populated on the HyperShift-Operator
* Add a test for this scenario during upgrade
* Fix the description for the EXT DNS operator metric to include (-1)

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Bug that blocks upgrades

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-2832

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?       github.com/stolostron/hypershift-addon-operator/cmd     [no test files]
ok      github.com/stolostron/hypershift-addon-operator/pkg/agent       19.143s coverage: 71.7% of statements

ok      github.com/stolostron/hypershift-addon-operator/pkg/install     156.531s        coverage: 86.4% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/manager     0.070s  coverage: 56.2% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/metrics     0.014s  coverage: 100.0% of statements
?       github.com/stolostron/hypershift-addon-operator/pkg/util        [no test files]
```
