### PR TITLE
reconcile error rate metrics

### DIFF
--- a/example/addon-manager-deployment.yaml
+++ b/example/addon-manager-deployment.yaml
@@ -26,7 +26,7 @@ rules:
   verbs: ["approve"]
 - apiGroups: ["cluster.open-cluster-management.io"]
   resources: ["managedclusters"]
-  verbs: ["get", "list", "watch", "patch", "update"]
+  verbs: ["get", "list", "watch", "patch", "update", "delete"]
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["roles", "rolebindings","clusterroles", "clusterrolebindings"]
   verbs: ["get", "list", "watch", "create", "update", "delete"]

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -389,8 +389,14 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	c.log.Info(fmt.Sprintf("Reconciling hostedcluster secrect %s", req))
 	defer c.log.Info(fmt.Sprintf("Done reconcile hostedcluster secrect %s", req))
 
-	// Update the AddOnPlacementScore resource, continue reconcile even if error occurred
-	_ = c.SyncAddOnPlacementScore(ctx, false)
+	// Update the AddOnPlacementScore resource, requeue reconcile if error occurred
+	metrics.TotalReconcileCount.Inc() // increase reconcile action count
+	if err := c.SyncAddOnPlacementScore(ctx, false); err != nil {
+		c.log.Info(fmt.Sprintf("failed to create or update ethe AddOnPlacementScore %s, error: %s. Will try again in 30 seconds", util.HostedClusterScoresResourceName, err.Error()))
+		metrics.ReconcileRequeueCount.Inc()
+		metrics.FailedReconcileCount.Inc()
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Duration(1) * time.Minute}, nil
+	}
 
 	// Delete HC secrets on the hub using labels for HC and the hosting NS
 	deleteMirrorSecrets := func() error {
@@ -478,6 +484,16 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			hubMirrorSecret.SetNamespace(c.clusterName)
 			hubMirrorSecret.SetName(fmt.Sprintf("%s-%s", secretName, se.Name))
 
+			if strings.HasSuffix(hubMirrorSecret.Name, "kubeadmin-password") {
+				if hc.Status.KubeadminPassword == nil {
+					// the kubeadmin password secret is not ready yet
+					// this secret will not be created if a custom identity provider
+					// is configured in configuration.oauth.identityProviders
+					c.log.Info("cannot find the kubeadmin password secret yet.")
+					continue
+				}
+			}
+
 			se.SetName(fmt.Sprintf("%s-%s", hc.Name, se.Name))
 			if err := c.spokeClient.Get(ctx, client.ObjectKeyFromObject(se), se); err != nil {
 				lastErr = err
@@ -497,11 +513,11 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 				errExt := c.generateExtManagedKubeconfigSecret(ctx, extSecret.Data, *hc)
 
 				if errExt != nil {
-					lastErr = errExt
 					// This is where we avoid counting metrics for certain error conditions
 					// Klusterlet namespace will not exist until import is done
 					if !strings.Contains(errExt.Error(), "failed to find the klusterlet namespace") {
 						metrics.KubeconfigSecretCopyFailureCount.Inc()
+						lastErr = errExt // it is an error condition only if the klueterlet namespace exists
 					}
 
 				} else {
@@ -550,19 +566,25 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return lastErr
 	}
 
+	metrics.TotalReconcileCount.Inc() // increase reconcile action count
 	if err := createOrUpdateMirrorSecrets(); err != nil {
 		c.log.Info(fmt.Sprintf("failed to create external-managed-kubeconfig and mirror secrets for hostedcluster %s, error: %s. Will try again in 30 seconds", hc.Name, err.Error()))
-		return ctrl.Result{Requeue: true, RequeueAfter: 30 * time.Second}, nil
+		metrics.FailedReconcileCount.Inc()
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Duration(1) * time.Minute}, nil
 	}
 
-	if err := c.createHostedClusterClaim(ctx, adminKubeConfigSecretWithCert,
-		generateClusterClientFromSecret); err != nil {
-		// just log the infomation and wait for the next reconcile to retry.
-		// since the hosted cluster may:
-		//   - not available now
-		//   - have not been imported to the hub, and there is no clusterclaim CRD.
-		c.log.Info("unable to create hosted cluster claim, wait for the next retry", "error", err.Error())
-		return ctrl.Result{Requeue: true, RequeueAfter: 1 * time.Minute}, nil
+	if isVersionHistoryStateFound(hc.Status.Version.History, configv1.CompletedUpdate) {
+		if err := c.createHostedClusterClaim(ctx, adminKubeConfigSecretWithCert,
+			generateClusterClientFromSecret); err != nil {
+			// just log the infomation and wait for the next reconcile to retry.
+			// since the hosted cluster may:
+			//   - not available now
+			//   - have not been imported to the hub, and there is no clusterclaim CRD.
+			c.log.Info("unable to create hosted cluster claim, wait for the next retry", "error", err.Error())
+			// this is not critical for managing hosted clusters. don't count as a failed reconcile
+			metrics.ReconcileRequeueCount.Inc()
+			return ctrl.Result{Requeue: true, RequeueAfter: time.Duration(1) * time.Minute}, nil
+		}
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -404,9 +404,10 @@ kind: Config`)
 	err = aCtrl.spokeClient.Get(ctx, kcSecretNN, secret)
 	assert.Nil(t, err, "is nil when the admin kubeconfig secret is found")
 
-	pwdSecretNN := types.NamespacedName{Name: fmt.Sprintf("%s-kubeadmin-password", hc.Spec.InfraID), Namespace: aCtrl.clusterName}
+	// The hosted cluster does not have status.KubeadminPassword so the kubeadmin-password is not expected to be copied
+	pwdSecretNN := types.NamespacedName{Name: fmt.Sprintf("%s-kubeadmin-password", hc.Name), Namespace: aCtrl.clusterName}
 	err = aCtrl.hubClient.Get(ctx, pwdSecretNN, secret)
-	assert.Nil(t, err, "is nil when the kubeadmin password secret is found")
+	assert.True(t, err != nil && errors.IsNotFound(err), "is true when the kubeadmin-password secret is not copied")
 
 	kcExtSecretNN := types.NamespacedName{Name: "external-managed-kubeconfig", Namespace: "klusterlet-" + hc.Spec.InfraID}
 	err = aCtrl.hubClient.Get(ctx, kcExtSecretNN, secret)

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -234,7 +234,7 @@ kind: Config`)
 	err = aCtrl.hubClient.Get(ctx, kcExtSecretNN, secret)
 	assert.NotNil(t, err, "external-managed-kubeconfig secret not found")
 	assert.Equal(t, true, res.Requeue)
-	assert.Equal(t, 30*time.Second, res.RequeueAfter)
+	assert.Equal(t, 1*time.Minute, res.RequeueAfter)
 	// Test that we do not count the klusterlet namespace missing as an error, this just means import has not been
 	// triggered
 	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.KubeconfigSecretCopyFailureCount))

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -273,7 +273,6 @@ func TestReconcileRequeueFromFailedReconcile(t *testing.T) {
 	// Test that we do not count the klusterlet namespace missing as an error, this just means import has not been
 	// triggered
 	assert.Equal(t, float64(1), testutil.ToFloat64(metrics.PlacementScoreFailureCount))
-
 }
 
 func TestReconcileWithAnnotation(t *testing.T) {
@@ -362,8 +361,6 @@ kind: Config`)
 	err = aCtrl.hubClient.Create(ctx, hc)
 	assert.Nil(t, err, "err nil when hosted cluster is created successfully")
 
-	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.PlacementScoreFailureCount))
-
 	// Create klusterlet namespace
 	klusterletNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -414,7 +411,6 @@ kind: Config`)
 	assert.Nil(t, err, "is nil when kubeconfig data can be loaded")
 	assert.Equal(t, kubeconfig.Clusters["cluster"].Server, "https://kube-apiserver."+hc.Namespace+"-"+hc.Name+".svc.cluster.local:443")
 
