### PR TITLE
ACM-1851 

### DIFF
--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -205,26 +205,42 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 		}
 	}
 
-	awsPlatform := true
+	awsPlatform := false
+	oidcBucket := true
+	privateLinkCreds := true
 
+	//Attempt to retrieve oidc bucket secret
 	bucketSecretKey := types.NamespacedName{Name: util.HypershiftBucketSecretName, Namespace: c.clusterName}
 	se := &corev1.Secret{}
 	if err := c.hubClient.Get(ctx, bucketSecretKey, se); err != nil {
 		c.log.Info(fmt.Sprintf("bucket secret(%s) not found on the hub, installing hypershift operator for non-AWS platform.", bucketSecretKey))
 
-		awsPlatform = false
+		oidcBucket = false
 	}
 
 	// cache the bucket secret for comparison againt the hub's to detect any change
 	c.bucketSecret = *se
 
+	
+	//Attempt to retrieve private link creds
+	privateSecretKey := types.NamespacedName{Name: util.HypershiftPrivateLinkSecretName, Namespace: c.clusterName}
+	spl := &corev1.Secret{}
+	if err := c.hubClient.Get(ctx, privateSecretKey, spl); err != nil {
+		c.log.Info(fmt.Sprintf("private secret(%s) not found on the hub, installing hypershift operator for non-AWS platform.", privateSecretKey))
+
+		privateLinkCreds = false
+	}
+	// cache the private link secret for comparison againt the hub's to detect any change
+	c.privateLinkSecret = *spl
+
+	//Platform is aws if either secret exists
+	awsPlatform = oidcBucket || privateLinkCreds
+
 	args := []string{
 		"--namespace", hypershiftOperatorKey.Namespace,
 	}
 
