### PR TITLE
remove enable-uwm-telemetry-remote-write for sd

### DIFF
--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -302,7 +302,6 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 
 	//Enable control plane telemetry forwarding
 	telemetryArgs := []string{
-		"--enable-uwm-telemetry-remote-write",
 		"--platform-monitoring", "OperatorOnly",
 	}
 	args = append(args, telemetryArgs...)
@@ -317,6 +316,11 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 			"SRE",
 		}
 		args = append(args, rhobsArgs...)
+	} else {
+		uwmArgs := []string{
+			"--enable-uwm-telemetry-remote-write",
+		}
+		args = append(args, uwmArgs...)
 	}
 
 	hypershiftImage := c.operatorImage

--- a/pkg/install/hypershift_test.go
+++ b/pkg/install/hypershift_test.go
@@ -38,7 +38,7 @@ const (
 
 func initClient() ctrlClient.Client {
 	scheme := runtime.NewScheme()
-	//corev1.AddToScheme(scheme)
+	corev1.AddToScheme(scheme)
 	appsv1.AddToScheme(scheme)
 	corev1.AddToScheme(scheme)
 	metav1.AddMetaToScheme(scheme)
@@ -881,8 +881,8 @@ func TestRunHypershiftInstallPrivateLinkExternalDNS(t *testing.T) {
 				"--external-dns-domain-filter", "my.house.com",
 				"--external-dns-provider", "aws",
 				"--external-dns-txt-owner-id", "the-owner",
-				"--enable-uwm-telemetry-remote-write",
 				"--platform-monitoring", "OperatorOnly",
+				"--enable-uwm-telemetry-remote-write",
 				"--hypershift-image", "my-test-image",
 			}
 			assert.Equal(t, expectArgs, installJob.Spec.Template.Spec.Containers[0].Args, "mismatched container arguments")
@@ -990,7 +990,6 @@ func TestRunHypershiftInstallEnableRHOBS(t *testing.T) {
 			installJob := installJobList.Items[0]
 			expectArgs := []string{
 				"--namespace", "hypershift",
-				"--enable-uwm-telemetry-remote-write",
 				"--platform-monitoring", "OperatorOnly",
 				"--rhobs-monitoring", "true",
 				"--metrics-set", "SRE",
@@ -1142,8 +1141,8 @@ func TestRunHypershiftInstallExternalDNSDifferentSecret(t *testing.T) {
 				"--external-dns-domain-filter", "my.house.com",
 				"--external-dns-provider", "aws",
 				"--external-dns-txt-owner-id", "the-owner",
-				"--enable-uwm-telemetry-remote-write",
 				"--platform-monitoring", "OperatorOnly",
+				"--enable-uwm-telemetry-remote-write",
 				"--hypershift-image", "my-test-image",
 			}
 			assert.Equal(t, expectArgs, installJob.Spec.Template.Spec.Containers[0].Args, "mismatched container arguments")


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Do not add `--enable-uwm-telemetry-remote-write` HO install argument in SD (when RHOBS is enabled)

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  SD environment configuration

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-3648

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?       github.com/stolostron/hypershift-addon-operator/cmd     [no test files]
ok      github.com/stolostron/hypershift-addon-operator/pkg/agent       19.398s coverage: 71.7% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/install     277.210s        coverage: 87.1% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/manager     0.634s  coverage: 56.2% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/metrics     0.527s  coverage: 100.0% of statements
?       github.com/stolostron/hypershift-addon-operator/pkg/util        [no test files]
```
