### PR TITLE
Managed cluster not getting deleted when HC is deleted

### DIFF
--- a/example/addon-manager-deployment.yaml
+++ b/example/addon-manager-deployment.yaml
@@ -28,7 +28,7 @@ rules:
   resources: ["managedclusters"]
   verbs: ["get", "list", "watch", "patch", "update"]
 - apiGroups: ["rbac.authorization.k8s.io"]
-  resources: ["roles", "rolebindings"]
+  resources: ["roles", "rolebindings","clusterroles", "clusterrolebindings"]
   verbs: ["get", "list", "watch", "create", "update", "delete"]
 - apiGroups: ["authorization.k8s.io"]
   resources: ["subjectaccessreviews"]
@@ -36,6 +36,15 @@ rules:
 - apiGroups: ["cluster.open-cluster-management.io"]
   resources: ["addonplacementscores", "addonplacementscores/status"]
   verbs: ["get", "list", "watch", "create", "delete", "update", patch]
+- apiGroups: ["addon.open-cluster-management.io"]
+  resources: ["addondeploymentconfigs"]
+  verbs: ["get", "list", "watch"]  
+- apiGroups: ["operators.coreos.com"]
+  resources: ["clusterserviceversions"]
+  verbs: ["get", "list"]  
+- apiGroups: ["multicluster.openshift.io"]
+  resources: ["multiclusterengines"]
+  verbs: ["list"]  
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -719,6 +719,32 @@ func (c *agentController) deleteManagedCluster(ctx context.Context, hc *hyperv1b
 		managedClusterName = hc.Name
 	}
 
+	// Delete the managed cluster
+	mc := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: managedClusterName,
+		},
+	}
+
+	if err := c.hubClient.Get(ctx, client.ObjectKeyFromObject(mc), mc); err != nil {
+		if apierrors.IsNotFound(err) {
+			c.log.Info(fmt.Sprintf("managedCluster %v is already deleted", managedClusterName))
+			mc = nil
+		} else {
+			c.log.Info(fmt.Sprintf("failed to get the managedCluster %v", managedClusterName))
+			return err
+		}
+	}
+
+	if mc != nil {
+		if err := c.hubClient.Delete(ctx, mc); err != nil {
+			c.log.Info(fmt.Sprintf("failed to delete the managedCluster %v", managedClusterName))
+			return err
+		}
+
+		c.log.Info(fmt.Sprintf("deleted managedCluster %v", managedClusterName))
+	}
+
 	klusterletName := "klusterlet-" + managedClusterName
 
 	// Remove the operator.open-cluster-management.io/klusterlet-hosted-cleanup finalizer in klusterlet
@@ -728,11 +754,12 @@ func (c *agentController) deleteManagedCluster(ctx context.Context, hc *hyperv1b
 		},
 	}
 
-	if err := c.spokeClient.Get(ctx, client.ObjectKeyFromObject(klusterlet), klusterlet); err != nil {
+	if err := c.spokeUncachedClient.Get(ctx, client.ObjectKeyFromObject(klusterlet), klusterlet); err != nil {
 		if apierrors.IsNotFound(err) {
 			c.log.Info(fmt.Sprintf("klusterlet %v is already deleted", klusterletName))
+			return nil
 		} else {
-			c.log.Error(err, fmt.Sprintf("failed to get the klusterlet %v", klusterletName))
+			c.log.Info(fmt.Sprintf("failed to get the klusterlet %v", klusterletName))
 			return err
 		}
 	}
@@ -740,28 +767,13 @@ func (c *agentController) deleteManagedCluster(ctx context.Context, hc *hyperv1b
 	updated := controllerutil.RemoveFinalizer(klusterlet, "operator.open-cluster-management.io/klusterlet-hosted-cleanup")
 	c.log.Info(fmt.Sprintf("klusterlet %v finalizer removed:%v", klusterletName, updated))
 
-	// Delete the managed cluster
-	mc := &clusterv1.ManagedCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: managedClusterName,
-		},
-	}
-
-	if err := c.spokeClient.Get(ctx, client.ObjectKeyFromObject(mc), mc); err != nil {
-		if apierrors.IsNotFound(err) {
-			c.log.Info(fmt.Sprintf("managedCluster %v is already deleted", managedClusterName))
-		} else {
-			c.log.Error(err, fmt.Sprintf("failed to get the managedCluster %v", managedClusterName))
+	if updated {
+		if err := c.spokeUncachedClient.Update(ctx, klusterlet); err != nil {
+			c.log.Info("failed to update klusterlet to remove the finalizer")
 			return err
 		}
 	}
 
-	if err := c.spokeClient.Delete(ctx, mc); err != nil {
-		c.log.Error(err, fmt.Sprintf("failed to delete the managedCluster %v", managedClusterName))
-		return err
-	}
-
-	c.log.Info(fmt.Sprintf("deleted managedCluster %v", managedClusterName))
 	return nil
 }
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -75,6 +75,10 @@ var agentPermissionFiles = []string{
 	"manifests/permission/role.yaml",
 	// rolebinding to bind the above role to a certain user group
 	"manifests/permission/rolebinding.yaml",
+	// clusterrole with RBAC rules to access resources on hub
+	"manifests/permission/clusterrole.yaml",
+	// clusterrolebinding to bind the above role to a certain user group
+	"manifests/permission/clusterrolebinding.yaml",
 }
 
 type override struct {

--- a/pkg/manager/manifests/permission/clusterrole.yaml
+++ b/pkg/manager/manifests/permission/clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .RoleAndRolebindingName }}
+rules:
+  - apiGroups: ["cluster.open-cluster-management.io"]
+    resources: ["managedclusters"]
+    verbs: ["get", "list", "delete"]    

--- a/pkg/manager/manifests/permission/clusterrolebinding.yaml
+++ b/pkg/manager/manifests/permission/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .RoleAndRolebindingName }}
+  namespace: {{ .ClusterName }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .RoleAndRolebindingName }}
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: {{ .Group }}


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* When HC is deleted, managed cluster is not getting deleted from the hub and SA doesn't have required permissions. Also, changed order to delete the managed cluster before updating klusterlet to remove finalizer.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Fixes the deletion of the managed cluster when the HC is deleted.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-2094

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	14.390s	coverage: 70.7% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	176.229s	coverage: 86.0% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	1.232s	coverage: 55.8% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	0.517s	coverage: 100.0% of statements
```
