### PR TITLE
HyperShift cluster role binding not created for managed clusters

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -212,11 +212,13 @@ func applyAgentPermissionManifestFromFile(file, clusterName, componentName strin
 		ClusterName            string
 		Group                  string
 		RoleAndRolebindingName string
+		ClusterRolebindingName string
 	}{
 		ClusterName: clusterName,
 
 		Group:                  groups[0],
 		RoleAndRolebindingName: fmt.Sprintf("open-cluster-management:%s:agent", componentName),
+		ClusterRolebindingName: fmt.Sprintf("open-cluster-management:%s:%s:agent", componentName, clusterName),
 	}
 
 	results := resourceapply.ApplyDirectly(

--- a/pkg/manager/manifests/permission/clusterrolebinding.yaml
+++ b/pkg/manager/manifests/permission/clusterrolebinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .RoleAndRolebindingName }}
+  name: {{ .ClusterRolebindingName }}
   namespace: {{ .ClusterName }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* A cluster role binding with the same name is attempted to be created for each managed cluster that the hypershift addon is installed on. The binding fails to create, causing the managed cluster to fail to delete due to lack of permission. This change creates a different cluster role binding for each managed cluster the HC addon is installed on. The ideal way is to have one binding and includes the groups for all the managed clusters but the addon registration does not support updating the binding.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Managed clusters, other than local-cluster, are not being deleted when the HC is deleted. The delete fails due to lack of permission.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-2094

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	30.031s	coverage: 71.3% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	176.169s	coverage: 86.0% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	121.381s	coverage: 60.2% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	0.629s	coverage: 100.0% of statements
```