-	spl := &corev1.Secret{}
-
-	if awsPlatform { // if the S3 secret is found, install hypershift with s3 options
+	if oidcBucket { // if the S3 secret is found, install hypershift with s3 options
 		bucketName := string(se.Data["bucket"])
 		bucketRegion := string(se.Data["region"])
 
@@ -245,9 +261,9 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 
 		// Set this to one to indicate that the AWS S3 bucket secret is used for the operator installation
 		metrics.IsAWSS3BucketSecretConfigured.Set(1)
+	}
 
-		//Private link creds
-		privateSecretKey := types.NamespacedName{Name: util.HypershiftPrivateLinkSecretName, Namespace: c.clusterName}
+	if privateLinkCreds { // if private link credentials is found, install hypershift with private secret options
 
 		if err := c.hubClient.Get(ctx, privateSecretKey, spl); err == nil {
 			if err := c.createAwsSpokeSecret(ctx, spl, true); err != nil {
@@ -263,10 +279,9 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 		} else {
 			c.log.Info(fmt.Sprintf("private-link secret(%s) was not found", privateSecretKey))
 		}
-
-		// cache the private link secret for comparison againt the hub's to detect any change
-		c.privateLinkSecret = *spl
 	}
+
+
 	//External DNS
 	extDNSSecretKey := types.NamespacedName{Name: util.HypershiftExternalDNSSecretName, Namespace: c.clusterName}
 	sExtDNS := &corev1.Secret{}

--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -221,7 +221,6 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 	// cache the bucket secret for comparison againt the hub's to detect any change
 	c.bucketSecret = *se
 
-
 	//Attempt to retrieve private link creds
 	privateSecretKey := types.NamespacedName{Name: util.HypershiftPrivateLinkSecretName, Namespace: c.clusterName}
 	spl := &corev1.Secret{}
@@ -233,10 +232,9 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 	// cache the private link secret for comparison againt the hub's to detect any change
 	c.privateLinkSecret = *spl
 
-
 	//Platform is aws if either secret exists
 	awsPlatform = oidcBucket || privateLinkCreds
-	if (!awsPlatform) {
+	if !awsPlatform {
 		c.log.Info(fmt.Sprintf("bucket secret(%s) and private secret(%s) not found on the hub, installing hypershift operator for non-AWS platform.", bucketSecretKey, privateSecretKey))
 	}
 
@@ -265,7 +263,7 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 
 		// Set this to one to indicate that the AWS S3 bucket secret is used for the operator installation
 		metrics.IsAWSS3BucketSecretConfigured.Set(1)
-		
+
 	}
 
 	if privateLinkCreds { // if private link credentials is found, install hypershift with private secret options
@@ -279,8 +277,12 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 			"--private-platform", "AWS",
 		}
 		args = append(args, awsArgs...)
-	
+
 	}
+	// c.log.Info("Args are:\n")
+	// for i := 0; i < len(args); i++ {
+	// 	c.log.Info(args[i] + "\n")
+	// }
 
 	//External DNS
 	extDNSSecretKey := types.NamespacedName{Name: util.HypershiftExternalDNSSecretName, Namespace: c.clusterName}

--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -225,7 +225,7 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 	privateSecretKey := types.NamespacedName{Name: util.HypershiftPrivateLinkSecretName, Namespace: c.clusterName}
 	spl := &corev1.Secret{}
 	if err := c.hubClient.Get(ctx, privateSecretKey, spl); err != nil {
-		c.log.Info(fmt.Sprintf("private secret(%s) not found on the hub.", privateSecretKey))
+		c.log.Info(fmt.Sprintf("private link secret(%s) not found on the hub.", privateSecretKey))
 
 		privateLinkCreds = false
 	}
@@ -236,7 +236,7 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 	awsPlatform = oidcBucket || privateLinkCreds
 	c.awsPlatform = awsPlatform
 	if !awsPlatform {
-		c.log.Info(fmt.Sprintf("bucket secret(%s) and private secret(%s) not found on the hub, installing hypershift operator for non-AWS platform.", bucketSecretKey, privateSecretKey))
+		c.log.Info(fmt.Sprintf("bucket secret(%s) and private link secret(%s) not found on the hub, installing hypershift operator for non-AWS platform.", bucketSecretKey, privateSecretKey))
 	}
 
 	args := []string{

--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -234,6 +234,7 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 
 	//Platform is aws if either secret exists
 	awsPlatform = oidcBucket || privateLinkCreds
+	c.awsPlatform = awsPlatform
 	if !awsPlatform {
 		c.log.Info(fmt.Sprintf("bucket secret(%s) and private secret(%s) not found on the hub, installing hypershift operator for non-AWS platform.", bucketSecretKey, privateSecretKey))
 	}
@@ -279,10 +280,6 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 		args = append(args, awsArgs...)
 
 	}
-	// c.log.Info("Args are:\n")
-	// for i := 0; i < len(args); i++ {
-	// 	c.log.Info(args[i] + "\n")
-	// }
 
 	//External DNS
 	extDNSSecretKey := types.NamespacedName{Name: util.HypershiftExternalDNSSecretName, Namespace: c.clusterName}

--- a/pkg/install/hypershift_test.go
+++ b/pkg/install/hypershift_test.go
@@ -1718,3 +1718,74 @@ func TestOperatorImagesUpdatedCheck(t *testing.T) {
 	imagesUpdated = aCtrl.operatorImagesUpdated(imb, *dp)
 	assert.True(t, imagesUpdated, "detected that there is difference between the image stream and deployment images")
 }
+
+func TestAWSPlatformDetection(t *testing.T) {
+	ctx := context.Background()
+
+	zapLog, _ := zap.NewDevelopment()
+	client := initClient()
+	controller := &UpgradeController{
+		spokeUncachedClient:       client,
+		hubClient:                 client,
+		log:                       zapr.NewLogger(zapLog),
+		addonNamespace:            "addon",
+		operatorImage:             "my-test-image",
+		clusterName:               "cluster1",
+		pullSecret:                "pull-secret",
+		hypershiftInstallExecutor: &HypershiftTestCliExecutor{},
+		privateLinkSecret:         corev1.Secret{},
+		bucketSecret:              corev1.Secret{},
+	}
+
+	privateLinkSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.HypershiftPrivateLinkSecretName,
+			Namespace: controller.clusterName,
+		},
+		Data: map[string][]byte{
+			"region":      []byte(`us-east-1`),
+			"credentials": []byte(`my-credential-file`),
+		},
+	}
+	bucketSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.HypershiftBucketSecretName,
+			Namespace: controller.clusterName,
+		},
+		Data: map[string][]byte{
+			"bucket":      []byte(`my-bucket`),
+			"region":      []byte(`us-east-1`),
+			"credentials": []byte(`myCredential`),
+		},
+	}
+
+	controller.Start()
+	assert.Eventually(t, func() bool {
+		return !controller.awsPlatform
+	}, 10*time.Second, 1*time.Second, "Neither OIDC or Private Link Credentials provided. Installing for non-AWS platform")
+	controller.Stop()
+
+	controller.hubClient.Create(ctx, privateLinkSecret)
+
+	controller.Start()
+	assert.Eventually(t, func() bool {
+		return controller.awsPlatform
+	}, 10*time.Second, 1*time.Second, "Only Private Link Credentials provided. Installing for AWS platform")
+	controller.Stop()
+
+	controller.hubClient.Create(ctx, bucketSecret)
+
+	controller.Start()
+	assert.Eventually(t, func() bool {
+		return controller.awsPlatform
+	}, 10*time.Second, 1*time.Second, "Both OIDC or Private Link Credentials provided. Installing for AWS platform")
+	controller.Stop()
+
+	controller.hubClient.Delete(ctx, privateLinkSecret)
+
+	controller.Start()
+	assert.Eventually(t, func() bool {
+		return controller.awsPlatform
+	}, 10*time.Second, 1*time.Second, "Only OIDC Credentials provided. Installing for AWS platform")
+	controller.Stop()
+}

