### PR TITLE
Make install job keep retrying if it fails

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -169,13 +169,9 @@ func (o *AgentOptions) runControllerManager(ctx context.Context) error {
 	uCtrl := install.NewUpgradeController(hubClient, spokeKubeClient, o.Log, o.AddonName, o.AddonNamespace, o.SpokeClusterName,
 		o.HypershiftOperatorImage, o.PullSecretName, o.WithOverride, ctx)
 
-	// retry 3 times, in case something wrong with creating the hypershift install job
-	if err := uCtrl.RunHypershiftOperatorInstallOnAgentStartup(ctx); err != nil {
-		log.Error(err, "failed to install hypershift Operator")
-		// merics for the hypershift operator installation is in its own function
-		metrics.AddonAgentFailedToStartBool.Set(1)
-		return err
-	}
+	// Perform initial hypershift operator installation on start-up, then start the process to continuously check
+	// if the hypershift operator re-installation is needed
+	uCtrl.Start()
 
 	leaseClient, err := kubernetes.NewForConfig(spokeConfig)
 	if err != nil {
@@ -239,10 +235,6 @@ func (o *AgentOptions) runControllerManager(ctx context.Context) error {
 		metrics.AddonAgentFailedToStartBool.Set(1)
 		return fmt.Errorf("unable to set up ready check, err: %w", err)
 	}
-
-	// After the initial hypershift operator installation, start the process to continuously check
-	// if the hypershift operator re-installation is needed
-	uCtrl.Start()
 
 	return mgr.Start(ctrl.SetupSignalHandler())
 }

--- a/pkg/install/install_job.go
+++ b/pkg/install/install_job.go
@@ -75,9 +75,9 @@ func (c *UpgradeController) runHyperShiftInstallJob(ctx context.Context, image, 
 		jobPodSpec.Containers[0].VolumeMounts = []corev1.VolumeMount{{Name: util.HypershiftInstallJobVolume, MountPath: mountPath}}
 	}
 
-	backoffLimit := int32(3)
+	backoffLimit := int32(0)
 	activeDeadlineSeconds := int64(600)
-	ttlSecondsAfterFinished := int32(172800) // 48 hrs
+	ttlSecondsAfterFinished := int32(1200) // 20 mins
 	job := &kbatch.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: util.HypershiftInstallJobName,
@@ -98,7 +98,7 @@ func (c *UpgradeController) runHyperShiftInstallJob(ctx context.Context, image, 
 
 	c.log.Info(fmt.Sprintf("created HyperShift install job: %s", job.Name))
 
-	return job, wait.PollImmediate(10*time.Second, 5*time.Minute, c.isInstallJobFinished(ctx, job.Name))
+	return job, wait.PollImmediate(10*time.Second, 2*time.Minute, c.isInstallJobFinished(ctx, job.Name))
 }
 
 func (c *UpgradeController) isInstallJobSuccessful(ctx context.Context, jobName string) (bool, error) {

--- a/pkg/install/upgrade_test.go
+++ b/pkg/install/upgrade_test.go
@@ -389,6 +389,14 @@ func TestPrivateLinkSecretChanges(t *testing.T) {
 	}, 10*time.Second, 1*time.Second, "Nothing has changed. The hypershift operator does not need to be re-installed")
 	controller.Stop()
 
+	controller.startup = true
+	controller.installfailed = false
+	controller.Start()
+	assert.Eventually(t, func() bool {
+		return controller.startup && controller.installfailed
+	}, 3*time.Minute, 10*time.Second, "Nothing has changed, but Startup=true. The hypershift operator needs to be re-installed")
+	controller.Stop()
+
 	changedPrivateLinkSecret := &corev1.Secret{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      util.HypershiftPrivateLinkSecretName,
@@ -410,6 +418,8 @@ func TestPrivateLinkSecretChanges(t *testing.T) {
 		return false
 	}, 10*time.Second, 1*time.Second, "The private link secret was updated successfully")
 
+	controller.startup = false
+	controller.installfailed = false
 	controller.Start()
 	assert.Eventually(t, func() bool {
 		return controller.reinstallNeeded
@@ -430,6 +440,8 @@ func TestPrivateLinkSecretChanges(t *testing.T) {
 	}, 10*time.Second, 1*time.Second, "The private link secret was removed. The hypershift operator needs to be re-installed")
 	controller.Stop()
 
+	controller.startup = false
+	controller.installfailed = false
 	controller.Start()
 	assert.Eventually(t, func() bool {
 		return !controller.reinstallNeeded


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Changed installation job to keep trying if the prev job failed. Install job does not need to create a pod (1 pod for each job) to retry the installation anymore. Removed invoking install job from agent startup, but instead use the same upgrade logic. May want to keep jobs around for less than 48 hrs now that the failed jobs keep retrying.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Install job used to fail too quickly. If dependencies eventually resolve, but the install job does not retry.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-3190

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	18.987s	coverage: 72.2% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	158.009s	coverage: 85.9% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	1.268s	coverage: 56.2% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	0.580s	coverage: 100.0% of statements
```

Signed-off-by: Philip Wu <phwu@redhat.com>
