### PR TITLE
set created-via annotation to hypershift

### DIFF
--- a/pkg/agent/auto_import_controller.go
+++ b/pkg/agent/auto_import_controller.go
@@ -31,6 +31,7 @@ const (
 	klueterletDeployMode      = "import.open-cluster-management.io/klusterlet-deploy-mode"
 	createdViaAnno            = "open-cluster-management/created-via"
 	clusterSetLabel           = "cluster.open-cluster-management.io/clusterset"
+	createdViaHypershift      = "hypershift"
 )
 
 type AutoImportController struct {
@@ -184,7 +185,7 @@ func populateManagedClusterData(mc *clusterv1.ManagedCluster) {
 	annotations := map[string]string{
 		klueterletDeployMode:   "Hosted",
 		hostingClusterNameAnno: "local-cluster",
-		createdViaAnno:         "other",
+		createdViaAnno:         createdViaHypershift,
 	}
 	for key, value := range annotations {
 		if v, ok := mc.Annotations[key]; !ok || len(v) == 0 {

--- a/pkg/agent/auto_import_controller_test.go
+++ b/pkg/agent/auto_import_controller_test.go
@@ -91,6 +91,10 @@ func TestNoACMAutoImport(t *testing.T) {
 	err = AICtrl.hubClient.Get(ctx, types.NamespacedName{Name: hcNN.Name}, gotMC)
 	assert.Nil(t, err, "err nil if managed cluster is found")
 
+	// Check that the created-by annotation is set to hypershift
+	annotations := gotMC.GetAnnotations()
+	assert.Equal(t, createdViaHypershift, annotations[createdViaAnno])
+
 	//check klusterletaddonconfing doesnt exist
 	gotKAC := &agentv1.KlusterletAddonConfig{}
 	err = AICtrl.hubClient.Get(ctx, types.NamespacedName{Name: hcNN.Name, Namespace: hcNN.Name}, gotKAC)
@@ -165,6 +169,10 @@ func TestACMAutoImport(t *testing.T) {
 	gotMC := &clusterv1.ManagedCluster{}
 	err = AICtrl.hubClient.Get(ctx, types.NamespacedName{Name: hcNN.Name}, gotMC)
 	assert.Nil(t, err, "err nil if managed cluster is found")
+
+	// Check that the created-by annotation is set to hypershift
+	annotations := gotMC.GetAnnotations()
+	assert.Equal(t, createdViaHypershift, annotations[createdViaAnno])
 
 	//check klusterletaddonconfing exists
 	gotKAC := &agentv1.KlusterletAddonConfig{}


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Set `open-cluster-management/created-via: hypershift` annotation when the hypershift agent auto-imports a hosted cluster.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  So we can collect telemetry data on the usage of MCE hypershift to provision OCP hosted clusters.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-6547

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?   	github.com/stolostron/hypershift-addon-operator/cmd	[no test files]
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	33.027s	coverage: 71.7% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	176.466s	coverage: 86.1% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	121.613s	coverage: 61.7% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	0.454s	coverage: 100.0% of statements
?   	github.com/stolostron/hypershift-addon-operator/pkg/util	[no test files]

```
