### PR TITLE
ACM-5994 Clear cache and catch update error

### DIFF
--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -409,6 +409,7 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 	err = c.updateHyperShiftDeployment(ctx)
 	if err != nil {
 		c.log.Error(err, "failed to update the hypershift operator deployment")
+		return err
 	}
 
 	return nil

--- a/pkg/install/upgrade.go
+++ b/pkg/install/upgrade.go
@@ -79,6 +79,7 @@ func (c *UpgradeController) Start() {
 				c.log.Error(err, "failed to install hypershift operator")
 
 				c.installfailed = true
+				c.clearCache()
 				metrics.InstallationFailningGaugeBool.Set(float64(1))
 			} else {
 				c.installfailed = false
@@ -174,4 +175,12 @@ func (c *UpgradeController) configmapDataChanged(oldCM, newCM corev1.ConfigMap, 
 		return true
 	}
 	return false
+}
+
+func (c* UpgradeController) clearCache() {
+	c.bucketSecret = corev1.Secret{}
+	c.extDnsSecret = corev1.Secret{}
+	c.privateLinkSecret = corev1.Secret{}    
+	c.imageOverrideConfigmap = corev1.ConfigMap{}
+	c.installFlagsConfigmap = corev1.ConfigMap{}
 }

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -179,7 +179,7 @@ var _ = ginkgo.Describe("Install", func() {
 					for _, p := range podList.Items {
 						if strings.HasPrefix(p.Name, "hypershift-addon-agent") {
 							addonAgentPod = &p
-							ginkgo.By("Found addon agent pod" + p.Name)
+							ginkgo.By("Found addon agent pod " + p.Name)
 
 							break
 						}


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Clear cache and return err on failed deployment update

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Failed deployment update error may fall through and not reinstall with correct arguments. Catch error and clear cache

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-5994

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?       github.com/stolostron/hypershift-addon-operator/cmd     [no test files]
ok      github.com/stolostron/hypershift-addon-operator/pkg/agent       12.513s coverage: 71.3% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/install     175.386s        coverage: 84.9% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/manager     120.042s        coverage: 60.6% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/metrics     0.006s  coverage: 100.0% of statements
?       github.com/stolostron/hypershift-addon-operator/pkg/util        [no test files]
```
