### PR TITLE
Ho install flags overrides

### DIFF
--- a/docs/hypershift_operator_installation.md
+++ b/docs/hypershift_operator_installation.md
@@ -1,0 +1,115 @@
+# Hypershift Operator installation flags
+
+If you run `hypershift install --help` [hypershift CLI](https://github.com/stolostron/hypershift-addon-operator/blob/main/docs/installing_hypershift_cli.md) command, you can see the hypershift operator installation flags. For example,
+
+```
+Installs the HyperShift operator
+
+Usage:
+  hypershift install [flags]
+  hypershift install [command]
+
+Available Commands:
+  render      Render HyperShift Operator manifests to stdout
+
+Flags:
+      --additional-trust-bundle string                 Path to a file with user CA bundle
+      --aws-private-creds string                       Path to an AWS credentials file with privileges sufficient to manage private cluster resources
+      --aws-private-region string                      AWS region where private clusters are supported by this operator
+      --aws-private-secret string                      Name of an existing secret containing the AWS private link credentials.
+      --aws-private-secret-key string                  Name of the secret key containing the AWS private link credentials. (default "credentials")
+      --development                                    Enable tweaks to facilitate local development
+      --enable-admin-rbac-generation                   Generate RBAC manifests for hosted cluster admins
+      --enable-ci-debug-output                         If extra CI debug output should be enabled
+      --enable-conversion-webhook                      Enable webhook for converting hypershift API types (default true)
+      --enable-uwm-telemetry-remote-write              If true, HyperShift operator ensures user workload monitoring is enabled and that it is configured to remote write telemetry metrics from control planes
+      --enable-validating-webhook                      Enable webhook for validating hypershift API types
+      --exclude-etcd                                   Leave out etcd manifests
+      --external-dns-credentials string                Credentials to use for managing DNS records using external-dns
+      --external-dns-domain-filter string              Restrict external-dns to changes within the specifed domain.
+      --external-dns-provider string                   Provider to use for managing DNS records using external-dns
+      --external-dns-secret string                     Name of an existing secret containing the external-dns credentials.
+      --external-dns-txt-owner-id string               external-dns TXT registry owner ID.
+  -h, --help                                           help for install
+      --hypershift-image string                        The HyperShift image to deploy (default "quay.io/hypershift/hypershift-operator:latest")
+      --image-refs string                              Image references to user in Hypershift installation
+      --metrics-set metricsSet                         The set of metrics to produce for each HyperShift control plane. Valid values are: Telemetry, SRE, All (default Telemetry)
+      --namespace string                               The namespace in which to install HyperShift (default "hypershift")
+      --oidc-storage-provider-s3-bucket-name string    Name of the bucket in which to store the clusters OIDC discovery information. Required for AWS guest clusters
+      --oidc-storage-provider-s3-credentials string    Credentials to use for writing the OIDC documents into the S3 bucket. Required for AWS guest clusters
+      --oidc-storage-provider-s3-region string         Region of the OIDC bucket. Required for AWS guest clusters
+      --oidc-storage-provider-s3-secret string         Name of an existing secret containing the OIDC S3 credentials.
+      --oidc-storage-provider-s3-secret-key string     Name of the secret key containing the OIDC S3 credentials. (default "credentials")
+      --platform-monitoring PlatformMonitoringOption   Select an option for enabling platform cluster monitoring. Valid values are: None, OperatorOnly, All
+      --private-platform string                        Platform on which private clusters are supported by this operator (supports "AWS" or "None") (default "None")
+      --rhobs-monitoring                               If true, HyperShift will generate and use the RHOBS version of monitoring resources (ServiceMonitors, PodMonitors, etc)
+      --wait-until-available                           If true, pauses installation until hypershift operator has been rolled out and its webhook service is available (if installing the webhook)
+```
+
+You optionally create some secrets to [configure a hosting cluster](https://github.com/stolostron/hypershift-addon-operator/blob/main/docs/provision_hosted_cluster_on_mce_local_cluster.md#configuring-the-hosting-cluster). The hypershift addon agent uses these secrets to build some of these installation flags.
+
+## OIDC S3 credentials secret
+
+If you create the OIDC S3 credentials secret for the HyperShift operator named `hypershift-operator-oidc-provider-s3-credentials` in `local-cluster` namespace, the hypershift addon agent uses this secret to build the following hypershift operator installation flags.
+
+```
+    --oidc-storage-provider-s3-bucket-name string    Name of the bucket in which to store the clusters OIDC discovery information. Required for AWS guest clusters
+    --oidc-storage-provider-s3-credentials string    Credentials to use for writing the OIDC documents into the S3 bucket. Required for AWS guest clusters
+    --oidc-storage-provider-s3-region string         Region of the OIDC bucket. Required for AWS guest clusters
+```
+
+## AWS private link secret
+
+If you create the AWS private link secret named `hypershift-operator-private-link-credentials` in `local-cluster` namespace, the hypershift addon agent uses this secret to build the following hypershift operator installation flags.
+
+```
+    --aws-private-creds string                       Path to an AWS credentials file with privileges sufficient to manage private cluster resources
+    --aws-private-region string                      AWS region where private clusters are supported by this operator
+    --aws-private-secret string                      Name of an existing secret containing the AWS private link credentials.
+```
+
+## External DNS secret
+
+If you create the external DNS secret named `hypershift-operator-external-dns-credentials` in `local-cluster` namespace, the hypershift addon agent uses this secret to build the following hypershift operator installation flags.
+
+```
+    --external-dns-domain-filter string              Restrict external-dns to changes within the specifed domain.
+    --external-dns-provider string                   Provider to use for managing DNS records using external-dns
+    --external-dns-secret string                     Name of an existing secret containing the external-dns credentials.
+    --external-dns-txt-owner-id string               external-dns TXT registry owner ID.
+```
+
+## Other default installation flags
+
+These are other installation flags that the hypershift addon agent sets by default when it installs or upgrades the hypershift operator.
+
+```
+--image-refs                            <the image references from MCE installation>
+--platform-monitoring                   OperatorOnly
+--enable-uwm-telemetry-remote-write
+```
+
+## Customizing the hypershift operator installation flags
+
+The installation flags for the `oidc-storage-provider-s3`, `aws-private` and `external-dns` can be updated by updating the corresponding secrets.
+
+You cannot update the `--image-refs`.
+
+If you want to add or remove other installation flags, create a config map named `hypershift-operator-install-flags` in `local-cluster` namespace.
+
+```yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: hypershift-operator-install-flags
+  namespace: local-cluster
+data:
+  installFlagsToAdd: "--metrics-set SRE --exclude-etcd"
+  installFlagsToRemove: "--enable-uwm-telemetry-remote-write"
+```
+
+The installation flags and their values specified in `data.installFlagsToAdd` are used when the hypershift addon agent installs the hypershift operator. All flag keys and values are added as a single string delimited by a space.
+
+The installation flags specified in `data.installFlagsToRemove` are removed when the hypershift addon agent installs the hypershift operator. So if you want to remove the default `--enable-uwm-telemetry-remote-write` flag, add it in `data.installFlagsToRemove`. All flag keys are added as a single string delimited by a space and you do not need to add the flag values.
+
+**Note:** The hypershift addon agent checks for any data change `hypershift-operator-install-flags` configmap in `local-cluster` namespace every 2 minutes and re-installs the hypershift operator if there is a change.

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -11,6 +11,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	hyperv1beta1 "github.com/openshift/hypershift/api/v1beta1"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stolostron/hypershift-addon-operator/pkg/install"
 	"github.com/stolostron/hypershift-addon-operator/pkg/metrics"
 	"github.com/stolostron/hypershift-addon-operator/pkg/util"
 	"github.com/stretchr/testify/assert"
@@ -719,6 +720,7 @@ func TestAgentCommand(t *testing.T) {
 func TestCleanupCommand(t *testing.T) {
 	ctx := context.Background()
 	zapLog, _ := zap.NewDevelopment()
+
 	cleanupCmd := NewCleanupCommand("operator", zapr.NewLogger(zapLog))
 	assert.Equal(t, "cleanup", cleanupCmd.Use)
 
@@ -730,7 +732,10 @@ func TestCleanupCommand(t *testing.T) {
 		AddonNamespace: "hypershift",
 	}
 
-	err := o.runCleanup(ctx, nil)
+	uCtrl := install.NewUpgradeController(nil, initClient(), o.Log, o.AddonName, o.AddonNamespace, "my-spoke-cluster",
+		"my-test-image", "my-pull-secret", true, ctx)
+
+	err := o.runCleanup(ctx, uCtrl)
 	assert.Nil(t, err, "is nil if cleanup is succcessful")
 }
 

--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -318,7 +318,7 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 
 	// Get the hypershift operator installation flags configmap from the hub
 	installFlagsCM := c.getConfigMapFromHub(util.HypershiftInstallFlagsCM)
-	c.imageOverrideConfigmap = installFlagsCM
+	c.installFlagsConfigmap = installFlagsCM
 
 	hypershiftImage := c.operatorImage
 	imageStreamCMData := make(map[string]string, 0)

--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -316,28 +316,9 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 	// cache the external DNS secret for comparison againt the hub's to detect any change
 	c.extDnsSecret = *sExtDNS
 
-	//Enable control plane telemetry forwarding
-	telemetryArgs := []string{
-		"--platform-monitoring", "OperatorOnly",
-	}
-	args = append(args, telemetryArgs...)
-
-	// Enable RHOBS
-	if strings.EqualFold(os.Getenv("RHOBS_MONITORING"), "true") {
-		c.log.Info("RHOBS_MONITORING=true, adding --rhobs-monitoring true --metrics-set SRE")
-		rhobsArgs := []string{
-			"--rhobs-monitoring",
-			"true",
-			"--metrics-set",
-			"SRE",
-		}
-		args = append(args, rhobsArgs...)
-	} else {
-		uwmArgs := []string{
-			"--enable-uwm-telemetry-remote-write",
-		}
-		args = append(args, uwmArgs...)
-	}
+	// Get the hypershift operator installation flags configmap from the hub
+	installFlagsCM := c.getConfigMapFromHub(util.HypershiftInstallFlagsCM)
+	c.imageOverrideConfigmap = installFlagsCM
 
 	hypershiftImage := c.operatorImage
 	imageStreamCMData := make(map[string]string, 0)
@@ -359,13 +340,18 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 			!(c.operatorImagesUpdated(im, *operatorDeployment) ||
 				c.secretDataUpdated(util.HypershiftBucketSecretName, *se) ||
 				c.secretDataUpdated(util.HypershiftPrivateLinkSecretName, *spl) ||
-				c.secretDataUpdated(util.HypershiftExternalDNSSecretName, *sExtDNS)) {
-			c.log.Info("no change in hypershift operator images and secrets, skipping hypershift operator installation")
+				c.secretDataUpdated(util.HypershiftExternalDNSSecretName, *sExtDNS) ||
+				c.configmapDataUpdated(util.HypershiftInstallFlagsCM, installFlagsCM)) {
+			c.log.Info("no change in hypershift operator images, secrets and install flags, skipping hypershift operator installation")
 			return nil
 		}
 	} else {
 		args = append(args, "--hypershift-image", hypershiftImage)
 	}
+
+	// migrate the install flags that we used to add by default
+	// and add the rest of operator installation flags user specified
+	args = append(args, c.buildOtherInstallFlags(installFlagsCM)...)
 
 	// Emit metrics to indicate that hypershift operator installation is in progress
 	metrics.InInstallationOrUpgradeBool.Set(1)
@@ -415,6 +401,9 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 	if err := c.saveSecretLocally(ctx, sExtDNS); err != nil { // external DNS secret
 		return err
 	}
+	if err := c.saveConfigmapLocally(ctx, &installFlagsCM); err != nil { // hypershift operator installation flags
+		return err
+	}
 
 	// Add label and update image pull secret in Hypershift deployment
 	err = c.updateHyperShiftDeployment(ctx)
@@ -423,6 +412,103 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 	}
 
 	return nil
+}
+
+func (c *UpgradeController) buildOtherInstallFlags(installFlagsCM corev1.ConfigMap) []string {
+	flagsToAdd := []string{}
+	flagsToRemove := []string{}
+
+	if installFlagsCM.Data != nil {
+		c.log.Info(fmt.Sprintf("found %s configmap for the hypershift operator installation", util.HypershiftInstallFlagsCM))
+		flagsToAdd = strings.Fields(installFlagsCM.Data["installFlagsToAdd"])
+		flagsToRemove = strings.Fields(installFlagsCM.Data["installFlagsToRemove"])
+	}
+
+	args := []string{}
+
+	//Enable control plane telemetry forwarding
+	telemetryArgs := []string{
+		"--platform-monitoring", "OperatorOnly",
+	}
+	if !contains(flagsToRemove, "--platform-monitoring") { // if the flagsToRemove contains --platform-monitoring, do not add it
+		if contains(flagsToAdd, "--platform-monitoring") { // if the flagsToAdd contains --platform-monitoring, get the value from the list
+			val := getParamValue(flagsToAdd, "--platform-monitoring")
+			if val == "" {
+				c.log.Info("--platform-monitoring does not have any value in installParamsToAdd, setting it to default [ --platform-monitoringOperatorOnly ]")
+				args = append(args, telemetryArgs...)
+			} else {
+				c.log.Info(fmt.Sprintf("updating the install flag [ --platform-monitoring %s ]", val))
+				args = append(args, []string{
+					"--platform-monitoring", val,
+				}...)
+			}
+		} else {
+			args = append(args, telemetryArgs...)
+		}
+	}
+
+	// Enable RHOBS
+	if strings.EqualFold(os.Getenv("RHOBS_MONITORING"), "true") {
+		c.log.Info("RHOBS_MONITORING=true, adding --rhobs-monitoring true --metrics-set SRE")
+		rhobsArgs := []string{
+			"--rhobs-monitoring",
+			"true",
+			"--metrics-set",
+			"SRE",
+		}
+		args = append(args, rhobsArgs...)
+	} else {
+		// add --enable-uwm-telemetry-remote-write only if RHOBS monitoring is not enabled
+		uwmArgs := []string{
+			"--enable-uwm-telemetry-remote-write",
+		}
+		if contains(flagsToRemove, "--enable-uwm-telemetry-remote-write") {
+			c.log.Info("installFlagsToRemove contains --enable-uwm-telemetry-remote-write, removing it from the install flag list")
+		} else {
+			args = append(args, uwmArgs...)
+		}
+	}
+
+	// now add the rest of installParamsToAdd
+	for _, flag := range flagsToAdd {
+		// if the string is a flag key having -- prefix and not already added to the args
+		if strings.HasPrefix(flag, "--") && !contains(args, flag) {
+			flagVal := getParamValue(flagsToAdd, flag)
+			flagArgs := []string{flag}
+			if flagVal != "" {
+				flagArgs = append(flagArgs, flagVal)
+			}
+			args = append(args, flagArgs...)
+			c.log.Info(fmt.Sprintf("install flag [ %v ] added", flagArgs))
+		}
+	}
+
+	return args
+}
+
+func contains(theList []string, flagToFind string) bool {
+	for _, flag := range theList {
+		if flag == flagToFind {
+			return true
+		}
+	}
+	return false
+}
+
+func getParamValue(s []string, e string) string {
+	for i, a := range s {
+		if a == e {
+			if i == (len(s) - 1) {
+				return ""
+			}
+			if !strings.HasPrefix(s[i+1], "--") {
+				return s[i+1]
+			} else {
+				return ""
+			}
+		}
+	}
+	return ""
 }
 
 func (c *UpgradeController) createAwsSpokeSecret(ctx context.Context, hubSecret *corev1.Secret, regionRequired bool) error {
@@ -473,6 +559,24 @@ func (c *UpgradeController) saveSecretLocally(ctx context.Context, hubSecret *co
 		c.log.Info(fmt.Sprintf("save the secret (%s/%s) locally on cluster %s", c.addonNamespace, hubSecret.Name, c.clusterName))
 		_, err := controllerutil.CreateOrUpdate(ctx, c.spokeUncachedClient, spokeSecret, func() error {
 			spokeSecret.Data = hubSecret.Data
+			return nil
+		})
+		return err
+	}
+	return nil
+}
+
+func (c *UpgradeController) saveConfigmapLocally(ctx context.Context, hubConfigmap *corev1.ConfigMap) error {
+	if hubConfigmap.Name != "" {
+		spokeConfigmap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hubConfigmap.Name,
+				Namespace: c.addonNamespace,
+			},
+		}
+		c.log.Info(fmt.Sprintf("save the configmap (%s/%s) locally on cluster %s", c.addonNamespace, hubConfigmap.Name, c.clusterName))
+		_, err := controllerutil.CreateOrUpdate(ctx, c.spokeUncachedClient, spokeConfigmap, func() error {
+			spokeConfigmap.Data = hubConfigmap.Data
 			return nil
 		})
 		return err
