### PR TITLE
remove optional storage class name specification

### DIFF
--- a/test/canary/resources/hosted_cluster_manifestwork.yaml
+++ b/test/canary/resources/hosted_cluster_manifestwork.yaml
@@ -356,7 +356,6 @@ spec:
             storage:
               persistentVolume:
                 size: 4Gi
-                storageClassName: gp3-csi
               type: PersistentVolume
           managementType: Managed
         fips: false


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* remove optional storage class name specification

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  so that canary test can be run on GCP cluster

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* ACM 2811

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
not applicable
```
