### PR TITLE
detect ACM operator in any namespace

### DIFF
--- a/pkg/agent/auto_import_controller_test.go
+++ b/pkg/agent/auto_import_controller_test.go
@@ -144,7 +144,7 @@ func TestACMAutoImport(t *testing.T) {
 
 	// create acm operator
 	acmOperator := operatorv1.Operator{
-		ObjectMeta: metav1.ObjectMeta{Name: acmOperatorName}}
+		ObjectMeta: metav1.ObjectMeta{Name: acmOperatorNamePrefix + "ocm"}}
 	err = AICtrl.hubClient.Create(ctx, &acmOperator)
 	assert.Nil(t, err, "err nil when acm operator is created successfully")
 
@@ -219,7 +219,7 @@ func TestToggleAutoImport(t *testing.T) {
 
 	// create acm operator
 	acmOperator := operatorv1.Operator{
-		ObjectMeta: metav1.ObjectMeta{Name: acmOperatorName}}
+		ObjectMeta: metav1.ObjectMeta{Name: acmOperatorNamePrefix + ".ocm"}}
 	err = AICtrl.hubClient.Create(ctx, &acmOperator)
 	assert.Nil(t, err, "err nil when acm operator is created successfully")
 


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Find ACM operator in any namespace

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  The auto-import controller currently looks for ACM operator named `advanced-cluster-management.open-cluster-management` assuming that it is installed in `open-cluster-management` namespace to determine whether to enable ACM addons. Users can install the ACM operator in any namespace which changes the operator name to `advanced-cluster-management.xyz`. 

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-6917

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?   	github.com/stolostron/hypershift-addon-operator/cmd	[no test files]
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	30.846s	coverage: 72.0% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	176.357s	coverage: 86.1% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	121.259s	coverage: 61.7% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	0.532s	coverage: 100.0% of statements
?   	github.com/stolostron/hypershift-addon-operator/pkg/util	[no test files]

```