@@ -611,7 +715,7 @@ func (c *UpgradeController) readInDownstreamOverride() ([]byte, error) {
 
 	// This is the user provided upgrade images configmap
 	// Override the image values in the installer provided imagestream with this
-	imUpgradeConfigMap := c.getImageOverrideMapFromHub()
+	imUpgradeConfigMap := c.getConfigMapFromHub(util.HypershiftOverrideImagesCM)
 	if imUpgradeConfigMap.Data != nil {
 		c.log.Info(fmt.Sprintf("found %s configmap, overriding hypershift images in the imagestream", util.HypershiftOverrideImagesCM))
 
@@ -748,6 +852,22 @@ func (c *UpgradeController) secretDataUpdated(secretName string, secret corev1.S
 
 	if !reflect.DeepEqual(localSecret.Data, secret.Data) { // compare only the secret data
 		c.log.Info("the secret has changed")
+		return true
+	}
+
+	return false
+}
+
+func (c *UpgradeController) configmapDataUpdated(cmName string, cm corev1.ConfigMap) bool {
+	c.log.Info(fmt.Sprintf("comparing hypershift operator installation flags configmap(%s) to the locally saved configmap", cmName))
+	cmKey := types.NamespacedName{Name: cmName, Namespace: c.addonNamespace}
+	localCM := &corev1.ConfigMap{}
+	if err := c.spokeUncachedClient.Get(context.TODO(), cmKey, localCM); err != nil && !apierrors.IsNotFound(err) {
+		c.log.Error(err, "failed to find configmap:") // just log and continue
+	}
+
+	if !reflect.DeepEqual(localCM.Data, cm.Data) { // compare only the configmap data
+		c.log.Info("the configmap has changed")
 		return true
 	}
 

--- a/pkg/install/hypershift_test.go
+++ b/pkg/install/hypershift_test.go
@@ -47,7 +47,6 @@ func initClient() ctrlClient.Client {
 	ncb := fake.NewClientBuilder()
 	ncb.WithScheme(scheme)
 	return ncb.Build()
-
 }
 
 func initErrorClient() ctrlClient.Client {
@@ -56,7 +55,6 @@ func initErrorClient() ctrlClient.Client {
 	ncb := fake.NewClientBuilder()
 	ncb.WithScheme(scheme)
 	return ncb.Build()
-
 }
 
 func initDeployObj() *appsv1.Deployment {
@@ -875,9 +873,9 @@ func TestRunHypershiftInstallPrivateLinkExternalDNS(t *testing.T) {
 				"--external-dns-domain-filter", "my.house.com",
 				"--external-dns-provider", "aws",
 				"--external-dns-txt-owner-id", "the-owner",
+				"--hypershift-image", "my-test-image",
 				"--platform-monitoring", "OperatorOnly",
 				"--enable-uwm-telemetry-remote-write",
-				"--hypershift-image", "my-test-image",
 			}
 			assert.Equal(t, expectArgs, installJob.Spec.Template.Spec.Containers[0].Args, "mismatched container arguments")
 		}
@@ -983,10 +981,10 @@ func TestRunHypershiftInstallEnableRHOBS(t *testing.T) {
 			installJob := installJobList.Items[0]
 			expectArgs := []string{
 				"--namespace", "hypershift",
+				"--hypershift-image", "my-test-image",
 				"--platform-monitoring", "OperatorOnly",
 				"--rhobs-monitoring", "true",
 				"--metrics-set", "SRE",
-				"--hypershift-image", "my-test-image",
 			}
 			assert.Equal(t, expectArgs, installJob.Spec.Template.Spec.Containers[0].Args, "mismatched container arguments")
 			assert.Equal(t, "RHOBS_MONITORING", installJob.Spec.Template.Spec.Containers[0].Env[0].Name, "RHOBS_MONITORING environment variable should exist")
@@ -1133,9 +1131,9 @@ func TestRunHypershiftInstallExternalDNSDifferentSecret(t *testing.T) {
 				"--external-dns-domain-filter", "my.house.com",
 				"--external-dns-provider", "aws",
 				"--external-dns-txt-owner-id", "the-owner",
+				"--hypershift-image", "my-test-image",
 				"--platform-monitoring", "OperatorOnly",
 				"--enable-uwm-telemetry-remote-write",
-				"--hypershift-image", "my-test-image",
 			}
 			assert.Equal(t, expectArgs, installJob.Spec.Template.Spec.Containers[0].Args, "mismatched container arguments")
 		}

--- a/pkg/manager/cli_download_install.go
+++ b/pkg/manager/cli_download_install.go
@@ -22,7 +22,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-
 func EnableHypershiftCLIDownload(hubclient client.Client, log logr.Logger) error {
 	// get the current version of MCE CSV from multicluster-engine namespace
 	csv, err := GetMCECSV(hubclient, log)

--- a/pkg/manager/cli_download_install_test.go
+++ b/pkg/manager/cli_download_install_test.go
@@ -10,13 +10,13 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	mcev1 "github.com/stolostron/backplane-operator/api/v1"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	mcev1 "github.com/stolostron/backplane-operator/api/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -228,11 +228,10 @@ func getTestClusterRole() *rbacv1.ClusterRole {
 func getTestMCE(name string, namespace string) *mcev1.MultiClusterEngine {
 	mce := &mcev1.MultiClusterEngine{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
+			Name: name,
 		},
 		Spec: mcev1.MultiClusterEngineSpec{
-			TargetNamespace:    namespace,
-			
+			TargetNamespace: namespace,
 		},
 	}
 	return mce

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -27,6 +27,7 @@ const (
 
 	HypershiftOverrideImagesCM = "hypershift-override-images"
 	ImageUpgradeControllerName = "hypershift-image-upgrade"
+	HypershiftInstallFlagsCM   = "hypershift-operator-install-flags"
 
 	HypershiftOperatorNamespace       = "hypershift"
 	HypershiftOperatorName            = "operator"


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Allow users to add or remove hypershift operator installation options
* Tests and documentation

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  So users can customize the hypershift operator installations

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-4093

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
KUBEBUILDER_ASSETS="/Users/rokej/Library/Application Support/io.kubebuilder.envtest/k8s/1.22.1-darwin-amd64" go test github.com/stolostron/hypershift-addon-operator/cmd github.com/stolostron/hypershift-addon-operator/pkg/agent github.com/stolostron/hypershift-addon-operator/pkg/install github.com/stolostron/hypershift-addon-operator/pkg/manager github.com/stolostron/hypershift-addon-operator/pkg/metrics github.com/stolostron/hypershift-addon-operator/pkg/util -coverprofile cover.out
?   	github.com/stolostron/hypershift-addon-operator/cmd	[no test files]
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	39.419s	coverage: 71.1% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	176.307s	coverage: 86.0% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	1.025s	coverage: 55.8% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	0.503s	coverage: 100.0% of statements
?   	github.com/stolostron/hypershift-addon-operator/pkg/util	[no test files]
```
