### PR TITLE
[Cherrypick] ACM-2180 Reconcile on klusterlet as well (#237)

### DIFF
--- a/pkg/agent/external_secret_controller.go
+++ b/pkg/agent/external_secret_controller.go
@@ -1,0 +1,103 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	hyperv1beta1 "github.com/openshift/hypershift/api/v1beta1"
+
+	operatorapiv1 "open-cluster-management.io/api/operator/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+const (
+	hcAnnotation = "create-external-hub-kubeconfig"
+)
+
+type ExternalSecretController struct {
+	hubClient   client.Client
+	spokeClient client.Client
+	log         logr.Logger
+}
+
+var ExternalSecretPredicateFunctions = predicate.Funcs{
+	CreateFunc: func(e event.CreateEvent) bool {
+		return true
+	},
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		return false
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return false
+	},
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (c *ExternalSecretController) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&operatorapiv1.Klusterlet{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
+		WithEventFilter(ExternalSecretPredicateFunctions).
+		Complete(c)
+}
+
+// Reconcile updates the Hypershift addon status based on the Deployment status.
+func (c *ExternalSecretController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	c.log.Info(fmt.Sprintf("reconciling klusterlet: %s", req.Name))
+	defer c.log.Info(fmt.Sprintf("done reconciling klusterlet: %s", req.Name))
+
+	if !strings.Contains(req.Name, "klusterlet-") {
+		c.log.Info("klusterlet not from a hosted cluster")
+		return ctrl.Result{}, nil //No need to error
+	}
+
+	_, hostedClusterName, _ := strings.Cut(req.Name, "klusterlet-")
+
+	lo := &client.ListOptions{}
+	hostedClusters := &hyperv1beta1.HostedClusterList{}
+
+	// List the HostedCluster objects across all namespaces
+	if err := c.spokeClient.List(ctx, hostedClusters, lo); err != nil {
+		c.log.Error(err, "unable to list hosted clusters in all namespaces")
+		return ctrl.Result{}, err
+	}
+
+	hostedClusterObj := &hyperv1beta1.HostedCluster{}
+	// Loop over the list of HostedCluster objects and find the one with the specified name
+	for index, hc := range hostedClusters.Items {
+		if hc.Name == hostedClusterName {
+			hostedClusterObj = &hostedClusters.Items[index]
+			break
+		}
+	}
+
+	//Could not find hosted cluster
+	if hostedClusterObj.Name == "" {
+		errh := errors.New("could not retrieve hosted cluster")
+		c.log.Error(errh, fmt.Sprintf("unable to find hosted cluster with name %s", hostedClusterName))
+		return ctrl.Result{}, errh
+	}
+
+	// Add/update the annotation to the hostedcluster
+	if hostedClusterObj.ObjectMeta.Annotations == nil { // Create the annotation map if it doesn't exist
+		hostedClusterObj.ObjectMeta.Annotations = make(map[string]string)
+	}
+
+	currentTime := time.Now()
+	hostedClusterObj.Annotations[hcAnnotation] = currentTime.Format(time.RFC3339)
+	c.log.Info(fmt.Sprintf("Annotated %s with %s", hostedClusterObj.Name, hcAnnotation))
+
+	if err := c.spokeClient.Update(ctx, hostedClusterObj); err != nil { //Add/update hostedcluster annotation
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/pkg/agent/external_secret_controller_test.go
+++ b/pkg/agent/external_secret_controller_test.go
@@ -1,0 +1,242 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/zapr"
+	hyperv1beta1 "github.com/openshift/hypershift/api/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
+	operatorapiv1 "open-cluster-management.io/api/operator/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+//Things to test
+//klusterlet with no managed cluster, expect info message
+//klusterlet created, klusterlet should have finalizer and hostedcluster should be annotated
+//klusterlet deleted, klusterlet should no longer have finalizer and hostedcluster annotation should be removed
+
+func TestKlusterletReconcile(t *testing.T) {
+	ctx := context.Background()
+	client := initClient()
+	zapLog, _ := zap.NewDevelopment()
+
+	ESCtrl := &ExternalSecretController{
+		spokeClient: client,
+		hubClient:   client,
+		log:         zapr.NewLogger(zapLog),
+	}
+
+	apiService := &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-apiserver",
+			Namespace: "clusters-hd-1",
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:     "https",
+					Port:     443,
+					Protocol: "TCP",
+					TargetPort: intstr.IntOrString{
+						IntVal: 6443,
+					},
+				},
+			},
+		},
+	}
+
+	klusterletNamespaceNsn := types.NamespacedName{
+		Name:      "klusterlet-hd-1",
+		Namespace: "",
+	}
+	HCNamespaceNsn := types.NamespacedName{
+		Name:      "hd-1",
+		Namespace: "clusters",
+	}
+
+	kl := &operatorapiv1.Klusterlet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "klusterlet-hd-1",
+		},
+	}
+
+	hcNN := types.NamespacedName{Name: "hd-1", Namespace: "clusters"}
+
+	err := ESCtrl.hubClient.Create(ctx, apiService)
+	assert.Nil(t, err, "err nil when kube-apiserver service is created successfully")
+	defer ESCtrl.hubClient.Delete(ctx, apiService)
+
+	// Create hosted cluster
+	hc := getHostedCluster(hcNN)
+	err = ESCtrl.hubClient.Create(ctx, hc)
+	assert.Nil(t, err, "err nil when hosted cluster is created successfully")
+
+	//Create klusterlet (import)
+	err = ESCtrl.hubClient.Create(ctx, kl)
+	assert.Nil(t, err, "err nil when klusterlet is created successfully")
+
+	//Should create annotation
+	_, err = ESCtrl.Reconcile(ctx, ctrl.Request{NamespacedName: klusterletNamespaceNsn})
+	assert.Nil(t, err, "err nil when reconcile is successful")
+
+	//Check annotation
+	gotH := &hyperv1beta1.HostedCluster{}
+	err = ESCtrl.hubClient.Get(ctx, HCNamespaceNsn, gotH)
+	assert.Nil(t, err, "err nil if hostedcluster is found")
+	firstTimestamp, ok := gotH.ObjectMeta.Annotations["create-external-hub-kubeconfig"]
+	assert.True(t, ok, "true if annotation exists")
+
+	//Delete klusterlet
+	err = ESCtrl.hubClient.Delete(ctx, kl)
+	assert.Nil(t, err, "err nil if klusterlet is successfully deleted")
+
+	//Nothing should happen to hosted cluster
+	_, err = ESCtrl.Reconcile(ctx, ctrl.Request{NamespacedName: klusterletNamespaceNsn})
+	assert.Nil(t, err, "err nil when reconcile is successful")
+
+	//Annotation should still exist and be unchanged
+	err = ESCtrl.hubClient.Get(ctx, HCNamespaceNsn, gotH)
+	assert.Nil(t, err, "err nil if hostedcluster is found")
+	secondTimestamp, found := gotH.ObjectMeta.Annotations["create-external-hub-kubeconfig"]
+	assert.True(t, firstTimestamp == secondTimestamp && found, "true if annotation is unchanged")
+
+	kl = &operatorapiv1.Klusterlet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "klusterlet-hd-1",
+		},
+	}
+
+	time.Sleep(1 * time.Second) //Sleep one second to ensure different timestamp
+
+	//Recreate klusterlet (reimport)
+	err = ESCtrl.hubClient.Create(ctx, kl)
+	assert.Nil(t, err, "err nil when klusterlet is created successfully")
+
+	//Annotation should be updated to current time
+	_, err = ESCtrl.Reconcile(ctx, ctrl.Request{NamespacedName: klusterletNamespaceNsn})
+	assert.Nil(t, err, "err nil when reconcile is successful")
+
+	//Annotation should have newer timestamp
+	err = ESCtrl.hubClient.Get(ctx, HCNamespaceNsn, gotH)
+	assert.Nil(t, err, "err nil if hostedcluster is found")
+	secondTimestamp, found = gotH.ObjectMeta.Annotations["create-external-hub-kubeconfig"]
+	assert.True(t, firstTimestamp != secondTimestamp && found, "true if annotation exists and is changed")
+
+}
+
+func TestNoHCReconcile(t *testing.T) {
+	ctx := context.Background()
+	client, sch := initErrorHCClient()
+	zapLog, _ := zap.NewDevelopment()
+
+	ESCtrl := &ExternalSecretController{
+		spokeClient: client,
+		hubClient:   client,
+		log:         zapr.NewLogger(zapLog),
+	}
+
+	apiService := &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-apiserver",
+			Namespace: "clusters-hd-1",
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:     "https",
+					Port:     443,
+					Protocol: "TCP",
+					TargetPort: intstr.IntOrString{
+						IntVal: 6443,
+					},
+				},
+			},
+		},
+	}
+
+	klusterletNamespaceNsn := types.NamespacedName{
+		Name:      "klusterlet-hd-1",
+		Namespace: "",
+	}
+
+	kl := &operatorapiv1.Klusterlet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "klusterlet-hd-1",
+		},
+	}
+
+	err := ESCtrl.hubClient.Create(ctx, apiService)
+	assert.Nil(t, err, "err nil when kube-apiserver service is created successfully")
+	defer ESCtrl.hubClient.Delete(ctx, apiService)
+
+	//-----Cannot list hosted clusters-----
+	//Create klusterlet (import)
+	err = ESCtrl.hubClient.Create(ctx, kl)
+	assert.Nil(t, err, "err nil when klusterlet is created successfully")
+	_, err = ESCtrl.Reconcile(ctx, ctrl.Request{NamespacedName: klusterletNamespaceNsn})
+	assert.NotNil(t, err, "err not nil when unable to list hosted clusters")
+
+	err = ESCtrl.hubClient.Delete(ctx, kl)
+	assert.Nil(t, err, "err nil if klusterlet is successfully deleted")
+	hyperv1beta1.AddToScheme(sch)
+
+
+
+	//-----No associated hosted cluster (mismatched klusterlet and HC name)-----
+	hcNN := types.NamespacedName{Name: "hd-2", Namespace: "clusters"}
+
+	// Create hosted cluster
+	hc := getHostedCluster(hcNN)
+	err = ESCtrl.hubClient.Create(ctx, hc)
+	assert.Nil(t, err, "err nil when hosted cluster is created successfully")
+
+	kl = &operatorapiv1.Klusterlet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "klusterlet-hd-1",
+		},
+	}
+
+	//Create klusterlet (import)
+	err = ESCtrl.hubClient.Create(ctx, kl)
+	assert.Nil(t, err, "err nil when klusterlet is created successfully")
+
+	_, err = ESCtrl.Reconcile(ctx, ctrl.Request{NamespacedName: klusterletNamespaceNsn})
+	assert.NotNil(t, err, "err not nil when no associated hosted cluster")
+
+}
+
+func initErrorHCClient() (client.Client, *runtime.Scheme) {
+	scheme := runtime.NewScheme()
+	appsv1.AddToScheme(scheme)
+	corev1.AddToScheme(scheme)
+	metav1.AddMetaToScheme(scheme)
+	clusterv1alpha1.AddToScheme(scheme)
+	clusterv1.AddToScheme(scheme)
+	operatorapiv1.AddToScheme(scheme)
+
+	ncb := fake.NewClientBuilder()
+	ncb.WithScheme(scheme)
+	return ncb.Build(), scheme
+
+}

