### PR TITLE
ACM-5994 Reinstall operator when deployment arguments are mismatched

### DIFF
--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -174,7 +174,7 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 	}
 
 	// Cache the operator deployment to check for change in args
-	if (operatorDeployment != nil) {
+	if operatorDeployment != nil {
 		c.operatorDeployment = *operatorDeployment
 	}
 

--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -173,6 +173,11 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 		return nil
 	}
 
+	// Cache the operator deployment to check for change in args
+	if (operatorDeployment != nil) {
+		c.operatorDeployment = *operatorDeployment
+	}
+
 	// Initially set this to zero to indicate that the AWS S3 bucket secret is not used for the operator installation
 	metrics.IsAWSS3BucketSecretConfigured.Set(0)
 

--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -173,11 +173,6 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 		return nil
 	}
 
-	// Cache the operator deployment to check for change in args
-	if operatorDeployment != nil {
-		c.operatorDeployment = *operatorDeployment
-	}
-
 	// Initially set this to zero to indicate that the AWS S3 bucket secret is not used for the operator installation
 	metrics.IsAWSS3BucketSecretConfigured.Set(0)
 

--- a/pkg/install/upgrade.go
+++ b/pkg/install/upgrade.go
@@ -128,7 +128,7 @@ func (c *UpgradeController) installOptionsChanged() bool {
 
 	// check for changes in hypershift operator deployment arguments
 	operatorDeployment, err := c.getDeployment()
-	if err == nil && c.operatorArgMismatch(*operatorDeployment) {
+	if err == nil && c.operatorArgMismatch(operatorDeployment) {
 		return true
 	}
 	return false
@@ -183,15 +183,16 @@ func (c *UpgradeController) configmapDataChanged(oldCM, newCM corev1.ConfigMap, 
 	return false
 }
 
-func (c *UpgradeController) getDeployment() (*appsv1.Deployment, error) {
+func (c *UpgradeController) getDeployment() (appsv1.Deployment, error) {
 	deployment := &appsv1.Deployment{}
 	nsn := types.NamespacedName{Namespace: util.HypershiftOperatorNamespace, Name: util.HypershiftOperatorName}
 	err := c.spokeUncachedClient.Get(c.ctx, nsn, deployment)
 	if err != nil {
-		return nil, err
+		c.log.Error(err, "failed to get operater deployment: ")
+		return *deployment, err
 	}
 
-	return deployment, nil
+	return *deployment, nil
 }
 
 func (c *UpgradeController) operatorArgMismatch(dep appsv1.Deployment) bool {

--- a/pkg/install/upgrade.go
+++ b/pkg/install/upgrade.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -190,7 +189,7 @@ func (c *UpgradeController) deploymentArgsChanged(oldDeployment, newDeployment a
 	oldArgs := oldDeployment.Spec.Template.Spec.Containers[0].Args
 	newArgs := newDeployment.Spec.Template.Spec.Containers[0].Args
 	if !reflect.DeepEqual(oldArgs, newArgs) {
-		c.log.Info(fmt.Sprintf("the arguments of the deployment(%s) have changed", oldDeployment.Name))
+		c.log.Info(fmt.Sprintf("the arguments of the %s deployment have changed", oldDeployment.Name))
 		return true
 	}
 	return false
@@ -199,9 +198,9 @@ func (c *UpgradeController) deploymentArgsChanged(oldDeployment, newDeployment a
 func (c *UpgradeController) getDeployment() (*appsv1.Deployment, error) {
 	deployment := &appsv1.Deployment{}
 	nsn := types.NamespacedName{Namespace: util.HypershiftOperatorNamespace, Name: util.HypershiftOperatorName}
-	err := c.hubClient.Get(c.ctx, nsn, deployment)
+	err := c.spokeUncachedClient.Get(c.ctx, nsn, deployment)
 	if err != nil {
-		if !apierrors.IsNotFound(err) {
+		if !errors.IsNotFound(err) {
 			return nil, err
 		}
 		return nil, nil

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -179,7 +179,7 @@ var _ = ginkgo.Describe("Install", func() {
 					for _, p := range podList.Items {
 						if strings.HasPrefix(p.Name, "hypershift-addon-agent") {
 							addonAgentPod = &p
-							ginkgo.By("Found addon agent pod" + p.Name)
+							ginkgo.By("Found addon agent pod " + p.Name)
 
 							break
 						}


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
*  Reinstall operator when operator deployment args change

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  If OIDC args are added after operator is already installed, the operator isn't reinstalled with new args. This change watches operator deployment args and reinstalls the operator if they differ from expected args

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-5994

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?       github.com/stolostron/hypershift-addon-operator/cmd     [no test files]
ok      github.com/stolostron/hypershift-addon-operator/pkg/agent       13.068s coverage: 71.2% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/install     178.439s        coverage: 86.3% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/manager     120.040s        coverage: 60.6% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/metrics     0.005s  coverage: 100.0% of statements
?       github.com/stolostron/hypershift-addon-operator/pkg/util        [no test files]
```
