### PR TITLE
Delete managed cluster when hosted cluster is deleted

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -8,28 +8,29 @@ import (
 	"time"
 
 	"github.com/go-logr/zapr"
+	configv1 "github.com/openshift/api/config/v1"
+	hyperv1beta1 "github.com/openshift/hypershift/api/v1beta1"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stolostron/hypershift-addon-operator/pkg/metrics"
 	"github.com/stolostron/hypershift-addon-operator/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/clientcmd"
 	clustercsfake "open-cluster-management.io/api/client/cluster/clientset/versioned/fake"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
+	operatorapiv1 "open-cluster-management.io/api/operator/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	configv1 "github.com/openshift/api/config/v1"
-	hyperv1beta1 "github.com/openshift/hypershift/api/v1beta1"
-
-	"github.com/stolostron/hypershift-addon-operator/pkg/metrics"
 )
 
 func TestReconcile(t *testing.T) {
@@ -702,6 +703,105 @@ func TestRunControllerManager(t *testing.T) {
 	assert.NotNil(t, err, "err it not nil if the controller fail to run")
 }
 
+func Test_agentController_deleteManagedCluster(t *testing.T) {
+	ctx := context.Background()
+	client := initClient()
+	zapLog, _ := zap.NewDevelopment()
+
+	fakeClusterCS := clustercsfake.NewSimpleClientset()
+
+	kl := &operatorapiv1.Klusterlet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "klusterlet-hc-1",
+		},
+	}
+	err := client.Create(ctx, kl)
+	assert.Nil(t, err, "err nil when klusterlet is created successfully")
+
+	mc := &clusterv1.ManagedCluster{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "c1",
+		},
+		Spec: clusterv1.ManagedClusterSpec{
+			HubAcceptsClient:     false,
+			LeaseDurationSeconds: 0,
+		},
+	}
+	err = client.Create(ctx, mc)
+	assert.Nil(t, err, "err nil when managedcluster is created successfully")
+
+	hcNN := types.NamespacedName{Name: "hc-1", Namespace: "clusters"}
+	hcNoAnno := getHostedCluster(hcNN)
+	err = client.Create(ctx, hcNoAnno)
+	assert.Nil(t, err, "err nil when hostedcluster is created successfully")
+
+	hcNN2 := types.NamespacedName{Name: "hc-2", Namespace: "clusters"}
+	hcAnno := getHostedCluster(hcNN2)
+	hcAnno.Annotations = map[string]string{util.ManagedClusterAnnoKey: "c1"}
+	err = client.Create(ctx, hcAnno)
+	assert.Nil(t, err, "err nil when hostedcluster is created successfully")
+
+	aCtrl := &agentController{
+		spokeClustersClient:         fakeClusterCS,
+		spokeUncachedClient:         client,
+		spokeClient:                 client,
+		hubClient:                   client,
+		log:                         zapr.NewLogger(zapLog),
+		maxHostedClusterCount:       80,
+		thresholdHostedClusterCount: 60,
+	}
+
+	type args struct {
+		ctx context.Context
+		hc  *hyperv1beta1.HostedCluster
+	}
+	tests := []struct {
+		name    string
+		hc      *hyperv1beta1.HostedCluster
+		mc      *clusterv1.ManagedCluster
+		wantErr bool
+	}{
+		{
+			name:    "Delete nil hostedhosted",
+			hc:      nil,
+			wantErr: true,
+		},
+		{
+			name:    "Delete hostedhosted with no managedcluster-name annotation",
+			hc:      hcNoAnno,
+			mc:      mc,
+			wantErr: true,
+		},
+		{
+			name:    "Delete hostedhosted with no managedcluster-name annotation",
+			hc:      hcAnno,
+			mc:      mc,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := aCtrl.deleteManagedCluster(ctx, tt.hc); (err != nil) != tt.wantErr {
+				t.Errorf("agentController.deleteManagedCluster() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if mc != nil {
+				gotMc := &clusterv1.ManagedCluster{}
+				err = client.Get(ctx, types.NamespacedName{Name: mc.Name, Namespace: mc.Namespace}, gotMc)
+
+				if !tt.wantErr {
+					// Managed cluster is deleted
+					assert.NotNil(t, err, "err not nil if managed cluster is not found")
+					assert.True(t, apierrors.IsNotFound(err), "true if error is type IsNotFound")
+				} else {
+					assert.Nil(t, err, "err nil if managed cluster is found")
+				}
+			}
+		})
+	}
+}
+
 func initClient() client.Client {
 	scheme := runtime.NewScheme()
 	//corev1.AddToScheme(scheme)
@@ -710,6 +810,8 @@ func initClient() client.Client {
 	metav1.AddMetaToScheme(scheme)
 	hyperv1beta1.AddToScheme(scheme)
 	clusterv1alpha1.AddToScheme(scheme)
+	clusterv1.AddToScheme(scheme)
+	operatorapiv1.AddToScheme(scheme)
 
 	ncb := fake.NewClientBuilder()
 	ncb.WithScheme(scheme)

--- a/pkg/manager/manifests/templates/clusterrole.yaml
+++ b/pkg/manager/manifests/templates/clusterrole.yaml
@@ -19,8 +19,11 @@ rules:
     verbs: ["create", "update", "patch"]         
   # Allow addon to install hypershift
   - apiGroups: ["cluster.open-cluster-management.io"]
-    resources: ["clusterclaims"]
+    resources: ["clusterclaims", "managedclusters"]
     verbs: ["get", "list", "create", "patch", "update", "delete"]
+  - apiGroups: ["operator.open-cluster-management.io"]
+    resources: ["klusterlets"]
+    verbs: ["get", "list", "patch", "update"]    
   - apiGroups: [""]
     resources: ["services", "serviceaccounts", "configmaps", "secrets", "namespaces"]
     verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]     


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Delete the managed cluster when the hosted cluster is deleted

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  There are issues if the managed cluster is reused for another hosted cluster with the same name. By deleting the managed cluster when the HC is deleted, this performs the necessary cleanup and not have an orpaned MC. If another HC with the same name is provisioned, then user would need to create a new MC again.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-2094

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	20.979s	coverage: 72.1% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	277.322s	coverage: 87.1% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	1.384s	coverage: 56.2% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	0.657s	coverage: 100.0% of statements
```
