### PR TITLE
ACM-3429 retry retrieving mce csv

### DIFF
--- a/pkg/manager/cli_download_install.go
+++ b/pkg/manager/cli_download_install.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/ghodss/yaml"
 	"github.com/go-logr/logr"
@@ -24,7 +25,22 @@ import (
 
 func EnableHypershiftCLIDownload(hubclient client.Client, log logr.Logger) error {
 	// get the current version of MCE CSV from multicluster-engine namespace
-	csv, err := GetMCECSV(hubclient, log)
+
+	//Every 3 minutes, try to get csv in case of cluster upgrade (5 attempts)
+	var csv *operatorsv1alpha1.ClusterServiceVersion
+	var err error
+	for try := 1; try <= 5; try++ {
+		if try != 1 {
+			log.Error(err, "failed to get the most current version of MCE CSV from multicluster-engine namespace, retrying in 3 minutes (attempt %d/5)", try)
+			time.Sleep(3 * time.Minute)
+		}
+		csv, err = GetMCECSV(hubclient, log)
+		if err == nil {
+			break
+		}
+	}
+
+	//Failed 5 attempts
 	if err != nil {
 		log.Error(err, "failed to get the most current version of MCE CSV from multicluster-engine namespace")
 		return err


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Attempt to retrieve MCE csv multiple times in case of ACM upgrade

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  If hypershift-preview is enabled before ACM upgrade, the hypershift addon manager pod may be upgraded before the clusterrole is upgraded, which prevents addon-manager from retrieving the csv

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-3429

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?       github.com/stolostron/hypershift-addon-operator/cmd     [no test files]
ok      github.com/stolostron/hypershift-addon-operator/pkg/agent       17.348s coverage: 72.4% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/install     280.606s        coverage: 87.0% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/manager     0.047s  coverage: 56.4% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/metrics     0.011s  coverage: 100.0% of statements
?       github.com/stolostron/hypershift-addon-operator/pkg/util        [no test files]
```
