### PR TITLE
SLO metrics

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -389,8 +389,14 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	c.log.Info(fmt.Sprintf("Reconciling hostedcluster secrect %s", req))
 	defer c.log.Info(fmt.Sprintf("Done reconcile hostedcluster secrect %s", req))
 
-	// Update the AddOnPlacementScore resource, continue reconcile even if error occurred
-	_ = c.SyncAddOnPlacementScore(ctx, false)
+	// Update the AddOnPlacementScore resource, requeue reconcile if error occurred
+	metrics.TotalReconcileCount.Inc() // increase reconcile action count
+	if err := c.SyncAddOnPlacementScore(ctx, false); err != nil {
+		c.log.Info(fmt.Sprintf("failed to create or update ethe AddOnPlacementScore %s, error: %s. Will try again in 30 seconds", util.HostedClusterScoresResourceName, err.Error()))
+		metrics.ReconcileRequeueCount.Inc()
+		metrics.FailedReconcileCount.Inc()
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Duration(1) * time.Minute}, nil
+	}
 
 	// Delete HC secrets on the hub using labels for HC and the hosting NS
 	deleteMirrorSecrets := func() error {
@@ -478,6 +484,16 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			hubMirrorSecret.SetNamespace(c.clusterName)
 			hubMirrorSecret.SetName(fmt.Sprintf("%s-%s", secretName, se.Name))
 
+			if strings.HasSuffix(hubMirrorSecret.Name, "kubeadmin-password") {
+				if hc.Status.KubeadminPassword == nil {
+					// the kubeadmin password secret is not ready yet
+					// this secret will not be created if a custom identity provider
+					// is configured in configuration.oauth.identityProviders
+					c.log.Info("cannot find the kubeadmin password secret yet.")
+					continue
+				}
+			}
+
 			se.SetName(fmt.Sprintf("%s-%s", hc.Name, se.Name))
 			if err := c.spokeClient.Get(ctx, client.ObjectKeyFromObject(se), se); err != nil {
 				lastErr = err
@@ -497,11 +513,11 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 				errExt := c.generateExtManagedKubeconfigSecret(ctx, extSecret.Data, *hc)
 
 				if errExt != nil {
-					lastErr = errExt
 					// This is where we avoid counting metrics for certain error conditions
 					// Klusterlet namespace will not exist until import is done
 					if !strings.Contains(errExt.Error(), "failed to find the klusterlet namespace") {
 						metrics.KubeconfigSecretCopyFailureCount.Inc()
+						lastErr = errExt // it is an error condition only if the klueterlet namespace exists
 					}
 
 				} else {
@@ -550,19 +566,25 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return lastErr
 	}
 
+	metrics.TotalReconcileCount.Inc() // increase reconcile action count
 	if err := createOrUpdateMirrorSecrets(); err != nil {
 		c.log.Info(fmt.Sprintf("failed to create external-managed-kubeconfig and mirror secrets for hostedcluster %s, error: %s. Will try again in 30 seconds", hc.Name, err.Error()))
-		return ctrl.Result{Requeue: true, RequeueAfter: 30 * time.Second}, nil
+		metrics.FailedReconcileCount.Inc()
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Duration(1) * time.Minute}, nil
 	}
 
-	if err := c.createHostedClusterClaim(ctx, adminKubeConfigSecretWithCert,
-		generateClusterClientFromSecret); err != nil {
-		// just log the infomation and wait for the next reconcile to retry.
-		// since the hosted cluster may:
-		//   - not available now
-		//   - have not been imported to the hub, and there is no clusterclaim CRD.
-		c.log.Info("unable to create hosted cluster claim, wait for the next retry", "error", err.Error())
-		return ctrl.Result{Requeue: true, RequeueAfter: 1 * time.Minute}, nil
+	if isVersionHistoryStateFound(hc.Status.Version.History, configv1.CompletedUpdate) {
+		if err := c.createHostedClusterClaim(ctx, adminKubeConfigSecretWithCert,
+			generateClusterClientFromSecret); err != nil {
+			// just log the infomation and wait for the next reconcile to retry.
+			// since the hosted cluster may:
+			//   - not available now
+			//   - have not been imported to the hub, and there is no clusterclaim CRD.
+			c.log.Info("unable to create hosted cluster claim, wait for the next retry", "error", err.Error())
+			// this is not critical for managing hosted clusters. don't count as a failed reconcile
+			metrics.ReconcileRequeueCount.Inc()
+			return ctrl.Result{Requeue: true, RequeueAfter: time.Duration(1) * time.Minute}, nil
+		}
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/metrics/addon-agent-health-metrics.go
+++ b/pkg/metrics/addon-agent-health-metrics.go
@@ -2,6 +2,21 @@ package metrics
 
 import "github.com/prometheus/client_golang/prometheus"
 
+var TotalReconcileCount = prometheus.NewCounter(prometheus.CounterOpts{
+	Name: "mce_hs_addon_total_reconcile_count",
+	Help: "Total number of Hypershift addon agent's reconciliations",
+})
+
+var FailedReconcileCount = prometheus.NewCounter(prometheus.CounterOpts{
+	Name: "mce_hs_addon_failed_reconcile_count",
+	Help: "Number of Hypershift addon agent's failed reconciliations",
+})
+
+var ReconcileRequeueCount = prometheus.NewCounter(prometheus.CounterOpts{
+	Name: "mce_hs_addon_reconcile_requeue_count",
+	Help: "Number of Hypershift addon agent's requeued reconciliations",
+})
+
 var AddonAgentFailedToStartBool = prometheus.NewGauge(prometheus.GaugeOpts{
 	Name: "mce_hs_addon_failed_to_start_bool",
 	Help: "Hypershift addon agent failed to start true (1) or false (0)",
@@ -50,6 +65,9 @@ var HubResourceSyncFailureCount = prometheus.NewCounterVec(
 
 func init() {
 	CollectorsForRegistration = append(CollectorsForRegistration,
+		TotalReconcileCount,
+		FailedReconcileCount,
+		ReconcileRequeueCount,
 		AddonAgentFailedToStartBool,
 		InInstallationOrUpgradeBool,
 		InstallationOrUpgradeFailedCount,


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Fix the code that assumes all HCs have kubeadmin-password secret
* Generate metrics data to calculate reconcile error rate

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  To generate the overall SLO of the agent that takes part in HC creations

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-4447

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?   	github.com/stolostron/hypershift-addon-operator/cmd	[no test files]
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	34.390s	coverage: 74.1% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	281.406s	coverage: 87.0% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	1.233s	coverage: 56.2% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	0.519s	coverage: 100.0% of statements
?   	github.com/stolostron/hypershift-addon-operator/pkg/util	[no test files]
```
