### PR TITLE
add Power and Z CLI binaries

### DIFF
--- a/pkg/manager/cli_download_install.go
+++ b/pkg/manager/cli_download_install.go
@@ -309,41 +309,6 @@ func getConsoleDownload(routeUrl string, log logr.Logger) (*consolev1.ConsoleCLI
 		return nil, err
 	}
 
-	/*links := []consolev1.CLIDownloadLink{
-		{
-			Href: "https://" + routeUrl + "/linux/amd64/hypershift.tar.gz",
-			Text: "Download hypershift CLI for Linux for x86_64",
-		},
-		{
-			Href: "https://" + routeUrl + "/darwin/amd64/hypershift.tar.gz",
-			Text: "Download hypershift CLI for Mac for x86_64",
-		},
-		{
-			Href: "https://" + routeUrl + "/windows/amd64/hypershift.tar.gz",
-			Text: "Download hypershift CLI for Windows for x86_64",
-		},
-		{
-			Href: "https://" + routeUrl + "/linux/arm64/hypershift.tar.gz",
-			Text: "Download hypershift CLI for Linux for ARM 64",
-		},
-		{
-			Href: "https://" + routeUrl + "/darwin/arm64/hypershift.tar.gz",
-			Text: "Download hypershift CLI for Mac for ARM 64",
-		},
-		{
-			Href: "https://" + routeUrl + "/linux/ppc64/hypershift.tar.gz",
-			Text: "Download hypershift CLI for Linux for IBM Power",
-		},
-		{
-			Href: "https://" + routeUrl + "/linux/ppc64le/hypershift.tar.gz",
-			Text: "Download hypershift CLI for Linux for IBM Power, little endian",
-		},
-		{
-			Href: "https://" + routeUrl + "/linux/s390x/hypershift.tar.gz",
-			Text: "Download hypershift CLI for Linux for IBM Z",
-		},
-	}*/
-
 	links := []consolev1.CLIDownloadLink{}
 
 	links = append(links, consolev1.CLIDownloadLink{

--- a/pkg/manager/cli_download_install.go
+++ b/pkg/manager/cli_download_install.go
@@ -330,6 +330,18 @@ func getConsoleDownload(routeUrl string, log logr.Logger) (*consolev1.ConsoleCLI
 			Href: "https://" + routeUrl + "/darwin/arm64/hypershift.tar.gz",
 			Text: "Download hypershift CLI for Mac for ARM 64",
 		},
+		{
+			Href: "https://" + routeUrl + "/linux/ppc64/hypershift.tar.gz",
+			Text: "Download hypershift CLI for Linux for IBM Power",
+		},
+		{
+			Href: "https://" + routeUrl + "/linux/ppc64le/hypershift.tar.gz",
+			Text: "Download hypershift CLI for Linux for IBM Power, little endian",
+		},
+		{
+			Href: "https://" + routeUrl + "/linux/s390x/hypershift.tar.gz",
+			Text: "Download hypershift CLI for Linux for IBM Z",
+		},
 	}
 	cliDownload.Spec.Links = links
 

--- a/pkg/manager/cli_download_install.go
+++ b/pkg/manager/cli_download_install.go
@@ -309,7 +309,7 @@ func getConsoleDownload(routeUrl string, log logr.Logger) (*consolev1.ConsoleCLI
 		return nil, err
 	}
 
-	links := []consolev1.CLIDownloadLink{
+	/*links := []consolev1.CLIDownloadLink{
 		{
 			Href: "https://" + routeUrl + "/linux/amd64/hypershift.tar.gz",
 			Text: "Download hypershift CLI for Linux for x86_64",
@@ -342,7 +342,50 @@ func getConsoleDownload(routeUrl string, log logr.Logger) (*consolev1.ConsoleCLI
 			Href: "https://" + routeUrl + "/linux/s390x/hypershift.tar.gz",
 			Text: "Download hypershift CLI for Linux for IBM Z",
 		},
-	}
+	}*/
+
+	links := []consolev1.CLIDownloadLink{}
+
+	links = append(links, consolev1.CLIDownloadLink{
+		Href: "https://" + routeUrl + "/linux/amd64/hypershift.tar.gz",
+		Text: "Download hypershift CLI for Linux for x86_64",
+	})
+
+	links = append(links, consolev1.CLIDownloadLink{
+		Href: "https://" + routeUrl + "/darwin/amd64/hypershift.tar.gz",
+		Text: "Download hypershift CLI for Mac for x86_64",
+	})
+
+	links = append(links, consolev1.CLIDownloadLink{
+		Href: "https://" + routeUrl + "/windows/amd64/hypershift.tar.gz",
+		Text: "Download hypershift CLI for Windows for x86_64",
+	})
+
+	links = append(links, consolev1.CLIDownloadLink{
+		Href: "https://" + routeUrl + "/linux/arm64/hypershift.tar.gz",
+		Text: "Download hypershift CLI for Linux for ARM 64",
+	})
+
+	links = append(links, consolev1.CLIDownloadLink{
+		Href: "https://" + routeUrl + "/darwin/arm64/hypershift.tar.gz",
+		Text: "Download hypershift CLI for Mac for ARM 64",
+	})
+
+	links = append(links, consolev1.CLIDownloadLink{
+		Href: "https://" + routeUrl + "/linux/ppc64/hypershift.tar.gz",
+		Text: "Download hypershift CLI for Linux for IBM Power",
+	})
+
+	links = append(links, consolev1.CLIDownloadLink{
+		Href: "https://" + routeUrl + "/linux/ppc64le/hypershift.tar.gz",
+		Text: "Download hypershift CLI for Linux for IBM Power, little endian",
+	})
+
+	links = append(links, consolev1.CLIDownloadLink{
+		Href: "https://" + routeUrl + "/linux/s390x/hypershift.tar.gz",
+		Text: "Download hypershift CLI for Linux for IBM Z",
+	})
+
 	cliDownload.Spec.Links = links
 
 	return cliDownload, nil


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Add downloadable Power and Z hypershift CLI binaries

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Add downloadable Power and Z hypershift CLI binaries

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-6535

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
KUBEBUILDER_ASSETS="/Users/rokej/Library/Application Support/io.kubebuilder.envtest/k8s/1.22.1-darwin-amd64" go test github.com/stolostron/hypershift-addon-operator/cmd github.com/stolostron/hypershift-addon-operator/pkg/agent github.com/stolostron/hypershift-addon-operator/pkg/install github.com/stolostron/hypershift-addon-operator/pkg/manager github.com/stolostron/hypershift-addon-operator/pkg/metrics github.com/stolostron/hypershift-addon-operator/pkg/util -coverprofile cover.out
?   	github.com/stolostron/hypershift-addon-operator/cmd	[no test files]
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	31.213s	coverage: 71.2% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	176.116s	coverage: 86.0% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	120.928s	coverage: 60.6% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	0.646s	coverage: 100.0% of statements
?   	github.com/stolostron/hypershift-addon-operator/pkg/util	[no test files]

```
