### PR TITLE
Fix clusteradm to v0.4.0 to fix e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ ifeq (, $(shell which clusteradm))
 	@{ \
 	set -e ;\
 	export INSTALL_DIR="${GOPATH}/bin" ;\
-	curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash ;\
+	curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash -s -- 0.4.0 ;\
 	}
 	CLUSTERADM=${GOPATH}/bin/clusteradm
 else


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* fix clusteradm to a specific version

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  fix e2e

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* na

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
make ensure-clusteradm 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  4799  100  4799    0     0   101k      0 --:--:-- --:--:-- --:--:--  104k
Your system is linux_amd64
Installing clusteradm CLI...

Installing v0.4.0 OCM clusteradm CLI...
Downloading https://github.com/open-cluster-management-io/clusteradm/releases/download/v0.4.0/clusteradm_linux_amd64.tar.gz ...
clusteradm installed into /home/mng/go/bin successfully.

To get started with clusteradm, please visit https://open-cluster-management.io/getting-started/
CLUSTERADM=/home/mng/go/bin/clusteradm

```
