### PR TITLE
ACM-5994 - Detect changes from deployment instead of cached secrets

### DIFF
--- a/pkg/install/expectedArgs.go
+++ b/pkg/install/expectedArgs.go
@@ -23,54 +23,12 @@ type expectedArg struct {
 	argument    string
 }
 
-var (
-	expected = []expectedConfig{
-		{
-			objectName: util.HypershiftBucketSecretName,
-			objectType: corev1.Secret{},
-			objectArgs: []expectedArg{
-				{argument: "--oidc-storage-provider-s3-bucket-name={bucket}", shouldExist: true},
-				{argument: "--oidc-storage-provider-s3-region={region}", shouldExist: true},
-				{argument: "--oidc-storage-provider-s3-credentials=/etc/oidc-storage-provider-s3-creds/credentials", shouldExist: true},
-			},
-			NoObjectArgs: []expectedArg{
-				{argument: "--oidc-storage-provider-s3-bucket-name=", shouldExist: false},
-				{argument: "--oidc-storage-provider-s3-region=", shouldExist: false},
-				{argument: "--oidc-storage-provider-s3-credentials=/etc/oidc-storage-provider-s3-creds/credentials", shouldExist: false},
-			},
-			deploymentName: util.HypershiftOperatorName,
-		},
-		{
-			objectName: util.HypershiftPrivateLinkSecretName,
-			objectType: corev1.Secret{},
-			objectArgs: []expectedArg{
-				{argument: "--private-platform=AWS", shouldExist: true},
-				{argument: "--private-platform=None", shouldExist: false},
-			},
-			NoObjectArgs: []expectedArg{
-				{argument: "--private-platform=None", shouldExist: true},
-				{argument: "--private-platform=AWS", shouldExist: false},
-			},
-			deploymentName: util.HypershiftOperatorName,
-		},
-		{
-			objectName: util.HypershiftExternalDNSSecretName,
-			objectType: corev1.Secret{},
-			objectArgs: []expectedArg{
-				{argument: "--domain-filter={domain-filter}", shouldExist: true},
-				{argument: "--provider={provider}", shouldExist: true},
-			},
-			deploymentName: util.HypershiftOperatorExternalDNSName,
-		},
-	}
-)
-
 func (c *UpgradeController) getDeployment(operatorName string) (appsv1.Deployment, error) {
 	deployment := &appsv1.Deployment{}
 	nsn := types.NamespacedName{Namespace: util.HypershiftOperatorNamespace, Name: operatorName}
 	err := c.spokeUncachedClient.Get(c.ctx, nsn, deployment)
 	if err != nil {
-		c.log.Error(err, fmt.Sprintf("failed to get %s deployment: ", operatorName))
+		c.log.Info(fmt.Sprintf("failed to get %s deployment", operatorName))
 		return *deployment, err
 	}
 

--- a/pkg/install/expectedArgs.go
+++ b/pkg/install/expectedArgs.go
@@ -62,23 +62,8 @@ var (
 			},
 			deploymentName: util.HypershiftOperatorExternalDNSName,
 		},
-		// {
-		// 	objectName:     util.HypershiftInstallFlagsCM,
-		// 	objectType:     corev1.ConfigMap{},
-		// 	objectArgs:     []expectedArg{}, // fill out directly from config map
-		// 	NoObjectArgs:   []expectedArg{}, // fill out directly from config map
-		// 	deploymentName: util.HypershiftOperatorName,
-		// },
 	}
 )
