### PR TITLE
always update-install existing HO when special annotation is absent

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -698,6 +698,17 @@ func TestRunControllerManager(t *testing.T) {
 		AddonName:      "hypershift-addon",
 		AddonNamespace: "hypershift",
 	}
+
+	fakeClusterCS := clustercsfake.NewSimpleClientset()
+
+	aCtrl := &agentController{
+		spokeClustersClient: fakeClusterCS,
+		spokeUncachedClient: client,
+		spokeClient:         client,
+		hubClient:           client,
+		log:                 zapr.NewLogger(zapLog),
+	}
+
 	err := o.runControllerManager(ctx)
 	assert.NotNil(t, err, "err it not nil if the controller fail to run")
 }

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -686,6 +686,7 @@ func TestCleanupCommand(t *testing.T) {
 		AddonName:      "hypershift-addon",
 		AddonNamespace: "hypershift",
 	}
+
 	err := o.runCleanup(ctx, nil)
 	assert.Nil(t, err, "is nil if cleanup is succcessful")
 }
@@ -697,16 +698,6 @@ func TestRunControllerManager(t *testing.T) {
 		Log:            zapr.NewLogger(zapLog),
 		AddonName:      "hypershift-addon",
 		AddonNamespace: "hypershift",
-	}
-
-	fakeClusterCS := clustercsfake.NewSimpleClientset()
-
-	aCtrl := &agentController{
-		spokeClustersClient: fakeClusterCS,
-		spokeUncachedClient: client,
-		spokeClient:         client,
-		hubClient:           client,
-		log:                 zapr.NewLogger(zapLog),
 	}
 
 	err := o.runControllerManager(ctx)

