### PR TITLE
additional code change to support custom API server cert

### DIFF
--- a/pkg/agent/clusterclaim.go
+++ b/pkg/agent/clusterclaim.go
@@ -11,7 +11,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
 
@@ -87,14 +86,11 @@ func (c *agentController) createHostedClusterZeroClusterClaim(ctx context.Contex
 	return createOrUpdate(ctx, c.spokeClustersClient, hcZeroClaim)
 }
 
-func (c *agentController) createHostedClusterClaim(ctx context.Context, secretKey types.NamespacedName,
+func (c *agentController) createHostedClusterClaim(ctx context.Context, secret *corev1.Secret,
 	generateClusterClientFromSecret func(secret *corev1.Secret) (clusterclientset.Interface, error)) error {
-	secret := &corev1.Secret{}
-	err := c.spokeClient.Get(ctx, secretKey, secret)
-	if err != nil {
-		return fmt.Errorf("unable to get hosted secret %s/%s, err: %w", secretKey.Namespace, secretKey.Name, err)
+	if secret.Data == nil {
+		return fmt.Errorf("the secret does not have any data")
 	}
-
 	clusterClient, err := generateClusterClientFromSecret(secret)
 	if err != nil {
 		return fmt.Errorf("failed to create spoke clusters client, err: %w", err)

--- a/pkg/manager/manifests/permission/role.yaml
+++ b/pkg/manager/manifests/permission/role.yaml
@@ -6,7 +6,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets", "configmaps"]
-    verbs: ["get", "list", "watch", "create", "delete"]
+    verbs: ["get", "list", "watch", "create", "delete", "update"]
   - apiGroups: ["addon.open-cluster-management.io"]
     resources: ["managedclusteraddons"]
     verbs: ["get", "list", "watch", "update", "patch"]


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Fix the code that creates/updates the admin-kubeconfig in the hub. Currenly, it only creates a new one but does not update the existing cert when the HC API server cert is renewed.
* Fix the code that generates a cluster claim in the hosted cluster. This code needs to be aware of the custom API server cert. 

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Support HC API server with a custom certificate

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-3990

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
KUBEBUILDER_ASSETS="/Users/rokej/Library/Application Support/io.kubebuilder.envtest/k8s/1.22.1-darwin-amd64" go test github.com/stolostron/hypershift-addon-operator/cmd github.com/stolostron/hypershift-addon-operator/pkg/agent github.com/stolostron/hypershift-addon-operator/pkg/install github.com/stolostron/hypershift-addon-operator/pkg/manager github.com/stolostron/hypershift-addon-operator/pkg/metrics github.com/stolostron/hypershift-addon-operator/pkg/util -coverprofile cover.out
?   	github.com/stolostron/hypershift-addon-operator/cmd	[no test files]
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	19.403s	coverage: 72.8% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	176.009s	coverage: 86.0% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	1.160s	coverage: 58.3% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	0.540s	coverage: 100.0% of statements
?   	github.com/stolostron/hypershift-addon-operator/pkg/util	[no test files]
```
