### PR TITLE
Use ubi-minimal as the docker base image for canary test execution

### DIFF
--- a/Dockerfile.canary
+++ b/Dockerfile.canary
@@ -1,11 +1,11 @@
-FROM ubuntu:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 # Install utils
-RUN apt update \
-        && apt install -y uuid-runtime \
-        && apt install -y curl \
-        && apt install -y openssh-client \
-        && apt install -y jq
+RUN  microdnf update -y \
+        && microdnf install uuid \
+        && microdnf install jq \
+        && microdnf install openssh-clients \
+        && microdnf clean all
 
 # Install the kubectl binary
 RUN curl -LO https://dl.k8s.io/release/v1.26.0/bin/linux/amd64/kubectl \
@@ -15,5 +15,12 @@ RUN curl -LO https://dl.k8s.io/release/v1.26.0/bin/linux/amd64/kubectl \
 COPY ./test/canary/run_canary_test.sh .
 RUN mkdir -p /resources
 COPY ./test/canary/resources /resources
+
+# Uncomment below to test with upstream
+#COPY ./test/canary/bin/hypershift /bin
+#RUN chmod +x /bin/hypershift
+
+# run as root
+USER root
 
 ENTRYPOINT ["./run_canary_test.sh"]

--- a/test/canary/run_canary_test.sh
+++ b/test/canary/run_canary_test.sh
@@ -104,14 +104,14 @@ HYPERSHIFT_COMMAND="hypershift"
 # Generate the first hosted cluster name
 CLUSTER_NAME_1=${CLUSTER_NAME_PREFIX}$(cat /dev/urandom | env LC_ALL=C tr -dc 'a-z0-9' | fold -w 6 | head -n 1)
 INFRA_ID_1=$(cat /dev/urandom | env LC_ALL=C tr -dc 'a-z0-9' | fold -w 32 | head -n 1)
-CLUSTER_UUID_1=$(uuidgen)
+CLUSTER_UUID_1=$(uuid)
 INFRA_OUTPUT_FILE_1=${CLUSTER_NAME_1}-infraout
 IAM_OUTPUT_FILE_1=${CLUSTER_NAME_1}-iam
 
 # Generate the second hosted cluster name
 CLUSTER_NAME_2=${CLUSTER_NAME_PREFIX}$(cat /dev/urandom | env LC_ALL=C tr -dc 'a-z0-9' | fold -w 6 | head -n 1)
 INFRA_ID_2=$(cat /dev/urandom | env LC_ALL=C tr -dc 'a-z0-9' | fold -w 32 | head -n 1)
-CLUSTER_UUID_2=$(uuidgen)
+CLUSTER_UUID_2=$(uuid)
 INFRA_OUTPUT_FILE_2=${CLUSTER_NAME_2}-infraout
 IAM_OUTPUT_FILE_2=${CLUSTER_NAME_2}-iam
 
@@ -553,8 +553,11 @@ enableHostedModeAddon() {
 echo "$(date) ==== Enable hypershift feature ===="
 enableHypershiftForLocalCluster
 
-echo "$(date) ==== Installing hypershift binary ===="
-installHypershiftBinary
+if ! command -v ${HYPERSHIFT_COMMAND} &> /dev/null
+then
+    echo "$(date) ==== Installing hypershift binary ===="
+    installHypershiftBinary
+fi
 
 # Enabled hosted mode addons
 # https://github.com/stolostron/hypershift-addon-operator/blob/main/docs/running_mce_acm_addons_hostedmode.md


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* The `ubuntu` image doesn't exist in PROW. Update the canary test to build and run using `ubi` image.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Ensure canary test PROW build successfully.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-2811

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
Ran the docker build and executed the test locally against ck cluster. It seems to be fine.
```
