### PR TITLE
ACM-3863 dont enable hypershift cli download on consoleless OCP

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -128,11 +128,16 @@ func NewManagerCommand(componentName string, log logr.Logger) *cobra.Command {
 			os.Exit(1)
 		}
 
-		err = EnableHypershiftCLIDownload(hubClient, log)
-		if err != nil {
-			// unable to install HypershiftCLIDownload is not critical.
-			// log and continue
-			log.Error(err, "failed to enable hypershift CLI download")
+		//Don't create and enable hypershift-cli-download if OCP web console not installed
+		cliDownloadCRD := &consolev1.ConsoleCLIDownload{}
+		err = hubClient.Get(context.TODO(), client.ObjectKey{}, cliDownloadCRD)
+		if err == nil {
+			err = EnableHypershiftCLIDownload(hubClient, log)
+			if err != nil {
+				// unable to install HypershiftCLIDownload is not critical.
+				// log and continue
+				log.Error(err, "failed to enable hypershift CLI download")
+			}
 		}
 
 		<-ctx.Done()


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Don't attempt to enable the hypershift cli download on OCP clusters with no console

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  > may result in a spurious false-positive error in the log that could cause unnecessary concern when doing PD, and if logic were ever added following the CR-creation code then there might be short-circuiting of other important stuff

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-3863

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?       github.com/stolostron/hypershift-addon-operator/cmd     [no test files]
ok      github.com/stolostron/hypershift-addon-operator/pkg/agent       22.399s coverage: 72.2% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/install     280.763s        coverage: 87.0% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/manager     0.047s  coverage: 55.6% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/metrics     0.017s  coverage: 100.0% of statements
?       github.com/stolostron/hypershift-addon-operator/pkg/util        [no test files]
```