--- a/pkg/manager/manifests/templates/clusterrole.yaml
+++ b/pkg/manager/manifests/templates/clusterrole.yaml
@@ -23,7 +23,7 @@ rules:
     verbs: ["get", "list", "create", "patch", "update", "delete"]
   - apiGroups: ["operator.open-cluster-management.io"]
     resources: ["klusterlets"]
-    verbs: ["get", "list", "patch", "update"]    
+    verbs: ["get", "list", "patch", "update", "watch"]    
   - apiGroups: [""]
     resources: ["services", "serviceaccounts", "configmaps", "secrets", "namespaces"]
     verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]     

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -25,6 +25,7 @@ const (
 	HypershiftOverrideKey        = "imagestream"
 	AddonControllerName          = "hypershift-addon"
 	AddonStatusControllerName    = "hypershift-addon-status"
+	ExternalSecretControllerName = "external-secret"
 	AgentDeploymentName          = "hypershift-addon-agent"
 
 	HypershiftOverrideImagesCM = "hypershift-override-images"


### PR DESCRIPTION
* Reconcile on klusterlet as well



* Controller to trigger HC reconcile



* fixed client, added finalizer steps



* Fix delete finalizer condition, change UpdateFunc



* changed event filter, increased retries



* Removed event filter for now



* Fix vulnerability



* Added tests



* Remove code smell



* Only reconcile on create, use timestamp for annotation



* resolve reviews



* Add coverage



* Remove retry, requeue instead



---------

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* 

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* 

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?       github.com/stolostron/hypershift-addon-operator/cmd     [no test files]
ok      github.com/stolostron/hypershift-addon-operator/pkg/agent       15.031s coverage: 71.3% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/install     175.632s        coverage: 86.0% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/manager     120.060s        coverage: 60.6% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/metrics     0.024s  coverage: 100.0% of statements
?       github.com/stolostron/hypershift-addon-operator/pkg/util        [no test files]
```
