### PR TITLE
ACM-3429 Add retry to get mce csv when upgrading

### DIFF
--- a/pkg/manager/cli_download_install.go
+++ b/pkg/manager/cli_download_install.go
@@ -26,13 +26,13 @@ import (
 
 func EnableHypershiftCLIDownload(hubclient client.Client, log logr.Logger) error {
 	// get the current version of MCE CSV from multicluster-engine namespace
-	
+
 	//Every 2 minutes, try to get csv in case of cluster upgrade (5 attempts)
 	var csv *operatorsv1alpha1.ClusterServiceVersion
 	var err error
 	for try := 1; try <= 5; try++ {
 		if try != 1 {
-			log.Error(err, "failed to get the most current version of MCE CSV from multicluster-engine namespace, retrying in 2 minutes (attempt " + strconv.Itoa(try) + "/5)")
+			log.Error(err, "failed to get the most current version of MCE CSV from multicluster-engine namespace, retrying in 2 minutes (attempt "+strconv.Itoa(try)+"/5)")
 			time.Sleep(2 * time.Minute)
 		}
 		csv, err = GetMCECSV(hubclient, log)

--- a/pkg/manager/cli_download_install.go
+++ b/pkg/manager/cli_download_install.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/ghodss/yaml"
 	"github.com/go-logr/logr"
@@ -24,7 +26,22 @@ import (
 
 func EnableHypershiftCLIDownload(hubclient client.Client, log logr.Logger) error {
 	// get the current version of MCE CSV from multicluster-engine namespace
-	csv, err := GetMCECSV(hubclient, log)
+	
+	//Every 2 minutes, try to get csv in case of cluster upgrade (5 attempts)
+	var csv *operatorsv1alpha1.ClusterServiceVersion
+	var err error
+	for try := 1; try <= 5; try++ {
+		if try != 1 {
+			log.Error(err, "failed to get the most current version of MCE CSV from multicluster-engine namespace, retrying in 2 minutes (attempt " + strconv.Itoa(try) + "/5)")
+			time.Sleep(2 * time.Minute)
+		}
+		csv, err = GetMCECSV(hubclient, log)
+		if err == nil {
+			break
+		}
+	}
+
+	//Failed 5 attempts
 	if err != nil {
 		log.Error(err, "failed to get the most current version of MCE CSV from multicluster-engine namespace")
 		return err

--- a/pkg/manager/cli_download_install_test.go
+++ b/pkg/manager/cli_download_install_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	consolev1 "github.com/openshift/api/console/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -17,7 +19,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestEnableHypershiftCLIDownload(t *testing.T) {
@@ -265,6 +270,40 @@ func TestEnableHypershiftCLIDownloadNoConsole(t *testing.T) {
 	assert.EqualError(t, err, "consoleclidownloads.console.openshift.io \"hypershift-cli-download\" not found")
 }
 
+func TestRetryCSV(t *testing.T) {
+	controllerContext := &controllercmd.ControllerContext{}
+	client, sch := initCSVErrorClient()
+	zapLog, _ := zap.NewDevelopment()
+	o := &override{
+		Client:            client,
+		log:               zapr.NewLogger(zapLog),
+		operatorNamespace: controllerContext.OperatorNamespace,
+		withOverride:      false,
+	}
+
+	//Channel to read errors from either goroutine
+	c := make(chan error)
+
+	// Create mock multicluster engine
+	newmce := getTestMCE("multiclusterengine", "multicluster-engine")
+	err := o.Client.Create(context.TODO(), newmce)
+	assert.Nil(t, err, "could not create test MCE")
+
+	dep := getTestAddonDeployment()
+	err = o.Client.Create(context.TODO(), dep)
+	assert.Nil(t, err, "err nil when addon deployment is created successfully")
+
+	clusterRole := getTestClusterRole()
+	err = o.Client.Create(context.TODO(), clusterRole)
+	assert.Nil(t, err, "err nil when addon clusterRole is created successfully")
+
+	go asyncEnableHypershiftCLIDownload(client, o.log, c) //Attempt to enable clidownload
+	go asyncClusterRole(o, sch, t)                        //Add permissions after a small period of time
+	result := <-c
+	assert.Nil(t, result, "could not get MCE")
+
+}
+
 func getTestMCECSV(version string, downstream bool) *operatorsv1alpha1.ClusterServiceVersion {
 	csv := &operatorsv1alpha1.ClusterServiceVersion{
 		TypeMeta: metav1.TypeMeta{
@@ -376,4 +415,40 @@ func getTestMCE(name string, namespace string) *mcev1.MultiClusterEngine {
 		},
 	}
 	return mce
+}
+
+func asyncClusterRole(o *override, s *runtime.Scheme, t *testing.T) {
+	//Simulate adding permissions to clusterrole after a delay
+	//Hard to simulate RBAC, add csv to scheme and create it after a delay instead
+	time.Sleep(1 * time.Minute)
+
+	operatorsv1alpha1.AddToScheme(s)
+
+	newcsv := getTestMCECSV("v2.2.1", true)
+	err := o.Client.Create(context.TODO(), newcsv)
+	assert.Nil(t, err, "err nil when mce csv is created successfull")
+
+}
+
+func asyncEnableHypershiftCLIDownload(mockClient client.Client, log logr.Logger, c chan error) {
+	err := EnableHypershiftCLIDownload(mockClient, log)
+	c <- err
+	log.Info("Successfully enabled HypershiftCLIDownload after retrying")
+	if err != nil {
+		log.Error(err, "Could not enable HypershiftCLIDownload after retrying")
+	}
+}
+
+func initCSVErrorClient() (client.Client, *runtime.Scheme) {
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
+	routev1.AddToScheme(scheme)
+	consolev1.AddToScheme(scheme)
+	appsv1.AddToScheme(scheme)
+	rbacv1.AddToScheme(scheme)
+	mcev1.AddToScheme(scheme)
+
+	ncb := fake.NewClientBuilder()
+	ncb.WithScheme(scheme)
+	return ncb.Build(), scheme
 }


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Add retry on getting csv in case permissions are not yet granted

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  During upgrade, clusterrole may be updated after pod which results in pod requestiong resources it doesn't have permission for

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-3429



<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?       github.com/stolostron/hypershift-addon-operator/cmd     [no test files]
ok      github.com/stolostron/hypershift-addon-operator/pkg/agent       12.611s coverage: 72.6% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/install     175.495s        coverage: 86.0% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/manager     120.051s        coverage: 60.2% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/metrics     0.007s  coverage: 100.0% of statements
?       github.com/stolostron/hypershift-addon-operator/pkg/util        [no test files]
```
### Success after second attempt
```script
2023-03-22T20:21:19.598Z	ERROR	manager	manager/cli_download_install.go:35	failed to get the most current version of MCE CSV from multicluster-engine namespace, retrying in 2 minutes (attempt 2/5)	{"error": "clusterserviceversions.operators.coreos.com is forbidden: User \"system:serviceaccount:multicluster-engine:hypershift-addon-manager-sa\" cannot list resource \"clusterserviceversions\" in API group \"operators.coreos.com\" at the cluster scope"}
github.com/stolostron/hypershift-addon-operator/pkg/manager.EnableHypershiftCLIDownload
	/go/src/github.com/stolostron/hypershift-addon-operator/pkg/manager/cli_download_install.go:35
.
.
.
.
2023-03-22T20:23:19.694Z	INFO	manager	manager/cli_download_install.go:107	MCE CSV found multicluster-engine.v2.1.5
```