### PR TITLE
ACM-4223 Hypershift addon agent kube-rbac-proxy image needs to come f…

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -65,6 +65,7 @@ func init() {
 const (
 	hypershiftAddonImageName    = "HYPERSHIFT_ADDON_IMAGE_NAME"
 	hypershiftOperatorImageName = "HYPERSHIFT_OPERATOR_IMAGE_NAME"
+	kubeRbacProxyImageName      = "KUBE_RBAC_PROXY_IMAGE_NAME"
 	templatePath                = "manifests/templates"
 )
 
@@ -266,6 +267,11 @@ func (o *override) getValueForAgentTemplate(cluster *clusterv1.ManagedCluster,
 		operatorImage = util.DefaultHypershiftOperatorImage
 	}
 
+	kubeRbacProxyImage := os.Getenv(kubeRbacProxyImageName)
+	if len(kubeRbacProxyImage) == 0 {
+		kubeRbacProxyImage = util.DefaultKubeRbacProxyImage
+	}
+
 	content := ""
 
 	if o.withOverride {
@@ -285,6 +291,7 @@ func (o *override) getValueForAgentTemplate(cluster *clusterv1.ManagedCluster,
 		AddonName                           string
 		AddonInstallNamespace               string
 		HypershiftOperatorImage             string
+		KubeRbacProxyImage                  string
 		Image                               string
 		SpokeRolebindingName                string
 		AgentServiceAccountName             string
@@ -300,6 +307,7 @@ func (o *override) getValueForAgentTemplate(cluster *clusterv1.ManagedCluster,
 		AddonName:                           fmt.Sprintf("%s-agent", addon.Name),
 		Image:                               addonImage,
 		HypershiftOperatorImage:             operatorImage,
+		KubeRbacProxyImage:                  kubeRbacProxyImage,
 		SpokeRolebindingName:                addon.Name,
 		AgentServiceAccountName:             fmt.Sprintf("%s-agent-sa", addon.Name),
 		HyeprshiftImageOverride:             o.withOverride,

--- a/pkg/manager/manifests/templates/deployment.yaml
+++ b/pkg/manager/manifests/templates/deployment.yaml
@@ -21,11 +21,7 @@ spec:
       containers:
 {{- if ne .disableMetrics "true" }}
       - name: kube-rbac-proxy
-        {{- if .kubeRbacProxyImage }}
-        image: "{{ .kubeRbacProxyImage }}"
-        {{- else }}
-        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.10
-        {{- end }}
+        image: {{ .KubeRbacProxyImage }}
         imagePullPolicy: IfNotPresent
         args:
         - --upstream=http://127.0.0.1:8383/

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -14,6 +14,8 @@ const (
 
 	DefaultHypershiftOperatorImage = "quay.io/hypershift/hypershift-operator:latest"
 
+	DefaultKubeRbacProxyImage = "registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.10"
+
 	// AgentInstallationNamespace is the namespace on the managed cluster to install the addon agent.
 	AgentInstallationNamespace = "open-cluster-management-agent-addon"
 


### PR DESCRIPTION
…rom local registry

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* The kube RBAC proxy image for emitting prometheus metrics securely needs to come from the local MCE registry 
* This goes with https://github.com/stolostron/backplane-operator/pull/422 backplane operator PR

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  to support disconnected environment

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-4223

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?   	github.com/stolostron/hypershift-addon-operator/cmd	[no test files]
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	30.175s	coverage: 71.3% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	176.583s	coverage: 86.0% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	120.969s	coverage: 60.6% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	1.111s	coverage: 100.0% of statements
?   	github.com/stolostron/hypershift-addon-operator/pkg/util	[no test files]
```
