### PR TITLE
Produce junit xml result file based for canary test

### DIFF
--- a/Dockerfile.canary
+++ b/Dockerfile.canary
@@ -13,6 +13,9 @@ RUN curl -LO https://dl.k8s.io/release/v1.26.0/bin/linux/amd64/kubectl \
         && mv kubectl /bin
 
 COPY ./test/canary/run_canary_test.sh .
+COPY ./test/canary/hypershift-failed.xml .
+COPY ./test/canary/hypershift-success.xml .
+RUN mkdir -p /results
 RUN mkdir -p /resources
 COPY ./test/canary/resources /resources
 

--- a/test/canary/README.md
+++ b/test/canary/README.md
@@ -33,6 +33,7 @@ OCP_RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-release:4.12.0-x86_64
 HOSTING_CLUSTER_NAME=local-cluster
 CLUSTER_NAME_PREFIX=ge-
 REGION=us-east-1
+RESULTS_DIR=/tmp
 ```
 
 Run the test:
@@ -40,6 +41,7 @@ Run the test:
 ```
 docker run \
   --volume $KUBECONFIG_PATH:/kubeconfig \
+  --volume $RESULTS_DIR:/results \
   --env KUBECONFIG=/kubeconfig \
   --env OCP_RELEASE_IMAGE=$OCP_RELEASE_IMAGE \
   --env OCP_PULL_SECRET=$OCP_PULL_SECRET \

--- a/test/canary/hypershift-failed.xml
+++ b/test/canary/hypershift-failed.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite name="Hypershift E2E Suite" tests="1" failures="1" errors="0" time="888.88">
+      <testcase name="Hypershift: [P1][Sev1][hypershift] Should run successfully - [Integration] Should run successfully" classname="Hypershift E2E Suite" time="888.88888888">
+          <failure type="Failure">run_canary_test:10&#xA;Failed after 888.888s.&#xA;Expected&#xA;    &lt;bool&gt;: false&#xA;to be true&#xA;run_canary_test:10</failure>
+      </testcase>
+  </testsuite>

--- a/test/canary/hypershift-success.xml
+++ b/test/canary/hypershift-success.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite name="Hypershift E2E Suite" tests="1" failures="0" errors="0" time="888.88">
+      <testcase name="Hypershift: [P1][Sev1][hypershift][Integration] Should run successfully" classname="Hypershift E2E Suite" time="8.888888888"></testcase>
+  </testsuite>

--- a/test/canary/run_canary_test.sh
+++ b/test/canary/run_canary_test.sh
@@ -24,6 +24,10 @@
 #export AWS_ACCESS_KEY_ID=
 #export AWS_SECRET_ACCESS_KEY=
 
+# Canary test expects a xml result file in a folder.
+# Default the result to failed until it's successful.
+cp /hypershift-failed.xml /results
+
 if [ -z ${OCP_RELEASE_IMAGE+x} ]; then
   echo "OCP_RELEASE_IMAGE is not defined"
   exit 1
@@ -295,7 +299,7 @@ deleteHostedCluster() {
     waitForManifestworkDelete ${HOSTING_CLUSTER_NAME} ${infraID}
 }
 
-cleaup() {
+cleanup() {
     clusterName=$1
     infraID=$2
     infraFile=$3
@@ -592,6 +596,10 @@ verifyHostedCluster ${INFRA_ID_1}
 echo "$(date) ==== Verifying hosted cluster  ${CLUSTER_NAME_2} ===="
 verifyHostedCluster ${INFRA_ID_2}
 
+# Test ran successfully, remove the failed result file and put the successful file in
+rm -f /results/hypershift-failed.xml
+cp /hypershift-success.xml /results
+
 # Delete the first managed cluster
 echo "$(date) ==== Deleting hosted cluster  ${CLUSTER_NAME_1} ===="
 deleteHostedCluster ${CLUSTER_NAME_1} ${INFRA_ID_1}
@@ -602,7 +610,9 @@ deleteHostedCluster ${CLUSTER_NAME_2} ${INFRA_ID_2}
 
 # Destroy infra, IAM and remove files
 echo "$(date) ==== Cleaning up hosted cluster  ${CLUSTER_NAME_1} ===="
-cleaup ${CLUSTER_NAME_1} ${INFRA_ID_1} ${INFRA_OUTPUT_FILE_1} ${IAM_OUTPUT_FILE_1}
+cleanup ${CLUSTER_NAME_1} ${INFRA_ID_1} ${INFRA_OUTPUT_FILE_1} ${IAM_OUTPUT_FILE_1}
 
 echo "$(date) ==== Cleaning up hosted cluster  ${CLUSTER_NAME_2} ===="
-cleaup ${CLUSTER_NAME_2} ${INFRA_ID_2} ${INFRA_OUTPUT_FILE_2} ${IAM_OUTPUT_FILE_2}
+cleanup ${CLUSTER_NAME_2} ${INFRA_ID_2} ${INFRA_OUTPUT_FILE_2} ${IAM_OUTPUT_FILE_2}
+
+exit 0


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* CICD requires all the canary test to produce a success or failed junit xml result file depending on the result of the canary test.
* The Success and Failure result data is mocked because we are not using a test framework like Gingko.
* The real useful outputs (such as outputs from echo commands) will be captured by the CICD "run_test.sh"

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  CICD requirement for canary test to produce a XML file that follows a certain format

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* ACM-2811

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
built canary docker image and ran it locally and it seems to be fine.
```
