### PR TITLE
add doc to create KlusterletAddonConfig

### DIFF
--- a/docs/provision_hosted_cluster_on_mce_local_cluster.md
+++ b/docs/provision_hosted_cluster_on_mce_local_cluster.md
@@ -253,7 +253,35 @@ You can also import the hosted cluster into MCE using custom resources in comman
     EOF
     ```
 
-3. After the hosted cluster is created, it will be imported into MCE. You can check the status by running
+3. Create the `KlusterletAddonConfig` resource to enable all ACM addons. This is applicable only in ACM hub. If you have installed MCE only, this is not applicable.
+
+    ```bash
+    $ cat <<EOF | oc apply -f -
+    apiVersion: agent.open-cluster-management.io/v1
+    kind: KlusterletAddonConfig
+    metadata:
+      name: $CLUSTER_NAME
+      namespace: $CLUSTER_NAME
+    spec:
+      clusterName: $CLUSTER_NAME
+      clusterNamespace: $CLUSTER_NAME
+      clusterLabels:
+        cloud: auto-detect
+        vendor: auto-detect
+      applicationManager:
+        enabled: true
+      certPolicyController:
+        enabled: true
+      iamPolicyController:
+        enabled: true
+      policyController:
+        enabled: true
+      searchCollector:
+        enabled: false
+    EOF
+    ```
+
+4. After the hosted cluster is created, it will be imported into MCE. You can check the status by running
   
     ```bash
      $ oc get managedcluster $CLUSTER_NAME
@@ -262,6 +290,21 @@ You can also import the hosted cluster into MCE using custom resources in comman
     ```
     NAME                               HUB ACCEPTED   MANAGED CLUSTER URLS                                                  JOINED   AVAILABLE   AGE
     $CLUSTER_NAME                      true           https://api.app-aws-411ga-hub-bhbj8.dev06.red-chesterfield.com:6443   True     True        25h
+    ```
+
+    ```bash
+     $ oc get managedclusteraddon -n $CLUSTER_NAME
+     ```
+    
+    ```
+    NAME                          AVAILABLE   DEGRADED   PROGRESSING
+    application-manager           True                   
+    cert-policy-controller        True                   
+    cluster-proxy                 True                   
+    config-policy-controller      True                   
+    governance-policy-framework   True                   
+    iam-policy-controller         True                   
+    work-manager                  True                   
     ```
 
 Your hosted cluster is now created and imported to MCE/ACM, which should also be visible from the MCE console.


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Add doc to create KlusterletAddonConfig to enable all ACM addons in a hypershift hosted cluster

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-2361

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
oc get managedclusteraddon -n rj-0117a
NAME                          AVAILABLE   DEGRADED   PROGRESSING
application-manager           True                   
cert-policy-controller        True                   
cluster-proxy                 True                   
config-policy-controller      True                   
governance-policy-framework   True                   
iam-policy-controller         True                   
work-manager                  True    
```
