### PR TITLE
Remove certificate-authority-data if HC has named certs

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -307,6 +307,20 @@ kind: Config`)
 	// Create hosted cluster
 	hc := getHostedCluster(hcNN)
 	hc.Annotations = map[string]string{util.ManagedClusterAnnoKey: "infra-abcdef"}
+	hc.Spec.Configuration = &hyperv1beta1.ClusterConfiguration{
+		APIServer: &configv1.APIServerSpec{
+			ServingCerts: configv1.APIServerServingCerts{
+				NamedCertificates: []configv1.APIServerNamedServingCert{
+					{
+						ServingCertificate: configv1.SecretNameReference{
+							Name: "test-tls",
+						},
+					},
+				},
+			},
+		},
+	}
+
 	err = aCtrl.hubClient.Create(ctx, hc)
 	assert.Nil(t, err, "err nil when hosted cluster is created successfully")
 
@@ -841,6 +855,133 @@ func Test_agentController_deleteManagedCluster(t *testing.T) {
 				} else {
 					assert.Nil(t, err, "err nil if managed cluster is found")
 				}
+			}
+		})
+	}
+}
+
+var kubeconfig0 = `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: test
+    server: https://kube-apiserver.ocm-dev-1sv4l4ldnr6rd8ni12ndo4vtiq2gd7a4-sbarouti267.svc.cluster.local:7443
+  name: cluster
+contexts:
+- context:
+    cluster: cluster
+    namespace: default
+    user: admin
+  name: admin
+current-context: admin
+kind: Config
+`
+
+var kubeconfig1 = `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: test
+    server: https://kube-apiserver.ocm-dev-1sv4l4ldnr6rd8ni12ndo4vtiq2gd7a4-sbarouti267.svc.cluster.local:7443
+  name: cluster
+contexts:
+- context:
+    cluster: cluster
+    namespace: default
+    user: admin
+  name: admin
+current-context: admin
+kind: Config
+`
+
+var kubeconfig2 = `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: test
+    server: https://kube-apiserver.ocm-dev-1sv4l4ldnr6rd8ni12ndo4vtiq2gd7a4-sbarouti267.svc.cluster.local:7443
+  name: cluster
+contexts:
+- context:
+    cluster: cluster
+    namespace: default
+    user: admin
+  name: admin
+current-context: admin
+kind: Config
+`
+
+func Test_removeCertAuthDataFromKubeConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		kubeconfig []byte
+	}{
+		{
+			name:       "No cluster",
+			kubeconfig: []byte(kubeconfig0),
+		},
+		{
+			name:       "Single cluster",
+			kubeconfig: []byte(kubeconfig1),
+		},
+		{
+			name:       "Two cluster",
+			kubeconfig: []byte(kubeconfig2),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := removeCertAuthDataFromKubeConfig(tt.kubeconfig)
+			assert.Nil(t, err, "No error removing certificate-authority-data")
+
+			gotConfig, err := clientcmd.Load(got)
+			assert.Nil(t, err, "No error loading updated kubeconfig")
+
+			for _, v := range gotConfig.Clusters {
+				assert.Nil(t, v.CertificateAuthorityData, "No certificate-authority-data")
+				assert.True(t, v.InsecureSkipTLSVerify)
+			}
+		})
+	}
+}
+
+func Test_hasNameCerts(t *testing.T) {
+	hcNN1 := types.NamespacedName{Name: "hd-1", Namespace: "clusters"}
+	hc1 := getHostedCluster(hcNN1)
+
+	hcNN2 := types.NamespacedName{Name: "hd-2", Namespace: "clusters"}
+	hc2 := getHostedCluster(hcNN2)
+	hc2.Spec.Configuration = &hyperv1beta1.ClusterConfiguration{
+		APIServer: &configv1.APIServerSpec{
+			ServingCerts: configv1.APIServerServingCerts{
+				NamedCertificates: []configv1.APIServerNamedServingCert{
+					{
+						ServingCertificate: configv1.SecretNameReference{
+							Name: "test-tls",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		hc   *hyperv1beta1.HostedCluster
+		want bool
+	}{
+		{
+			name: "No ServingCertificate",
+			hc:   hc1,
+			want: false,
+		},
+		{
+			name: "Has ServingCertificate",
+			hc:   hc2,
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasNameCerts(tt.hc); got != tt.want {
+				t.Errorf("hasNameCerts() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Remove certificate-authority-data from the admin-kubeconfig on the hub if the hosted cluster has serving certificates.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Workaround issue where the serving certificate is replaced by a generated self-signed cert.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-3990

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	19.640s	coverage: 72.5% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	280.989s	coverage: 87.0% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	1.114s	coverage: 55.8% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	0.584s	coverage: 100.0% of statements
```
