### PR TITLE
ACM-5994 Patch args if they differ from expected

### DIFF
--- a/pkg/install/upgrade.go
+++ b/pkg/install/upgrade.go
@@ -133,7 +133,9 @@ func (c *UpgradeController) installOptionsChanged() bool {
 	var expectArgs = []argObject{
 		{
 			name: util.HypershiftBucketSecretName,
-			args: []string{"--oidc-storage-provider-s3-bucket-name", "--oidc-storage-provider-s3-region", "--oidc-storage-provider-s3-credentials"},
+			args: []string{"--oidc-storage-provider-s3-bucket-name",
+				"--oidc-storage-provider-s3-region",
+				"--oidc-storage-provider-s3-credentials"},
 		},
 		{
 			name: util.HypershiftPrivateLinkSecretName,

--- a/pkg/install/upgrade.go
+++ b/pkg/install/upgrade.go
@@ -223,24 +223,22 @@ func (c *UpgradeController) getDeployment() (appsv1.Deployment, error) {
 }
 
 func (c *UpgradeController) operatorArgMismatch(dep appsv1.Deployment, mismatched []argObject) bool {
-
 	for i := range mismatched {
+
 		objExists := false
 		current := mismatched[i]
 		nsn := types.NamespacedName{Name: current.name, Namespace: c.clusterName}
 		switch current.obj.(type) {
 		case corev1.Secret:
-			if err := c.hubClient.Get(c.ctx, nsn, current.obj.(*corev1.Secret)); err == nil {
+			secretObj := &corev1.Secret{}
+			if err := c.hubClient.Get(c.ctx, nsn, secretObj); err == nil {
 				objExists = true
-			} else {
-				continue
 			}
 
 		case corev1.ConfigMap:
-			if err := c.hubClient.Get(c.ctx, nsn, current.obj.(*corev1.ConfigMap)); err == nil {
+			configObj := &corev1.ConfigMap{}
+			if err := c.hubClient.Get(c.ctx, nsn, configObj); err == nil {
 				objExists = true
-			} else {
-				continue
 			}
 
 		default:

--- a/pkg/install/upgrade_test.go
+++ b/pkg/install/upgrade_test.go
@@ -547,6 +547,7 @@ func TestInstallFlagChanges(t *testing.T) {
 						Name:  "nginx",
 						Image: "nginx:1.14.2",
 						Ports: []corev1.ContainerPort{{ContainerPort: 80}},
+						Args:  []string{"--hypershift-image", "--image-refs"},
 					}},
 				},
 			},

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -179,7 +179,7 @@ var _ = ginkgo.Describe("Install", func() {
 					for _, p := range podList.Items {
 						if strings.HasPrefix(p.Name, "hypershift-addon-agent") {
 							addonAgentPod = &p
-							ginkgo.By("Found addon agent pod" + p.Name)
+							ginkgo.By("Found addon agent pod " + p.Name)
 
 							break
 						}


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Patch operator args in case of mismatch

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Operator can be mistakenly installed without all the correct arguments. Patch operator with correct arguments if this happens.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-5994

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?       github.com/stolostron/hypershift-addon-operator/cmd     [no test files]
ok      github.com/stolostron/hypershift-addon-operator/pkg/agent       13.536s coverage: 71.2% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/install     175.717s        coverage: 85.8% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/manager     120.072s        coverage: 60.6% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/metrics     0.005s  coverage: 100.0% of statements
?       github.com/stolostron/hypershift-addon-operator/pkg/util        [no test files]
```