-	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.PlacementScoreFailureCount))
 	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.PlacementClusterClaimsFailureCount.WithLabelValues(util.MetricsLabelFullClusterClaim)))
 	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.PlacementClusterClaimsFailureCount.WithLabelValues(util.MetricsLabelThresholdClusterClaim)))
 	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.PlacementClusterClaimsFailureCount.WithLabelValues(util.MetricsLabelZeroClusterClaim)))
@@ -496,7 +492,6 @@ func TestHostedClusterCount(t *testing.T) {
 	assert.Nil(t, err, "is nil when addonPlacementScore is found")
 	assert.Equal(t, int32(aCtrl.maxHostedClusterCount-1), placementScore.Status.Scores[0].Value)
 
-	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.PlacementScoreFailureCount))
 	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.PlacementClusterClaimsFailureCount.WithLabelValues(util.MetricsLabelFullClusterClaim)))
 	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.PlacementClusterClaimsFailureCount.WithLabelValues(util.MetricsLabelThresholdClusterClaim)))
 	assert.Equal(t, float64(0), testutil.ToFloat64(metrics.PlacementClusterClaimsFailureCount.WithLabelValues(util.MetricsLabelZeroClusterClaim)))

--- a/pkg/metrics/addon-agent-health-metrics.go
+++ b/pkg/metrics/addon-agent-health-metrics.go
@@ -2,6 +2,21 @@ package metrics
 
 import "github.com/prometheus/client_golang/prometheus"
 
