### PR TITLE
[HOSTEDCP-1041] Enable defaulting webhook for hypershift operator with self managed

### DIFF
--- a/pkg/agent/auto_import_controller.go
+++ b/pkg/agent/auto_import_controller.go
@@ -215,7 +215,6 @@ func (c *AutoImportController) createKlusterletAddonConfig(hcName string, ctx co
 	kac.Spec.ClusterLabels["cloud"] = "Amazon"
 	kac.Spec.ClusterLabels["vendor"] = "Openshift"
 
-	
 	kac.Spec.ApplicationManagerConfig.Enabled = true
 	kac.Spec.SearchCollectorConfig.Enabled = true
 	kac.Spec.CertPolicyControllerConfig.Enabled = true

--- a/pkg/agent/external_secret_controller_test.go
+++ b/pkg/agent/external_secret_controller_test.go
@@ -201,8 +201,6 @@ func TestNoHCReconcile(t *testing.T) {
 	assert.Nil(t, err, "err nil if klusterlet is successfully deleted")
 	hyperv1beta1.AddToScheme(sch)
 
-
-
 	//-----No associated hosted cluster (mismatched klusterlet and HC name)-----
 	hcNN := types.NamespacedName{Name: "hd-2", Namespace: "clusters"}
 

--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -458,14 +458,21 @@ func (c *UpgradeController) buildOtherInstallFlags(installFlagsCM corev1.ConfigM
 		}
 		args = append(args, rhobsArgs...)
 	} else {
+		// Self Managed specific args. These are set when RHOBS_MONITORING is not in use
+		//
 		// add --enable-uwm-telemetry-remote-write only if RHOBS monitoring is not enabled
-		uwmArgs := []string{
+		// add --enable-defaulting-webhook when in self managed mode
+		selfManagedArgs := []string{
 			"--enable-uwm-telemetry-remote-write",
+			"--enable-defaulting-webhook",
 		}
-		if contains(flagsToRemove, "--enable-uwm-telemetry-remote-write") {
-			c.log.Info("installFlagsToRemove contains --enable-uwm-telemetry-remote-write, removing it from the install flag list")
-		} else {
-			args = append(args, uwmArgs...)
+		for _, flag := range selfManagedArgs {
+			if contains(flagsToRemove, flag) {
+				// skip this arg if in the flagsToRemove list.
+				c.log.Info(fmt.Sprintf("installFlagsToRemove contains %s, removing it from the install flag list", flag))
+			} else {
+				args = append(args, flag)
+			}
 		}
 	}
 

--- a/pkg/install/hypershift_test.go
+++ b/pkg/install/hypershift_test.go
@@ -876,6 +876,7 @@ func TestRunHypershiftInstallPrivateLinkExternalDNS(t *testing.T) {
 				"--hypershift-image", "my-test-image",
 				"--platform-monitoring", "OperatorOnly",
 				"--enable-uwm-telemetry-remote-write",
+				"--enable-defaulting-webhook",
 			}
 			assert.Equal(t, expectArgs, installJob.Spec.Template.Spec.Containers[0].Args, "mismatched container arguments")
 		}
@@ -1134,6 +1135,7 @@ func TestRunHypershiftInstallExternalDNSDifferentSecret(t *testing.T) {
 				"--hypershift-image", "my-test-image",
 				"--platform-monitoring", "OperatorOnly",
 				"--enable-uwm-telemetry-remote-write",
+				"--enable-defaulting-webhook",
 			}
 			assert.Equal(t, expectArgs, installJob.Spec.Template.Spec.Containers[0].Args, "mismatched container arguments")
 		}

--- a/pkg/install/upgrade_test.go
+++ b/pkg/install/upgrade_test.go
@@ -569,6 +569,7 @@ func TestInstallFlagChanges(t *testing.T) {
 				"--namespace", "hypershift",
 				"--hypershift-image", "my-test-image",
 				"--platform-monitoring", "AWS",
+				"--enable-defaulting-webhook",
 				"--exclude-etcd",
 				"--metrics-set", "SRE",
 			}


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):

This PR enables the optional defaulting webhook for the hypershift operator. This webhook is used by self managed Hypershift in order to dynamically set the release image to the latest supported release image for the current hypershift operator. The webhook will likely continue to be enhanced to support any sort of dynamic defaulting that we can't express accurately on the CRD using CEL..

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Some defaulting, such as defaulting the release image, can not be expressed accurately on the CRD's API using CEL. For this defaulting, we have created a webhook to inject the defaults at HostedCluster/NodePool creation time.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/HOSTEDCP-1041 
* https://github.com/openshift/hypershift/pull/2892

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
