### PR TITLE
Skip execution of canary test (report success) on non AWS cluster

### DIFF
--- a/test/canary/run_canary_test.sh
+++ b/test/canary/run_canary_test.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 
-# This script is run on the hub cluster
+# This script is run on the AWS hub cluster
+
+# If the cluster is not AWS then exit gracefully and report success
+# TODO ACM-3290 to support all platforms
+CLOUD_LABEL=$(kubectl get managedcluster local-cluster -o jsonpath='{.metadata.labels.cloud}')
+if [ "$CLOUD_LABEL" != "Amazon" ]; then
+    echo "Skipping test execution. The local-cluster managedcluster does not have a cloud label with the value: Amazon"
+    cp /hypershift-success.xml /results
+    exit 0
+fi
 
 #########################################
 #   POPULATE THESE WITH ENV VARS        #


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Skip execution of canary test (report success) on non AWS cluster

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Canary is running on different platforms but so far we can only support AWS

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* ACM-2811 ACM-3290

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
tested the inverse logic against AWS cluster and saw the test skipped successfully.
```