+var TotalReconcileCount = prometheus.NewCounter(prometheus.CounterOpts{
+	Name: "mce_hs_addon_total_reconcile_count",
+	Help: "Total number of Hypershift addon agent's reconciliations",
+})
+
+var FailedReconcileCount = prometheus.NewCounter(prometheus.CounterOpts{
+	Name: "mce_hs_addon_failed_reconcile_count",
+	Help: "Number of Hypershift addon agent's failed reconciliations",
+})
+
+var ReconcileRequeueCount = prometheus.NewCounter(prometheus.CounterOpts{
+	Name: "mce_hs_addon_reconcile_requeue_count",
+	Help: "Number of Hypershift addon agent's requeued reconciliations",
+})
+
 var AddonAgentFailedToStartBool = prometheus.NewGauge(prometheus.GaugeOpts{
 	Name: "mce_hs_addon_failed_to_start_bool",
 	Help: "Hypershift addon agent failed to start true (1) or false (0)",
@@ -50,6 +65,9 @@ var HubResourceSyncFailureCount = prometheus.NewCounterVec(
 
 func init() {
 	CollectorsForRegistration = append(CollectorsForRegistration,
+		TotalReconcileCount,
+		FailedReconcileCount,
+		ReconcileRequeueCount,
 		AddonAgentFailedToStartBool,
 		InInstallationOrUpgradeBool,
 		InstallationOrUpgradeFailedCount,


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Fix the code that assumes all HCs have kubeadmin-password secret
* Generate metrics data to calculate reconcile error rate
* Fix e2e test

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  To generate the overall SLO of the agent that takes part in HC creations

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-4446

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?   	github.com/stolostron/hypershift-addon-operator/cmd	[no test files]
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	23.639s	coverage: 72.3% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	176.305s	coverage: 86.0% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	0.591s	coverage: 58.3% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	0.938s	coverage: 100.0% of statements
?   	github.com/stolostron/hypershift-addon-operator/pkg/util	[no test files]
```

<img width="1596" alt="image" src="https://user-images.githubusercontent.com/41969005/226907402-778bb39a-4ea7-4d95-8b36-14c149b8abb9.png">

