### PR TITLE
Use Patch instead of Update for HostedCluster Objects

### DIFF
--- a/pkg/agent/external_secret_controller.go
+++ b/pkg/agent/external_secret_controller.go
@@ -86,6 +86,8 @@ func (c *ExternalSecretController) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, errh
 	}
 
+	originalHC := hostedClusterObj.DeepCopy()
+
 	// Add/update the annotation to the hostedcluster
 	if hostedClusterObj.ObjectMeta.Annotations == nil { // Create the annotation map if it doesn't exist
 		hostedClusterObj.ObjectMeta.Annotations = make(map[string]string)
@@ -95,7 +97,7 @@ func (c *ExternalSecretController) Reconcile(ctx context.Context, req ctrl.Reque
 	hostedClusterObj.Annotations[hcAnnotation] = currentTime.Format(time.RFC3339)
 	c.log.Info(fmt.Sprintf("Annotated %s with %s", hostedClusterObj.Name, hcAnnotation))
 
-	if err := c.spokeClient.Update(ctx, hostedClusterObj); err != nil { //Add/update hostedcluster annotation
+	if err := c.spokeClient.Patch(ctx, hostedClusterObj, client.MergeFromWithOptions(originalHC)); err != nil { //Add/update hostedcluster annotation
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
The HypershiftAddonOperator is using an outdated version of the HostedCluster API. The result is when this controller performs an `Update` on a HC, some new fields get dropped that this controller has no knowledge of.

One way to prevent this moving forward is to always use a Patch operation on objects owned by other controllers (like the HostedCluster object).


## Test API/Unit - Success
```script

```
