### PR TITLE
fix backup restore, canary test and install job retention

### DIFF
--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -317,7 +317,7 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 	c.extDnsSecret = *sExtDNS
 
 	// Get the hypershift operator installation flags configmap from the hub
-	installFlagsCM := c.getConfigMapFromHub(util.HypershiftInstallFlagsCM)
+	installFlagsCM, _ := c.getConfigMapFromHub(util.HypershiftInstallFlagsCM)
 	c.installFlagsConfigmap = installFlagsCM
 
 	hypershiftImage := c.operatorImage
@@ -715,7 +715,7 @@ func (c *UpgradeController) readInDownstreamOverride() ([]byte, error) {
 
 	// This is the user provided upgrade images configmap
 	// Override the image values in the installer provided imagestream with this
-	imUpgradeConfigMap := c.getConfigMapFromHub(util.HypershiftOverrideImagesCM)
+	imUpgradeConfigMap, _ := c.getConfigMapFromHub(util.HypershiftOverrideImagesCM)
 	if imUpgradeConfigMap.Data != nil {
 		c.log.Info(fmt.Sprintf("found %s configmap, overriding hypershift images in the imagestream", util.HypershiftOverrideImagesCM))
 

--- a/pkg/install/install_job.go
+++ b/pkg/install/install_job.go
@@ -77,7 +77,7 @@ func (c *UpgradeController) runHyperShiftInstallJob(ctx context.Context, image, 
 
 	backoffLimit := int32(0)
 	activeDeadlineSeconds := int64(600)
-	ttlSecondsAfterFinished := int32(1200) // 20 mins
+	ttlSecondsAfterFinished := int32(172800) // 48 hours
 	job := &kbatch.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: util.HypershiftInstallJobName,

--- a/pkg/install/upgrade.go
+++ b/pkg/install/upgrade.go
@@ -97,29 +97,29 @@ func (c *UpgradeController) Stop() {
 
 func (c *UpgradeController) installOptionsChanged() bool {
 	// check for changes in AWS S3 bucket secret
-	newBucketSecret := c.getSecretFromHub(util.HypershiftBucketSecretName)
-	if c.secretDataChanged(newBucketSecret, c.bucketSecret, util.HypershiftBucketSecretName) {
+	newBucketSecret, err := c.getSecretFromHub(util.HypershiftBucketSecretName)
+	if err == nil && c.secretDataChanged(newBucketSecret, c.bucketSecret, util.HypershiftBucketSecretName) {
 		c.bucketSecret = newBucketSecret // save the new secret for the next cycle of comparison
 		return true
 	}
 
 	// check for changes in external DNS secret
-	newExtDnsSecret := c.getSecretFromHub(util.HypershiftExternalDNSSecretName)
-	if c.secretDataChanged(newExtDnsSecret, c.extDnsSecret, util.HypershiftExternalDNSSecretName) {
+	newExtDnsSecret, err := c.getSecretFromHub(util.HypershiftExternalDNSSecretName)
+	if err == nil && c.secretDataChanged(newExtDnsSecret, c.extDnsSecret, util.HypershiftExternalDNSSecretName) {
 		c.extDnsSecret = newExtDnsSecret // save the new secret for the next cycle of comparison
 		return true
 	}
 
 	// check for changes in AWS private link secret
-	newPrivateLinkSecret := c.getSecretFromHub(util.HypershiftPrivateLinkSecretName)
-	if c.secretDataChanged(newPrivateLinkSecret, c.privateLinkSecret, util.HypershiftPrivateLinkSecretName) {
+	newPrivateLinkSecret, err := c.getSecretFromHub(util.HypershiftPrivateLinkSecretName)
+	if err == nil && c.secretDataChanged(newPrivateLinkSecret, c.privateLinkSecret, util.HypershiftPrivateLinkSecretName) {
 		c.privateLinkSecret = newPrivateLinkSecret // save the new secret for the next cycle of comparison
 		return true
 	}
 
 	// check for changes in hypershift operator installation flags configmap
-	newInstallFlagsCM := c.getConfigMapFromHub(util.HypershiftInstallFlagsCM)
-	if c.configmapDataChanged(newInstallFlagsCM, c.installFlagsConfigmap, util.HypershiftInstallFlagsCM) {
+	newInstallFlagsCM, err := c.getConfigMapFromHub(util.HypershiftInstallFlagsCM)
+	if err == nil && c.configmapDataChanged(newInstallFlagsCM, c.installFlagsConfigmap, util.HypershiftInstallFlagsCM) {
 		c.installFlagsConfigmap = newInstallFlagsCM // save the new configmap for the next cycle of comparison
 		return true
 	}
@@ -127,15 +127,16 @@ func (c *UpgradeController) installOptionsChanged() bool {
 	return false
 }
 
-func (c *UpgradeController) getSecretFromHub(secretName string) corev1.Secret {
+func (c *UpgradeController) getSecretFromHub(secretName string) (corev1.Secret, error) {
 	secretKey := types.NamespacedName{Name: secretName, Namespace: c.clusterName}
 	newSecret := &corev1.Secret{}
 	if err := c.hubClient.Get(context.TODO(), secretKey, newSecret); err != nil && !errors.IsNotFound(err) {
 		c.log.Error(err, "failed to get secret from the hub: ")
 		// Update hub secret sync metrics count
 		metrics.HubResourceSyncFailureCount.WithLabelValues("secret").Inc()
+		return *newSecret, err
 	}
-	return *newSecret
+	return *newSecret, nil
 }
 
 func (c *UpgradeController) secretDataChanged(oldSecret, newSecret corev1.Secret, secretName string) bool {
@@ -148,21 +149,22 @@ func (c *UpgradeController) secretDataChanged(oldSecret, newSecret corev1.Secret
 
 func (c *UpgradeController) upgradeImageCheck() bool {
 	// Get the image override configmap from the hub and compare it to the controller's cached image override configmap
-	newImageOverrideConfigmap := c.getConfigMapFromHub(util.HypershiftOverrideImagesCM)
-	if c.configmapDataChanged(newImageOverrideConfigmap, c.imageOverrideConfigmap, util.HypershiftOverrideImagesCM) {
+	newImageOverrideConfigmap, err := c.getConfigMapFromHub(util.HypershiftOverrideImagesCM)
+	if err == nil && c.configmapDataChanged(newImageOverrideConfigmap, c.imageOverrideConfigmap, util.HypershiftOverrideImagesCM) {
 		c.imageOverrideConfigmap = newImageOverrideConfigmap // save the new configmap for the next cycle of comparison
 		return true
 	}
 	return false
 }
 
-func (c *UpgradeController) getConfigMapFromHub(cmName string) corev1.ConfigMap {
+func (c *UpgradeController) getConfigMapFromHub(cmName string) (corev1.ConfigMap, error) {
 	cm := &corev1.ConfigMap{}
 	cmKey := types.NamespacedName{Name: cmName, Namespace: c.clusterName}
 	if err := c.hubClient.Get(context.TODO(), cmKey, cm); err != nil && !errors.IsNotFound(err) {
 		c.log.Error(err, "failed to get configmap from the hub: ")
+		return *cm, err
 	}
-	return *cm
+	return *cm, nil
 }
 
 func (c *UpgradeController) configmapDataChanged(oldCM, newCM corev1.ConfigMap, cmName string) bool {

--- a/pkg/manager/manifests/templates/deployment.yaml
+++ b/pkg/manager/manifests/templates/deployment.yaml
@@ -86,6 +86,12 @@ spec:
         volumeMounts:
           - name: hub-config
             mountPath: /var/run/hub
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+          initialDelaySeconds: 2
+          periodSeconds: 10
       volumes:
         - name: hub-config
           secret:

--- a/test/canary/run_canary_test.sh
+++ b/test/canary/run_canary_test.sh
@@ -553,7 +553,7 @@ installHypershiftBinary() {
         exit 1
     fi
 
-    mv remote-source/app/bin/linux/amd64/hypershift /bin
+    mv hypershift /bin
     if [ $? -ne 0 ]; then
         echo "$(date) failed to mv extracted hypershift binary to /bin"
         exit 1


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* When a managed cluster is restored to a DR hub, detect the change in the hub kubeconfig and restart the agent to pick up the new hub's kubeconfig for API connection
* Fix the condition check for HO reinstallation
* Fix canary test 
* Change the HO installation job TTL from 20 minutes to 48 hours to give SREs enough time for troubleshooting 

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
* Backup and restore
* Tests
* Troubleshooting ability

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-4618

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
n-operator/pkg/util -coverprofile cover.out
?   	github.com/stolostron/hypershift-addon-operator/cmd	[no test files]
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	29.482s	coverage: 71.3% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	176.019s	coverage: 86.0% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	121.397s	coverage: 60.2% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	0.967s	coverage: 100.0% of statements
?   	github.com/stolostron/hypershift-addon-operator/pkg/util	[no test files]
```