--- a/pkg/install/hypershift_test.go
+++ b/pkg/install/hypershift_test.go
@@ -38,7 +38,6 @@ const (
 
 func initClient() ctrlClient.Client {
 	scheme := runtime.NewScheme()
-	corev1.AddToScheme(scheme)
 	appsv1.AddToScheme(scheme)
 	corev1.AddToScheme(scheme)
 	metav1.AddMetaToScheme(scheme)
@@ -72,16 +71,13 @@ func initDeployObj() *appsv1.Deployment {
 func initDeployAddonObj() *appsv1.Deployment {
 	deploy := initDeployObj()
 	deploy.Annotations = map[string]string{
-		util.HypershiftAddonAnnotationKey: util.AddonControllerName,
+		util.HypershiftOperatorNoMCEAnnotationKey: "true",
 	}
 	return deploy
 }
 
 func initDeployAddonImageDiffObj() *appsv1.Deployment {
 	deploy := initDeployObj()
-	deploy.Annotations = map[string]string{
-		util.HypershiftAddonAnnotationKey: util.AddonControllerName,
-	}
 	deploy.Spec.Template.Spec.Containers = []corev1.Container{
 		{Image: "testimage"},
 	}
@@ -189,12 +185,12 @@ func TestIsDeploymentMarked(t *testing.T) {
 		{
 			name:       "unmarked deployment",
 			deploy:     initDeployObj(),
-			expectedOk: false,
+			expectedOk: true,
 		},
 		{
 			name:       "marked deployment",
 			deploy:     initDeployAddonObj(),
-			expectedOk: true,
+			expectedOk: false,
 		},
 	}
 
@@ -210,7 +206,7 @@ func TestIsDeploymentMarked(t *testing.T) {
 				assert.Nil(t, aCtrl.spokeUncachedClient.Create(ctx, c.deploy), "")
 			}
 
-			ok := aCtrl.isDeploymentMarked(ctx)
+			ok := aCtrl.isHypershiftOperatorByMCE(ctx)
 			assert.Equal(t, c.expectedOk, ok, "ok as expected")
 		})
 	}
@@ -231,17 +227,17 @@ func TestDeploymentExistsWithNoImage(t *testing.T) {
 			expectedOk: true,
 		},
 		{
-			name:       "hypershift-operator Deployment, not owned by acm addon",
+			name:       "hypershift-operator Deployment, does not have not-by-mce annotation",
 			deploy:     initDeployObj(),
-			expectedOk: false,
-		},
-		{
-			name:       "hypershift-operator Deployment, owned by acm addon with identical images",
-			deploy:     initDeployAddonObj(),
 			expectedOk: true,
 		},
 		{
-			name:          "hypershift-operator Deployment, owned by acm addon with identical images",
+			name:       "hypershift-operator Deployment, has not-by-mce = true annotation with identical images",
+			deploy:     initDeployAddonObj(),
+			expectedOk: false,
+		},
+		{
+			name:          "hypershift-operator Deployment, does not have not-by-mce annotation with different images",
 			deploy:        initDeployAddonImageDiffObj(),
 			operatorImage: "my-new-image02",
 			expectedOk:    true,
@@ -403,9 +399,8 @@ func TestRunHypershiftInstall(t *testing.T) {
 			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "operator",
-			Namespace:   "hypershift",
-			Annotations: map[string]string{util.HypershiftAddonAnnotationKey: util.AddonControllerName},
+			Name:      "operator",
+			Namespace: "hypershift",
 		},
 		Spec: appsv1.DeploymentSpec{
 			Template: corev1.PodTemplateSpec{
@@ -808,9 +803,8 @@ func TestRunHypershiftInstallPrivateLinkExternalDNS(t *testing.T) {
 			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "operator",
-			Namespace:   "hypershift",
-			Annotations: map[string]string{util.HypershiftAddonAnnotationKey: util.AddonControllerName},
+			Name:      "operator",
+			Namespace: "hypershift",
 		},
 		Spec: appsv1.DeploymentSpec{
 			Template: corev1.PodTemplateSpec{
@@ -957,9 +951,8 @@ func TestRunHypershiftInstallEnableRHOBS(t *testing.T) {
 			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "operator",
-			Namespace:   "hypershift",
-			Annotations: map[string]string{util.HypershiftAddonAnnotationKey: util.AddonControllerName},
+			Name:      "operator",
+			Namespace: "hypershift",
 		},
 		Spec: appsv1.DeploymentSpec{
 			Template: corev1.PodTemplateSpec{
@@ -1079,9 +1072,8 @@ func TestRunHypershiftInstallExternalDNSDifferentSecret(t *testing.T) {
 			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "operator",
-			Namespace:   "hypershift",
-			Annotations: map[string]string{util.HypershiftAddonAnnotationKey: util.AddonControllerName},
+			Name:      "operator",
+			Namespace: "hypershift",
 		},
 		Spec: appsv1.DeploymentSpec{
 			Template: corev1.PodTemplateSpec{
@@ -1360,9 +1352,8 @@ func TestSkipHypershiftInstallWithNoChange(t *testing.T) {
 			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "operator",
-			Namespace:   "hypershift",
-			Annotations: map[string]string{util.HypershiftAddonAnnotationKey: util.AddonControllerName},
+			Name:      "operator",
+			Namespace: "hypershift",
 		},
 		Spec: appsv1.DeploymentSpec{
 			Template: corev1.PodTemplateSpec{
@@ -1638,9 +1629,8 @@ func TestOperatorImagesUpdatedCheck(t *testing.T) {
 			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "operator",
-			Namespace:   "hypershift",
-			Annotations: map[string]string{util.HypershiftAddonAnnotationKey: util.AddonControllerName},
+			Name:      "operator",
+			Namespace: "hypershift",
 		},
 		Spec: appsv1.DeploymentSpec{
 			Template: corev1.PodTemplateSpec{

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -33,9 +33,9 @@ const (
 	HypershiftOperatorExternalDNSName = "external-dns"
 
 	// Labels for resources to reference the Hosted Cluster
-	HypershiftClusterNameLabel      = "hypershiftdeployments.cluster.open-cluster-management.io/cluster-name"
-	HypershiftHostingNamespaceLabel = "hypershiftdeployments.cluster.open-cluster-management.io/hosting-namespace"
-	HypershiftAddonAnnotationKey    = "hypershift.open-cluster-management.io/createBy"
+	HypershiftClusterNameLabel           = "hypershiftdeployments.cluster.open-cluster-management.io/cluster-name"
+	HypershiftHostingNamespaceLabel      = "hypershiftdeployments.cluster.open-cluster-management.io/hosting-namespace"
+	HypershiftOperatorNoMCEAnnotationKey = "hypershift.open-cluster-management.io/not-by-mce"
 
 	// ImageStream image names
 	ImageStreamAwsCapiProvider      = "cluster-api-provider-aws"


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Do not add `hypershift.open-cluster-management.io/createBy: hypershift-addon` annotation to HO deployment
* Do not check for the existence of the annotation to determine whether to update, always update
* Do not update-install if `hypershift.open-cluster-management.io/not-by-mce: true` annotation is added to HO deployment by users manually

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  to ensure that HO gets updated to be compatible with ACM/MCE

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-3477

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