-
-func stringToExpectedArg(toAdd []string) []expectedArg {
-	var result []expectedArg
-	for s := range toAdd {
-		result = append(result, expectedArg{shouldExist: true, argument: toAdd[s]})
-	}
-	return result
-}
 
 func (c *UpgradeController) getDeployment(operatorName string) (appsv1.Deployment, error) {
 	deployment := &appsv1.Deployment{}
@@ -115,7 +100,6 @@ func getValueFromKey(secret corev1.Secret, key string) string {
 func argMismatch(args []expectedArg, deployArgs []string) bool {
 	for _, a := range args {
 		if argInList(a.argument, deployArgs) != a.shouldExist {
-			fmt.Printf("MISMATCH WITH ARG %s %t\n", a.argument, a.shouldExist)
 			return true
 		}
 	}
@@ -124,7 +108,6 @@ func argMismatch(args []expectedArg, deployArgs []string) bool {
 
 func argInList(arg string, list []string) bool {
 	for _, a := range list {
-		//fmt.Printf("comparing %s WITH %s\n", a, arg)
 		if strings.Contains(a, arg) {
 			return true
 		}

--- a/pkg/install/expectedArgs.go
+++ b/pkg/install/expectedArgs.go
@@ -1,0 +1,92 @@
+package install
+
+import (
+	"fmt"
+
+	"github.com/stolostron/hypershift-addon-operator/pkg/util"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type expectedConfig struct {
+	objectName     string
+	deploymentName string
+	objectArgs     []expectedArg
+	NoObjectArgs   []expectedArg
+	objectType     interface{}
+}
+
+type expectedArg struct {
+	shouldExist bool
+	argument    string
+}
+
+var (
+	expected = []expectedConfig{
+		{
+			objectName: util.HypershiftBucketSecretName,
+			objectType: corev1.Secret{},
+			objectArgs: []expectedArg{
+				{argument: "--oidc-storage-provider-s3-bucket-name={bucket}", shouldExist: true},
+				{argument: "--oidc-storage-provider-s3-region={region}", shouldExist: true},
+				{argument: "--oidc-storage-provider-s3-credentials=/etc/oidc-storage-provider-s3-creds/credentials", shouldExist: true},
+			},
+			NoObjectArgs: []expectedArg{
+				{argument: "--oidc-storage-provider-s3-bucket-name=", shouldExist: false},
+				{argument: "--oidc-storage-provider-s3-region=", shouldExist: false},
+				{argument: "--oidc-storage-provider-s3-credentials=/etc/oidc-storage-provider-s3-creds/credentials", shouldExist: false},
+			},
+			deploymentName: util.HypershiftOperatorName,
+		},
+		{
+			objectName: util.HypershiftPrivateLinkSecretName,
+			objectType: corev1.Secret{},
+			objectArgs: []expectedArg{
+				{argument: "--private-platform=AWS", shouldExist: true},
+				{argument: "--private-platform=None", shouldExist: false},
+			},
+			NoObjectArgs: []expectedArg{
+				{argument: "--private-platform=None", shouldExist: true},
+				{argument: "--private-platform=AWS", shouldExist: false},
+			},
+			deploymentName: util.HypershiftOperatorName,
+		},
+		{
+			objectName: util.HypershiftExternalDNSSecretName,
+			objectType: corev1.Secret{},
+			objectArgs: []expectedArg{
+				{argument: "--domain-filter={domain-filter}", shouldExist: true},
+				{argument: "--provider={provider}", shouldExist: true},
+			},
+			deploymentName: util.HypershiftOperatorExternalDNSName,
+		},
+		{
+			objectName:     util.HypershiftInstallFlagsCM,
+			objectType:     corev1.ConfigMap{},
+			objectArgs:     []expectedArg{}, // fill out directly from config map
+			NoObjectArgs:   []expectedArg{}, // fill out directly from config map
+			deploymentName: util.HypershiftOperatorName,
+		},
+	}
+)
+
+func stringToExpectedArg(toAdd []string) []expectedArg {
+	var result []expectedArg
+	for s := range toAdd {
+		result = append(result, expectedArg{shouldExist: true, argument: toAdd[s]})
+	}
+	return result
+}
+
+func (c *UpgradeController) getDeployment(operatorName string) (appsv1.Deployment, error) {
+	deployment := &appsv1.Deployment{}
+	nsn := types.NamespacedName{Namespace: util.HypershiftOperatorNamespace, Name: operatorName}
+	err := c.spokeUncachedClient.Get(c.ctx, nsn, deployment)
+	if err != nil {
+		c.log.Error(err, fmt.Sprintf("failed to get %s deployment: ", operatorName))
+		return *deployment, err
+	}
+
+	return *deployment, nil
+}

--- a/pkg/install/expectedArgs.go
+++ b/pkg/install/expectedArgs.go
@@ -62,13 +62,13 @@ var (
 			},
 			deploymentName: util.HypershiftOperatorExternalDNSName,
 		},
-		{
-			objectName:     util.HypershiftInstallFlagsCM,
-			objectType:     corev1.ConfigMap{},
-			objectArgs:     []expectedArg{}, // fill out directly from config map
-			NoObjectArgs:   []expectedArg{}, // fill out directly from config map
-			deploymentName: util.HypershiftOperatorName,
-		},
+		// {
+		// 	objectName:     util.HypershiftInstallFlagsCM,
+		// 	objectType:     corev1.ConfigMap{},
+		// 	objectArgs:     []expectedArg{}, // fill out directly from config map
+		// 	NoObjectArgs:   []expectedArg{}, // fill out directly from config map
+		// 	deploymentName: util.HypershiftOperatorName,
+		// },
 	}
 )
 
@@ -110,4 +110,24 @@ func matchAndTrim(s *string) string {
 func getValueFromKey(secret corev1.Secret, key string) string {
 	value := secret.Data[key]
 	return string(value)
+}
+
+func argMismatch(args []expectedArg, deployArgs []string) bool {
+	for _, a := range args {
+		if argInList(a.argument, deployArgs) != a.shouldExist {
+			fmt.Printf("MISMATCH WITH ARG %s %t\n", a.argument, a.shouldExist)
+			return true
+		}
+	}
+	return false
+}
+
+func argInList(arg string, list []string) bool {
+	for _, a := range list {
+		//fmt.Printf("comparing %s WITH %s\n", a, arg)
+		if strings.Contains(a, arg) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/install/expectedArgs.go
+++ b/pkg/install/expectedArgs.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/stolostron/hypershift-addon-operator/pkg/util"
 	appsv1 "k8s.io/api/apps/v1"
@@ -89,4 +90,24 @@ func (c *UpgradeController) getDeployment(operatorName string) (appsv1.Deploymen
 	}
 
 	return *deployment, nil
+}
+
+// Match {text} and remove it
+// Returns matched text e.g. --oidc-storage-provider-s3-bucket-name={bucket} will become "--oidc-storage-provider-s3-bucket-name=" and return "bucket"
+func matchAndTrim(s *string) string {
+	i := strings.Index(*s, "{")
+	if i >= 0 {
+		j := strings.Index(*s, "}")
+		if j >= 0 {
+			match := (*s)[i+1 : j]
+			*s = (*s)[:len(*s)-(len(match)+2)]
+			return match
+		}
+	}
+	return ""
+}
+
+func getValueFromKey(secret corev1.Secret, key string) string {
+	value := secret.Data[key]
+	return string(value)
 }

--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -248,9 +248,6 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 			return fmt.Errorf("hypershift-operator-oidc-provider-s3-credentials does not contain a bucket key")
 		}
 
-		// if err := c.createOrUpdateAwsSpokeSecret(ctx, se, true); err != nil {
-		// 	return err
-		// }
 		c.log.Info("oidc s3 bucket, region & credential arguments included")
 		awsArgs := []string{
 			"--oidc-storage-provider-s3-bucket-name", bucketName,
@@ -265,9 +262,6 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 	}
 
 	if privateLinkCreds { // if private link credentials is found, install hypershift with private secret options
-		// if err := c.createOrUpdateAwsSpokeSecret(ctx, spl, true); err != nil {
-		// 	return err
-		// }
 		c.log.Info("private link region & credential arguments included")
 		awsArgs := []string{
 			"--aws-private-secret", util.HypershiftPrivateLinkSecretName,
@@ -282,17 +276,6 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 	extDNSSecretKey := types.NamespacedName{Name: util.HypershiftExternalDNSSecretName, Namespace: c.clusterName}
 	sExtDNS := &corev1.Secret{}
 	if err := c.hubClient.Get(ctx, extDNSSecretKey, sExtDNS); err == nil {
-		// if awsPlatform {
-		// 	// For AWS DNS provider, users can specify either credentials or
-		// 	// aws-access-key-id and aws-secret-access-key
-		// 	if err := c.createOrUpdateAwsSpokeSecret(ctx, sExtDNS, false); err != nil {
-		// 		return err
-		// 	}
-		// } else {
-		// 	if err := c.createOrUpdateSpokeSecret(ctx, sExtDNS); err != nil {
-		// 		return err
-		// 	}
-		// }
 
 		c.log.Info("external dns provider & domain-filter arguments included")
 		awsArgs := []string{

--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -253,7 +253,7 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 			return fmt.Errorf("hypershift-operator-oidc-provider-s3-credentials does not contain a bucket key")
 		}
 
-		if err := c.createAwsSpokeSecret(ctx, se, true); err != nil {
+		if err := c.createOrUpdateAwsSpokeSecret(ctx, se, true); err != nil {
 			return err
 		}
 		c.log.Info("oidc s3 bucket, region & credential arguments included")
@@ -270,7 +270,7 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 	}
 
 	if privateLinkCreds { // if private link credentials is found, install hypershift with private secret options
-		if err := c.createAwsSpokeSecret(ctx, spl, true); err != nil {
+		if err := c.createOrUpdateAwsSpokeSecret(ctx, spl, true); err != nil {
 			return err
 		}
 		c.log.Info("private link region & credential arguments included")
@@ -290,11 +290,11 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 		if awsPlatform {
 			// For AWS DNS provider, users can specify either credentials or
 			// aws-access-key-id and aws-secret-access-key
-			if err := c.createAwsSpokeSecret(ctx, sExtDNS, false); err != nil {
+			if err := c.createOrUpdateAwsSpokeSecret(ctx, sExtDNS, false); err != nil {
 				return err
 			}
 		} else {
-			if err := c.createSpokeSecret(ctx, sExtDNS); err != nil {
+			if err := c.createOrUpdateSpokeSecret(ctx, sExtDNS); err != nil {
 				return err
 			}
 		}
@@ -511,7 +511,7 @@ func getParamValue(s []string, e string) string {
 	return ""
 }
 
-func (c *UpgradeController) createAwsSpokeSecret(ctx context.Context, hubSecret *corev1.Secret, regionRequired bool) error {
+func (c *UpgradeController) createOrUpdateAwsSpokeSecret(ctx context.Context, hubSecret *corev1.Secret, regionRequired bool) error {
 	spokeSecret := hubSecret.DeepCopy()
 
 	region := hubSecret.Data["region"]
@@ -525,10 +525,10 @@ func (c *UpgradeController) createAwsSpokeSecret(ctx context.Context, hubSecret 
 		}
 	}
 
-	return c.createSpokeSecret(ctx, spokeSecret)
+	return c.createOrUpdateSpokeSecret(ctx, spokeSecret)
 }
 
-func (c *UpgradeController) createSpokeSecret(ctx context.Context, hubSecret *corev1.Secret) error {
+func (c *UpgradeController) createOrUpdateSpokeSecret(ctx context.Context, hubSecret *corev1.Secret) error {
 
 	spokeSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -253,9 +253,9 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 			return fmt.Errorf("hypershift-operator-oidc-provider-s3-credentials does not contain a bucket key")
 		}
 
-		if err := c.createOrUpdateAwsSpokeSecret(ctx, se, true); err != nil {
-			return err
-		}
+		// if err := c.createOrUpdateAwsSpokeSecret(ctx, se, true); err != nil {
+		// 	return err
+		// }
 		c.log.Info("oidc s3 bucket, region & credential arguments included")
 		awsArgs := []string{
 			"--oidc-storage-provider-s3-bucket-name", bucketName,
@@ -270,9 +270,9 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 	}
 
 	if privateLinkCreds { // if private link credentials is found, install hypershift with private secret options
-		if err := c.createOrUpdateAwsSpokeSecret(ctx, spl, true); err != nil {
-			return err
-		}
+		// if err := c.createOrUpdateAwsSpokeSecret(ctx, spl, true); err != nil {
+		// 	return err
+		// }
 		c.log.Info("private link region & credential arguments included")
 		awsArgs := []string{
 			"--aws-private-secret", util.HypershiftPrivateLinkSecretName,
@@ -287,17 +287,17 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 	extDNSSecretKey := types.NamespacedName{Name: util.HypershiftExternalDNSSecretName, Namespace: c.clusterName}
 	sExtDNS := &corev1.Secret{}
 	if err := c.hubClient.Get(ctx, extDNSSecretKey, sExtDNS); err == nil {
-		if awsPlatform {
-			// For AWS DNS provider, users can specify either credentials or
-			// aws-access-key-id and aws-secret-access-key
-			if err := c.createOrUpdateAwsSpokeSecret(ctx, sExtDNS, false); err != nil {
-				return err
-			}
-		} else {
-			if err := c.createOrUpdateSpokeSecret(ctx, sExtDNS); err != nil {
-				return err
-			}
-		}
+		// if awsPlatform {
+		// 	// For AWS DNS provider, users can specify either credentials or
+		// 	// aws-access-key-id and aws-secret-access-key
+		// 	if err := c.createOrUpdateAwsSpokeSecret(ctx, sExtDNS, false); err != nil {
+		// 		return err
+		// 	}
+		// } else {
+		// 	if err := c.createOrUpdateSpokeSecret(ctx, sExtDNS); err != nil {
+		// 		return err
+		// 	}
+		// }
 
 		c.log.Info("external dns provider & domain-filter arguments included")
 		awsArgs := []string{

--- a/pkg/install/hypershift_test.go
+++ b/pkg/install/hypershift_test.go
@@ -1720,8 +1720,6 @@ func TestAWSPlatformDetection(t *testing.T) {
 		clusterName:               "cluster1",
 		pullSecret:                "pull-secret",
 		hypershiftInstallExecutor: &HypershiftTestCliExecutor{},
-		privateLinkSecret:         corev1.Secret{},
-		bucketSecret:              corev1.Secret{},
 	}
 
 	privateLinkSecret := &corev1.Secret{

--- a/pkg/install/hypershift_test.go
+++ b/pkg/install/hypershift_test.go
@@ -1418,7 +1418,7 @@ func TestCreateSpokeCredential(t *testing.T) {
 		},
 	}
 
-	err := aCtrl.createAwsSpokeSecret(ctx, bucketSecret, true)
+	err := aCtrl.createOrUpdateAwsSpokeSecret(ctx, bucketSecret, true)
 	assert.NotNil(t, err, "is not nil, when secret is not well formed")
 
 }
@@ -1449,7 +1449,7 @@ func TestSpokeCredentialUpdated(t *testing.T) {
 		},
 	}
 
-	err := aCtrl.createSpokeSecret(ctx, hubSecret)
+	err := aCtrl.createOrUpdateSpokeSecret(ctx, hubSecret)
 	assert.Nil(t, err, "expected secret creation to succeed")
 
 	spokeSecret := &corev1.Secret{
@@ -1465,7 +1465,7 @@ func TestSpokeCredentialUpdated(t *testing.T) {
 
 	// now update the hub secret and propagate that change to spoke
 	hubSecret.Data["credentials"] = []byte("February")
-	err = aCtrl.createSpokeSecret(ctx, hubSecret)
+	err = aCtrl.createOrUpdateSpokeSecret(ctx, hubSecret)
 	assert.Nil(t, err, "expected updating secret to succeed")
 
 	aCtrl.spokeUncachedClient.Get(ctx, ctrlClient.ObjectKeyFromObject(spokeSecret), spokeSecret)

--- a/pkg/install/upgrade.go
+++ b/pkg/install/upgrade.go
@@ -127,7 +127,8 @@ func (c *UpgradeController) installOptionsChanged() bool {
 		return true
 	}
 
-	return false
+	return c.checkArgs()
+
 }
 
 func (c *UpgradeController) getSecretFromHub(secretName string) (corev1.Secret, error) {
@@ -223,5 +224,56 @@ func (c *UpgradeController) syncHypershiftNS() error {
 		}
 
 	}
+
 	return nil
+}
+
+
+func (c *UpgradeController) populateExpectedArgs(toPopulate *[]expectedConfig) error {
+	//anything with {key} gets replaced with the value of 'key' in the secret
+	tp := *toPopulate
+	for e := range tp {
+		if _, isCM := tp[e].objectType.(corev1.ConfigMap); isCM {
+			newInstallFlagsCM, err := c.getConfigMapFromHub(util.HypershiftInstallFlagsCM)
+			if err == nil {
+				tp[e].objectArgs = append(tp[e].objectArgs, stringToExpectedArg(c.buildOtherInstallFlags(newInstallFlagsCM))...)
+			}
+		} else {
+
+		}
+	}
+	return nil
+}
+
+func (c *UpgradeController) checkArgs() bool {
+	// Create expected args based on secrets' existence and their values
+	// Compare the expected args to the actual args
+	// If they differ, reinstall
+
+	err := c.populateExpectedArgs(&expected)
+	
+
+	for o := range expected {
+		operatorDeployment, err := c.getDeployment(expected[o].deploymentName)
+		if err != nil {
+			continue
+		}
+		
+		// switch expected[o].objectName {
+		// case util.HypershiftBucketSecretName:
+
+		// case util.HypershiftPrivateLinkSecretName:
+
+		// case util.HypershiftExternalDNSSecretName:
+
+		// case util.HypershiftInstallFlagsCM:
+
+
+		// default:
+		// 	c.log.Info(fmt.Sprintf("unkown object (%s)", expected[o].objectName))
+			
+		// }
+	}
+
+	return false
 }

--- a/pkg/install/upgrade_test.go
+++ b/pkg/install/upgrade_test.go
@@ -147,7 +147,6 @@ func TestBucketSecretChanges(t *testing.T) {
 		clusterName:               "cluster1",
 		pullSecret:                "pull-secret",
 		hypershiftInstallExecutor: &HypershiftTestCliExecutor{},
-		bucketSecret:              corev1.Secret{},
 	}
 
 	newBucketSecret := &corev1.Secret{
@@ -252,7 +251,6 @@ func TestExtDnsSecretChanges(t *testing.T) {
 		clusterName:               "cluster1",
 		pullSecret:                "pull-secret",
 		hypershiftInstallExecutor: &HypershiftTestCliExecutor{},
-		extDnsSecret:              corev1.Secret{},
 	}
 
 	newExtDnsSecret := &corev1.Secret{
@@ -359,7 +357,6 @@ func TestPrivateLinkSecretChanges(t *testing.T) {
 		clusterName:               "cluster1",
 		pullSecret:                "pull-secret",
 		hypershiftInstallExecutor: &HypershiftTestCliExecutor{},
-		privateLinkSecret:         corev1.Secret{},
 	}
 
 	newPrivateLinkSecret := &corev1.Secret{

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -179,7 +179,7 @@ var _ = ginkgo.Describe("Install", func() {
 					for _, p := range podList.Items {
 						if strings.HasPrefix(p.Name, "hypershift-addon-agent") {
 							addonAgentPod = &p
-							ginkgo.By("Found addon agent pod" + p.Name)
+							ginkgo.By("Found addon agent pod " + p.Name)
 
 							break
 						}


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Compare state of secrets to state of deployment instead of cached secrets to detect changes

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-5994

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?       github.com/stolostron/hypershift-addon-operator/cmd     [no test files]
ok      github.com/stolostron/hypershift-addon-operator/pkg/agent       14.211s coverage: 71.2% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/install     173.372s        coverage: 88.0% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/manager     120.100s        coverage: 60.6% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/metrics     0.010s  coverage: 100.0% of statements
?       github.com/stolostron/hypershift-addon-operator/pkg/util        [no test files]
```
