### PR TITLE
fix addonplacementscore on initial agent startup

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -383,7 +383,7 @@ func TestHostedClusterCount(t *testing.T) {
 		thresholdHostedClusterCount: 3,
 	}
 
-	err := aCtrl.SyncAddOnPlacementScore(ctx)
+	err := aCtrl.SyncAddOnPlacementScore(ctx, false)
 	assert.Nil(t, err, "err nil when CreateAddOnPlacementScore was successfully")
 
 	// No HC yet, so the zero cluster claim value should be true
@@ -403,7 +403,7 @@ func TestHostedClusterCount(t *testing.T) {
 		i++
 	}
 
-	err = aCtrl.SyncAddOnPlacementScore(ctx)
+	err = aCtrl.SyncAddOnPlacementScore(ctx, false)
 	assert.Nil(t, err, "err nil when CreateAddOnPlacementScore was successfully")
 
 	// Created 4 HCs, max 5 so the full cluster claim value should be false
@@ -441,7 +441,7 @@ func TestHostedClusterCount(t *testing.T) {
 	err = aCtrl.hubClient.Create(ctx, hc)
 	assert.Nil(t, err, "err nil when hosted cluster is created successfully")
 
-	err = aCtrl.SyncAddOnPlacementScore(ctx)
+	err = aCtrl.SyncAddOnPlacementScore(ctx, false)
 	assert.Nil(t, err, "err nil when CreateAddOnPlacementScore was successfully")
 
 	// 5 HCs, max 5 so the full cluster claim value should be true
@@ -471,7 +471,7 @@ func TestHostedClusterCount(t *testing.T) {
 	err = aCtrl.hubClient.Delete(ctx, hc)
 	assert.Nil(t, err, "err nil when hosted cluster is deleted successfully")
 
-	err = aCtrl.SyncAddOnPlacementScore(ctx)
+	err = aCtrl.SyncAddOnPlacementScore(ctx, false)
 	assert.Nil(t, err, "err nil when CreateAddOnPlacementScore was successfully")
 
 	fullClusterClaim, err = aCtrl.spokeClustersClient.ClusterV1alpha1().ClusterClaims().Get(context.TODO(), hostedClusterCountFullClusterClaimKey, metav1.GetOptions{})
@@ -499,7 +499,7 @@ func TestHostedClusterCount(t *testing.T) {
 	err = aCtrl.hubClient.Delete(ctx, hc)
 	assert.Nil(t, err, "err nil when hosted cluster is deleted successfully")
 
-	err = aCtrl.SyncAddOnPlacementScore(ctx)
+	err = aCtrl.SyncAddOnPlacementScore(ctx, false)
 	assert.Nil(t, err, "err nil when CreateAddOnPlacementScore was successfully")
 
 	// 3 HCs, threshold 3 so the threshold cluster claim value should be true
@@ -514,7 +514,7 @@ func TestHostedClusterCount(t *testing.T) {
 	err = aCtrl.hubClient.Delete(ctx, hc)
 	assert.Nil(t, err, "err nil when hosted cluster is deleted successfully")
 
-	err = aCtrl.SyncAddOnPlacementScore(ctx)
+	err = aCtrl.SyncAddOnPlacementScore(ctx, false)
 	assert.Nil(t, err, "err nil when CreateAddOnPlacementScore was successfully")
 
 	// 2 HCs, threshold 3 so the threshold cluster claim value should be true
@@ -537,7 +537,7 @@ func TestHostedClusterCount(t *testing.T) {
 	err = aCtrl.hubClient.Delete(ctx, hc)
 	assert.Nil(t, err, "err nil when hosted cluster is deleted successfully")
 
-	err = aCtrl.SyncAddOnPlacementScore(ctx)
+	err = aCtrl.SyncAddOnPlacementScore(ctx, false)
 	assert.Nil(t, err, "err nil when CreateAddOnPlacementScore was successfully")
 
 	// 0 HC, max 5 so the full cluster claim value should be false
@@ -588,7 +588,7 @@ func TestHostedClusterCountErrorCase(t *testing.T) {
 		i++
 	}
 
-	err := aCtrl.SyncAddOnPlacementScore(ctx)
+	err := aCtrl.SyncAddOnPlacementScore(ctx, false)
 	assert.Nil(t, err, "err nil when CreateAddOnPlacementScore was successfully")
 
 	clusterClaim, err := aCtrl.spokeClustersClient.ClusterV1alpha1().ClusterClaims().Get(context.TODO(), hostedClusterCountFullClusterClaimKey, metav1.GetOptions{})
@@ -605,7 +605,7 @@ func TestHostedClusterCountErrorCase(t *testing.T) {
 	// should contain a condition indicating the failure but the existing score should not change
 	// The score should still be 5
 	aCtrl.spokeUncachedClient = initErrorClient()
-	err = aCtrl.SyncAddOnPlacementScore(ctx)
+	err = aCtrl.SyncAddOnPlacementScore(ctx, false)
 	assert.Nil(t, err, "err nil when CreateAddOnPlacementScore was successfully")
 
 	err = aCtrl.hubClient.Get(ctx, placementScoreNN, placementScore)


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* When the agent starts up the very first time on a new hosting cluster, it fails to get the list of hosted clusters because the hypershift operator has not been installed yet. This causes the addonPlacementScore to have no HC count breaking a placement that uses the addonPlacementScore.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  This needs to be fixed to properly initialize the addonPlacementScore on a new agent startup.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-3896

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
2023-02-28T17:21:00.951Z	INFO	agent.agent-reconciler	agent/agent.go:574	this is the initial agent startup and the hypershift CRDs are not installed yet, no matches for kind "HostedCluster" in version "hypershift.openshift.io/v1beta1"
2023-02-28T17:21:00.959Z	INFO	agent.agent-reconciler	agent/agent.go:575	going to continue updating AddOnPlacementScore and cluster claims with zero HC count
2023-02-28T17:21:00.994Z	INFO	agent.agent-reconciler	agent/agent.go:646	updated the addOnPlacementScore for local-cluster: 0
2023-02-28T17:21:00.994Z	INFO	agent.agent-reconciler	agent/clusterclaim.go:74	the hosted cluster count has not reached the maximum 80 yet. current count is 0
```

```
apiVersion: cluster.open-cluster-management.io/v1alpha1
kind: AddOnPlacementScore
metadata:
  creationTimestamp: "2023-02-28T17:20:54Z"
  generation: 1
  name: hosted-clusters-score
  namespace: local-cluster
  resourceVersion: "1821363"
  uid: d781df03-a121-48e4-b062-3d46f5609fe9
status:
  conditions:
  - lastTransitionTime: "2023-02-28T17:21:00Z"
    message: Hosted cluster count was updated successfully
    reason: HostedClusterCountUpdated
    status: "True"
    type: HostedClusterCountUpdated
  scores:
  - name: hostedClustersCount
    value: 0
```

```
  clusterClaims:
  - name: id.k8s.io
    value: 1a3babbd-6098-4d81-b859-9917d7154424
  - name: kubeversion.open-cluster-management.io
    value: v1.24.0+9546431
  - name: platform.open-cluster-management.io
    value: AWS
  - name: product.open-cluster-management.io
    value: OpenShift
  - name: above.threshold.hostedclustercount.hypershift.openshift.io
    value: "false"
  - name: consoleurl.cluster.open-cluster-management.io
    value: https://console-openshift-console.apps.app-aws-411ga-hub-58hzk.dev06.red-chesterfield.com
  - name: controlplanetopology.openshift.io
    value: HighlyAvailable
  - name: full.hostedclustercount.hypershift.openshift.io
    value: "false"
  - name: hostingcluster.hypershift.openshift.io
    value: "true"
  - name: id.openshift.io
    value: 1a3babbd-6098-4d81-b859-9917d7154424
  - name: infrastructure.openshift.io
    value: '{"infraName":"app-aws-411ga-hub-58h-ppwpn"}'
  - name: oauthredirecturis.openshift.io
    value: https://oauth-openshift.apps.app-aws-411ga-hub-58hzk.dev06.red-chesterfield.com/oauth/token/implicit
  - name: region.open-cluster-management.io
    value: us-east-1
  - name: version.openshift.io
    value: 4.11.0
  - name: zero.hostedclustercount.hypershift.openshift.io
    value: "true"
```
