### PR TITLE
fix CLI download deployment

### DIFF
--- a/pkg/manager/cli_download_install_test.go
+++ b/pkg/manager/cli_download_install_test.go
@@ -101,6 +101,14 @@ func TestEnableHypershiftCLIDownload(t *testing.T) {
 	err = o.Client.Create(context.TODO(), clusterRole)
 	assert.Nil(t, err, "err nil when addon clusterRole is created successfully")
 
+	//
+	// Create the oc cli ConsoleCLIDownload to satisfy that condition that checks for
+	// existing ConsoleCLIDownload to determine whether to enable ConsoleCLIDownload for hypershift
+	//
+	ocCliDownload := getTestOCCLIDownload()
+	err = o.Client.Create(context.TODO(), ocCliDownload)
+	assert.Nil(t, err, "err nil when oc cli ConsoleCLIDownload is created successfully")
+
 	err = EnableHypershiftCLIDownload(o.Client, o.log)
 	assert.Nil(t, err, "err nil when hypershift CLI download is deployed successfully")
 
@@ -139,6 +147,124 @@ func TestEnableHypershiftCLIDownload(t *testing.T) {
 	assert.Equal(t, "open-cluster-management:hypershift-preview:hypershift-addon-manager", cliDownload.OwnerReferences[0].Name)
 }
 
+func TestEnableHypershiftCLIDownloadNoConsole(t *testing.T) {
+	controllerContext := &controllercmd.ControllerContext{}
+
+	client := initClient()
+	zapLog, _ := zap.NewDevelopment()
+	o := &override{
+		Client:            client,
+		log:               zapr.NewLogger(zapLog),
+		operatorNamespace: controllerContext.OperatorNamespace,
+		withOverride:      false,
+	}
+
+	//
+	// This section tests that we can find the correct MCE CSV
+	// and get the hypershift CLI container image reference from the CSV
+	//
+
+	// Create mock multicluster engine
+	newmce := getTestMCE("multiclusterengine", "multicluster-engine")
+	err := o.Client.Create(context.TODO(), newmce)
+	assert.Nil(t, err, "could not create test MCE")
+
+	// This should get no MCE CSV (error case)
+	csv, err := GetMCECSV(o.Client, o.log)
+	assert.NotNil(t, err, "no MCE CSV found")
+
+	// Create upstream MCE 2.1.0 CSV
+	newcsv := getTestMCECSV("v2.1.0", false)
+	err = o.Client.Create(context.TODO(), newcsv)
+	assert.Nil(t, err, "err nil when mce csv is created successfull")
+
+	// Create downstream MCE 2.1.1 CSV
+	newcsv = getTestMCECSV("v2.1.1", false)
+	err = o.Client.Create(context.TODO(), newcsv)
+	assert.Nil(t, err, "err nil when mce csv is created successfull")
+
+	// This should get upstream MCE 2.1.1 CSV
+	csv, err = GetMCECSV(o.Client, o.log)
+	assert.Nil(t, err, "err nil when mce csv is found")
+	assert.Equal(t, "multicluster-engine.v2.1.1", csv.Name)
+
+	// upstream CSV should not contain the hypershift cli image
+	cliImage := getHypershiftCLIDownloadImage(csv, o.log)
+	assert.Equal(t, "", cliImage)
+
+	// Create downstream MCE 2.2.0 CSV
+	newcsv = getTestMCECSV("v2.2.0", true)
+	err = o.Client.Create(context.TODO(), newcsv)
+	assert.Nil(t, err, "err nil when mce csv is created successfull")
+
+	// Create downstream MCE 2.2.1 CSV
+	newcsv = getTestMCECSV("v2.2.1", true)
+	err = o.Client.Create(context.TODO(), newcsv)
+	assert.Nil(t, err, "err nil when mce csv is created successfull")
+
+	// This should get MCE 2.2.1 CSV
+	csv, err = GetMCECSV(o.Client, o.log)
+	assert.Nil(t, err, "err nil when mce csv is found")
+	assert.Equal(t, "multicluster-engine.v2.2.1", csv.Name)
+
+	cliImage = getHypershiftCLIDownloadImage(csv, o.log)
+	assert.Equal(t, "https://hypershift.cli.image.io", cliImage)
+
+	//
+	// Create the hypershift addon deployment which is going to be the owner
+	// of hypershift CLI deployment, service and route. When the hypershift feature
+	// is disabled, the hypershift CLI deployment, service and route should be deleted.
+	//
+	dep := getTestAddonDeployment()
+	err = o.Client.Create(context.TODO(), dep)
+	assert.Nil(t, err, "err nil when addon deployment is created successfully")
+
+	//
+	// Create the hypershift clusterrole which is going to be the owner
+	// of hypershift ConsoleCLIDownload which is cluster scoped resource.
+	// When the hypershift feature is disabled, the hypershift ConsoleCLIDownload should be deleted.
+	//
+	clusterRole := getTestClusterRole()
+	err = o.Client.Create(context.TODO(), clusterRole)
+	assert.Nil(t, err, "err nil when addon clusterRole is created successfully")
+
+	err = EnableHypershiftCLIDownload(o.Client, o.log)
+	assert.Nil(t, err, "err nil when hypershift CLI download is deployed successfully")
+
+	// Check hypershift CLI deployment
+	cliDeployment := &appsv1.Deployment{}
+	cliDeploymentNN := types.NamespacedName{Namespace: "multicluster-engine", Name: "hypershift-cli-download"}
+	err = o.Client.Get(context.TODO(), cliDeploymentNN, cliDeployment)
+	assert.Nil(t, err, "err nil when hypershift CLI download deployment exists")
+	assert.Equal(t, "hypershift-addon-manager", cliDeployment.OwnerReferences[0].Name)
+
+	// Check hypershift CLI deployment proxy settings
+	assert.Equal(t, 3, len(cliDeployment.Spec.Template.Spec.Containers[0].Env))
+	assert.True(t, strings.HasSuffix(cliDeployment.Spec.Template.Spec.Containers[0].Env[0].Name, "_PROXY"))
+	assert.True(t, strings.HasSuffix(cliDeployment.Spec.Template.Spec.Containers[0].Env[1].Name, "_PROXY"))
+	assert.True(t, strings.HasSuffix(cliDeployment.Spec.Template.Spec.Containers[0].Env[2].Name, "_PROXY"))
+
+	// Check hypershift CLI service
+	cliService := &corev1.Service{}
+	cliServiceNN := types.NamespacedName{Namespace: "multicluster-engine", Name: "hypershift-cli-download"}
+	err = o.Client.Get(context.TODO(), cliServiceNN, cliService)
+	assert.Nil(t, err, "err nil when hypershift CLI download service exists")
+	assert.Equal(t, "hypershift-addon-manager", cliService.OwnerReferences[0].Name)
+
+	// Check hypershift CLI route
+	cliRoute := &routev1.Route{}
+	cliRouteNN := types.NamespacedName{Namespace: "multicluster-engine", Name: "hypershift-cli-download"}
+	err = o.Client.Get(context.TODO(), cliRouteNN, cliRoute)
+	assert.Nil(t, err, "err nil when hypershift CLI download route exists")
+	assert.Equal(t, "hypershift-addon-manager", cliRoute.OwnerReferences[0].Name)
+
+	// Check hypershift CLI ConsoleCLIDownload
+	cliDownload := &consolev1.ConsoleCLIDownload{}
+	cliDownloadNN := types.NamespacedName{Name: "hypershift-cli-download"}
+	err = o.Client.Get(context.TODO(), cliDownloadNN, cliDownload)
+	assert.EqualError(t, err, "consoleclidownloads.console.openshift.io \"hypershift-cli-download\" not found")
+}
+
 func getTestMCECSV(version string, downstream bool) *operatorsv1alpha1.ClusterServiceVersion {
 	csv := &operatorsv1alpha1.ClusterServiceVersion{
 		TypeMeta: metav1.TypeMeta{
@@ -166,6 +292,21 @@ func getTestMCECSV(version string, downstream bool) *operatorsv1alpha1.ClusterSe
 		}
 	}
 	return csv
+}
+
+func getTestOCCLIDownload() *consolev1.ConsoleCLIDownload {
+	cli := &consolev1.ConsoleCLIDownload{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConsoleCLIDownload",
+			APIVersion: "console.openshift.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "oc-cli-downloads",
+		},
+		Spec: consolev1.ConsoleCLIDownloadSpec{},
+	}
+
+	return cli
 }
 
 func getTestAddonDeployment() *appsv1.Deployment {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/go-logr/logr"
 	"github.com/openshift/library-go/pkg/assets"
@@ -31,6 +32,7 @@ import (
 	"github.com/openshift/hypershift/support/rhobsmonitoring"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	mcev1 "github.com/stolostron/backplane-operator/api/v1"
 	"github.com/stolostron/hypershift-addon-operator/pkg/util"
 	appsv1 "k8s.io/api/apps/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -58,6 +60,7 @@ func init() {
 	utilruntime.Must(rbacv1.AddToScheme(genericScheme))
 	utilruntime.Must(monitoringv1.AddToScheme(genericScheme))
 	utilruntime.Must(rhobsmonitoring.AddToScheme(genericScheme))
+	utilruntime.Must(mcev1.AddToScheme(genericScheme))
 }
 
 const (
@@ -129,15 +132,18 @@ func NewManagerCommand(componentName string, log logr.Logger) *cobra.Command {
 		}
 
 		//Don't create and enable hypershift-cli-download if OCP web console not installed
-		cliDownloadCRD := &consolev1.ConsoleCLIDownload{}
-		err = hubClient.Get(context.TODO(), client.ObjectKey{}, cliDownloadCRD)
-		if err == nil {
+		cliDownloadList := &consolev1.ConsoleCLIDownloadList{}
+		err = hubClient.List(context.TODO(), cliDownloadList)
+		if err == nil && (len(cliDownloadList.Items) > 0) {
+			log.Info("enabling hypershift CLI download ..")
 			err = EnableHypershiftCLIDownload(hubClient, log)
 			if err != nil {
 				// unable to install HypershiftCLIDownload is not critical.
 				// log and continue
 				log.Error(err, "failed to enable hypershift CLI download")
 			}
+		} else {
+			log.Info(fmt.Sprintf("skip to enable hypershift CLI download. err: %s, cli download count: %s", err.Error(), strconv.Itoa(len(cliDownloadList.Items))))
 		}
 
 		<-ctx.Done()

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
-	"strconv"
 
 	"github.com/go-logr/logr"
 	"github.com/openshift/library-go/pkg/assets"
@@ -131,19 +130,11 @@ func NewManagerCommand(componentName string, log logr.Logger) *cobra.Command {
 			os.Exit(1)
 		}
 
-		//Don't create and enable hypershift-cli-download if OCP web console not installed
-		cliDownloadList := &consolev1.ConsoleCLIDownloadList{}
-		err = hubClient.List(context.TODO(), cliDownloadList)
-		if err == nil && (len(cliDownloadList.Items) > 0) {
-			log.Info("enabling hypershift CLI download ..")
-			err = EnableHypershiftCLIDownload(hubClient, log)
-			if err != nil {
-				// unable to install HypershiftCLIDownload is not critical.
-				// log and continue
-				log.Error(err, "failed to enable hypershift CLI download")
-			}
-		} else {
-			log.Info(fmt.Sprintf("skip to enable hypershift CLI download. err: %s, cli download count: %s", err.Error(), strconv.Itoa(len(cliDownloadList.Items))))
+		err = EnableHypershiftCLIDownload(hubClient, log)
+		if err != nil {
+			// unable to install HypershiftCLIDownload is not critical.
+			// log and continue
+			log.Error(err, "failed to enable hypershift CLI download")
 		}
 
 		<-ctx.Done()


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Fix hypershift CLI download code that is broken by a couple of recent commits
* Fix the code that fails to list MulticlusterEngines resources (https://github.com/stolostron/backplane-operator/pull/400)
* Fix the code that tries to figure out if there is ConsoleCLIDownload resource (or CRD)

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Currently the manager does not deploy the hypershift CLI download

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-4230
* https://github.com/stolostron/backlog/issues/27211

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
Running tool: /usr/local/bin/go test -timeout 180s -coverprofile=/var/folders/6m/zwb5lxd157bgxp_wm4bv95fc0000gn/T/vscode-go3tqeO2/go-code-cover -run ^TestEnableHypershiftCLIDownload$ github.com/stolostron/hypershift-addon-operator/pkg/manager

ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	0.951s	coverage: 48.2% of statements
```


