### PR TITLE
fix backup restore and install job retention

### DIFF
--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -611,7 +611,7 @@ func (c *UpgradeController) readInDownstreamOverride() ([]byte, error) {
 
 	// This is the user provided upgrade images configmap
 	// Override the image values in the installer provided imagestream with this
-	imUpgradeConfigMap := c.getImageOverrideMapFromHub()
+	imUpgradeConfigMap, _ := c.getImageOverrideMapFromHub()
 	if imUpgradeConfigMap.Data != nil {
 		c.log.Info(fmt.Sprintf("found %s configmap, overriding hypershift images in the imagestream", util.HypershiftOverrideImagesCM))
 

--- a/pkg/install/install_job.go
+++ b/pkg/install/install_job.go
@@ -77,7 +77,7 @@ func (c *UpgradeController) runHyperShiftInstallJob(ctx context.Context, image, 
 
 	backoffLimit := int32(0)
 	activeDeadlineSeconds := int64(600)
-	ttlSecondsAfterFinished := int32(1200) // 20 mins
+	ttlSecondsAfterFinished := int32(172800) // 48 hours
 	job := &kbatch.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: util.HypershiftInstallJobName,

--- a/pkg/manager/manifests/templates/deployment.yaml
+++ b/pkg/manager/manifests/templates/deployment.yaml
@@ -86,6 +86,12 @@ spec:
         volumeMounts:
           - name: hub-config
             mountPath: /var/run/hub
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+          initialDelaySeconds: 2
+          periodSeconds: 10
       volumes:
         - name: hub-config
           secret:

--- a/test/canary/run_canary_test.sh
+++ b/test/canary/run_canary_test.sh
@@ -553,7 +553,7 @@ installHypershiftBinary() {
         exit 1
     fi
 
-    mv remote-source/app/bin/linux/amd64/hypershift /bin
+    mv hypershift /bin
     if [ $? -ne 0 ]; then
         echo "$(date) failed to mv extracted hypershift binary to /bin"
         exit 1


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* When a managed cluster is restored to a DR hub, detect the change in the hub kubeconfig and restart the agent to pick up the new hub's kubeconfig for API connection
* Fix the condition check for HO reinstallation
* Fix canary test 
* Change the HO installation job TTL from 20 minutes to 48 hours to give SREs enough time for troubleshooting 

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
* Backup and restore
* Tests
* Troubleshooting ability

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-4618

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?   	github.com/stolostron/hypershift-addon-operator/cmd	[no test files]
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	33.471s	coverage: 72.8% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	281.069s	coverage: 87.1% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	121.431s	coverage: 58.4% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	1.043s	coverage: 100.0% of statements
?   	github.com/stolostron/hypershift-addon-operator/pkg/util	[no test files]

```
