### PR TITLE
Skip canary test execution if the Openshift version is 4.10 and under

### DIFF
--- a/test/canary/README.md
+++ b/test/canary/README.md
@@ -30,6 +30,8 @@ Edit the following if necessary or run it as it is:
 
 ```
 OCP_RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-release:4.12.0-x86_64
+HUB_OCP_VERSION=4.12.0
+UNSUPPORTED_OCP_VERSION=4.10.0
 HOSTING_CLUSTER_NAME=local-cluster
 CLUSTER_NAME_PREFIX=ge-
 REGION=us-east-1
@@ -44,6 +46,8 @@ docker run \
   --volume $RESULTS_DIR:/results \
   --env KUBECONFIG=/kubeconfig \
   --env OCP_RELEASE_IMAGE=$OCP_RELEASE_IMAGE \
+  --env HUB_OCP_VERSION=$HUB_OCP_VERSION \
+  --env UNSUPPORTED_OCP_VERSION=$UNSUPPORTED_OCP_VERSION \
   --env OCP_PULL_SECRET=$OCP_PULL_SECRET \
   --env HOSTING_CLUSTER_NAME=$HOSTING_CLUSTER_NAME \
   --env CLUSTER_NAME_PREFIX=$CLUSTER_NAME_PREFIX \

--- a/test/canary/run_canary_test.sh
+++ b/test/canary/run_canary_test.sh
@@ -42,6 +42,16 @@ if [ -z ${OCP_RELEASE_IMAGE+x} ]; then
   exit 1
 fi
 
+if [ -z ${HUB_OCP_VERSION+x} ]; then
+  echo "HUB_OCP_VERSION is not defined"
+  exit 1
+fi
+
+if [ -z ${UNSUPPORTED_OCP_VERSION+x} ]; then
+  echo "UNSUPPORTED_OCP_VERSION is not defined"
+  exit 1
+fi
+
 if [ -z ${OCP_PULL_SECRET+x} ]; then
   echo "OCP_PULL_SECRET is not defined"
   exit 1
@@ -86,6 +96,17 @@ fi
 if [ -z ${AWS_SECRET_ACCESS_KEY+x} ]; then
   echo "AWS_SECRET_ACCESS_KEY is not defined"
   exit 1
+fi
+
+# https://stackoverflow.com/questions/16989598/comparing-php-version-numbers-using-bash/24067243#24067243
+function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
+if version_gt $HUB_OCP_VERSION $UNSUPPORTED_OCP_VERSION; then
+     echo "Supported Openshift version $HUB_OCP_VERSION is greater than $UNSUPPORTED_OCP_VERSION"
+else
+    echo "Skipping test execution. HUB_OCP_VERSION: $HUB_OCP_VERSION and UNSUPPORTED_OCP_VERSION: $UNSUPPORTED_OCP_VERSION"
+    rm -f /results/hypershift-failed.xml
+    cp /hypershift-success.xml /results
+    exit 0
 fi
 
 # Create AWS credentials file


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* We discover that the recent DS hypershift binary only supports Openshift version 4.11 and above.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Ensure canary successful execution.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* ACM-2811

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
# tested against a 4.11.0 Openshift cluster and got the following output
Supported Openshift version 4.11.0
```