--- a/pkg/install/upgrade.go
+++ b/pkg/install/upgrade.go
@@ -36,7 +36,7 @@ type UpgradeController struct {
 	privateLinkSecret         corev1.Secret
 	imageOverrideConfigmap    corev1.ConfigMap
 	reinstallNeeded           bool // this is used only for code test
-	awsPlatform               bool //this is used only for code test
+	awsPlatform               bool // this is used only for code test
 	startup                   bool //
 	installfailed             bool // previous installation failed - retry needed on next attempt
 }

--- a/pkg/install/upgrade.go
+++ b/pkg/install/upgrade.go
@@ -36,6 +36,7 @@ type UpgradeController struct {
 	privateLinkSecret         corev1.Secret
 	imageOverrideConfigmap    corev1.ConfigMap
 	reinstallNeeded           bool // this is used only for code test
+	awsPlatform               bool //this is used only for code test
 	startup                   bool //
 	installfailed             bool // previous installation failed - retry needed on next attempt
 }

--- a/pkg/install/upgrade_test.go
+++ b/pkg/install/upgrade_test.go
@@ -2,7 +2,6 @@ package install
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -373,14 +372,11 @@ func TestPrivateLinkSecretChanges(t *testing.T) {
 	}
 	controller.hubClient.Create(ctx, newPrivateLinkSecret)
 
-	fmt.Println(newPrivateLinkSecret)
-
 	assert.Eventually(t, func() bool {
 		theSecret := &corev1.Secret{}
 		err := controller.hubClient.Get(ctx, types.NamespacedName{Namespace: controller.clusterName, Name: util.HypershiftPrivateLinkSecretName}, theSecret)
 		return err == nil
 	}, 10*time.Second, 1*time.Second, "The test private link secret was created successfully")
-
 
 	controller.Start()
 	assert.Eventually(t, func() bool {
@@ -412,7 +408,7 @@ func TestPrivateLinkSecretChanges(t *testing.T) {
 			Namespace: controller.clusterName,
 		},
 		Data: map[string][]byte{
-			"region": []byte(`us-west-1`),
+			"region":      []byte(`us-west-1`),
 			"credentials": []byte(`my-credential-file`),
 		},
 	}
@@ -472,5 +468,5 @@ func TestPrivateLinkSecretChanges(t *testing.T) {
 	}, 10*time.Second, 1*time.Second, "The agent fails to get the private link secret from the hub. The hypershift operator should not be re-installed")
 
 	controller.Stop()
-	
+
 }


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Aws platform detection was based on oidc s3 credentials, even though they are optional. Now aws platform detection is based on either oidc s3 credentials or private link credentials

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Correctly detect aws platform

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://github.com/stolostron/hypershift-addon-operator/issues/84

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?       github.com/stolostron/hypershift-addon-operator/cmd     [no test files]
ok      github.com/stolostron/hypershift-addon-operator/pkg/agent       17.087s coverage: 71.7% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/install     165.701s        coverage: 86.8% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/manager     0.118s  coverage: 56.2% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/metrics     0.013s  coverage: 100.0% of statements
?       github.com/stolostron/hypershift-addon-operator/pkg/util        [no test files]
```
