### PR TITLE
fix canary test image not having tar

### DIFF
--- a/Dockerfile.canary
+++ b/Dockerfile.canary
@@ -5,6 +5,7 @@ RUN  microdnf update -y \
         && microdnf install uuid \
         && microdnf install jq \
         && microdnf install openssh-clients \
+        && microdnf install tar \
         && microdnf clean all
 
 # Install the kubectl binary


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* fix canary test image not having tar

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  successful canary test run

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* ACM-2811

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
not appilcable
```
