### PR TITLE
Fix e2e by downloading and running the clusteradm binary instead of building it from source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,8 +131,22 @@ deploy-addon-manager:
 	$(KUBECTL) set env -n multicluster-engine deployment/hypershift-addon-manager HYPERSHIFT_ADDON_IMAGE_NAME=$(IMG)
 	$(KUBECTL) rollout status -n multicluster-engine deployment/hypershift-addon-manager --timeout=60s
 
-deploy-ocm:
+deploy-ocm: ensure-clusteradm
 	hack/install_ocm.sh
+
+.PHONY: ensure-clusteradm
+ensure-clusteradm:
+ifeq (, $(shell which clusteradm))
+	@{ \
+	set -e ;\
+	export INSTALL_DIR="${GOPATH}/bin" ;\
+	curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash ;\
+	}
+	CLUSTERADM=${GOPATH}/bin/clusteradm
+else
+	CLUSTERADM=$(shell which clusteradm)
+endif
+	$(@info CLUSTERADM="$(CLUSTERADM)")
 
 .PHONY: quickstart
 quickstart:

--- a/hack/install_ocm.sh
+++ b/hack/install_ocm.sh
@@ -8,21 +8,6 @@ CLUSTERADM=${CLUSTERADM:-clusteradm}
 KUBECTL=${KUBECTL:-kubectl}
 _managed_cluster_name="local-cluster"
 
-rm -rf clusteradm
-echo "############  Cloning clusteradm"
-git clone https://github.com/open-cluster-management-io/clusteradm.git
-
-cd clusteradm || {
-  printf "cd failed, clusteradm does not exist"
-  return 1
-}
-
-make install
-if [ $? -ne 0 ]; then
- echo "############  Failed to install clusteradm"
- exit 1
-fi
-
 $CLUSTERADM init --output-join-command-file join.sh --wait
 sh -c "$(cat join.sh) $_managed_cluster_name"
 $CLUSTERADM accept --clusters $_managed_cluster_name --wait 60


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Fix e2e by downloading and running the clusteradm binary instead of building it from source

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
* This project is currently using go 1.18 and the clusteradm project requires 1.19 to build.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* NA

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
Not applicable - e2e test script changes only
```
