### PR TITLE
make productized hcp CLI binaries downloadable

### DIFF
--- a/docs/installing_hypershift_cli.md
+++ b/docs/installing_hypershift_cli.md
@@ -2,36 +2,36 @@
 
 ## About the Hypershift Hosted Control Plane CLI
 
-The Hypershift Hosted Control Plane command-line interface (CLI) is an `oc` command-line [plugin](https://docs.openshift.com/container-platform/4.11/cli_reference/openshift_cli/extending-cli-plugins.html), that allows you to create OpenShift hosted control plane clusters and manage them.
+The Hypershift Hosted Control Plane command-line interface (hcp CLI) allows you to create and manage OpenShift hosted clusters.
 
-## Installing the Hypershift Hosted Control Plane CLI
+## Installing the hcp CLI
 
 1. [Enable the Hypershift hosted control plane feature](https://github.com/stolostron/hypershift-addon-operator/blob/main/docs/provision_hosted_cluster_on_mce_local_cluster.md#configuring-the-hosting-service-cluster)
 
-2. On the OCP console, click on the ? button at the top right hand corner and choose `Command line tools` menu to download the HyperShift CLI binary.
+2. On the OCP console, click on the ? button at the top right hand corner and choose `Command line tools` menu to download the hcp CLI binary.
 
 3. Unpack the archive.
 
 ```
-    $ tar xvzf hypershift.tar.gz
+    $ tar xvzf hcp.tar.gz
 ```
 
-4. Copy the `hypershift` CLI binary file to a directory in your PATH.
+4. Copy the `hcp` CLI binary file to a directory in your PATH.
 
 ```
-    $ chmod +x hypershift
-    $ sudo mv hypershift /usr/local/bin/.
+    $ chmod +x hcp
+    $ sudo mv hcp /usr/local/bin/.
 ```
 
-After you install the Hypershift Hosted Control Plane CLI, you can start using the `hypershift create cluster` command to create and manage hosted clusters. For more information on the CLI usage, see [this](https://hypershift-docs.netlify.app/getting-started/#create-a-hostedcluster/)
+After you install the hcp CLI, you can start using the `hcp create cluster` command to create and manage hosted clusters. For more information on the CLI usage, see [this](https://hypershift-docs.netlify.app/getting-started/#create-a-hostedcluster/)
 
 
 ```
-hypershift create cluster aws --name $CLUSTER_NAME --namespace $NAMESPACE --node-pool-replicas=3 --secret-creds $SECRET_CREDS --region $REGION
+hcp create cluster aws --name $CLUSTER_NAME --namespace $NAMESPACE --node-pool-replicas=3 --secret-creds $SECRET_CREDS --region $REGION
 ```
 
 For all available parameters and their descriptions, run
 
 ```
-hypershift create cluster aws --help
+hcp create cluster aws --help
 ```

--- a/pkg/manager/cli_download_install.go
+++ b/pkg/manager/cli_download_install.go
@@ -311,45 +311,38 @@ func getConsoleDownload(routeUrl string, log logr.Logger) (*consolev1.ConsoleCLI
 
 	links := []consolev1.CLIDownloadLink{}
 
-	links = append(links, consolev1.CLIDownloadLink{
-		Href: "https://" + routeUrl + "/linux/amd64/hcp.tar.gz",
-		Text: "Download hcp CLI for Linux for x86_64",
-	})
-
-	links = append(links, consolev1.CLIDownloadLink{
-		Href: "https://" + routeUrl + "/darwin/amd64/hcp.tar.gz",
-		Text: "Download hcp CLI for Mac for x86_64",
-	})
-
-	links = append(links, consolev1.CLIDownloadLink{
-		Href: "https://" + routeUrl + "/windows/amd64/hcp.tar.gz",
-		Text: "Download hcp CLI for Windows for x86_64",
-	})
-
-	links = append(links, consolev1.CLIDownloadLink{
-		Href: "https://" + routeUrl + "/linux/arm64/hcp.tar.gz",
-		Text: "Download hcp CLI for Linux for ARM 64",
-	})
-
-	links = append(links, consolev1.CLIDownloadLink{
-		Href: "https://" + routeUrl + "/darwin/arm64/hcp.tar.gz",
-		Text: "Download hcp CLI for Mac for ARM 64",
-	})
-
-	links = append(links, consolev1.CLIDownloadLink{
-		Href: "https://" + routeUrl + "/linux/ppc64/hcp.tar.gz",
-		Text: "Download hcp CLI for Linux for IBM Power",
-	})
-
-	links = append(links, consolev1.CLIDownloadLink{
-		Href: "https://" + routeUrl + "/linux/ppc64le/hcp.tar.gz",
-		Text: "Download hcp CLI for Linux for IBM Power, little endian",
-	})
-
-	links = append(links, consolev1.CLIDownloadLink{
-		Href: "https://" + routeUrl + "/linux/s390x/hcp.tar.gz",
-		Text: "Download hcp CLI for Linux for IBM Z",
-	})
+	links = append(links,
+		consolev1.CLIDownloadLink{
+			Href: "https://" + routeUrl + "/linux/amd64/hcp.tar.gz",
+			Text: "Download hcp CLI for Linux for x86_64"},
+		consolev1.CLIDownloadLink{
+			Href: "https://" + routeUrl + "/darwin/amd64/hcp.tar.gz",
+			Text: "Download hcp CLI for Mac for x86_64",
+		},
+		consolev1.CLIDownloadLink{
+			Href: "https://" + routeUrl + "/windows/amd64/hcp.tar.gz",
+			Text: "Download hcp CLI for Windows for x86_64",
+		},
+		consolev1.CLIDownloadLink{
+			Href: "https://" + routeUrl + "/linux/arm64/hcp.tar.gz",
+			Text: "Download hcp CLI for Linux for ARM 64",
+		},
+		consolev1.CLIDownloadLink{
+			Href: "https://" + routeUrl + "/darwin/arm64/hcp.tar.gz",
+			Text: "Download hcp CLI for Mac for ARM 64",
+		},
+		consolev1.CLIDownloadLink{
+			Href: "https://" + routeUrl + "/linux/ppc64/hcp.tar.gz",
+			Text: "Download hcp CLI for Linux for IBM Power",
+		},
+		consolev1.CLIDownloadLink{
+			Href: "https://" + routeUrl + "/linux/ppc64le/hcp.tar.gz",
+			Text: "Download hcp CLI for Linux for IBM Power, little endian",
+		},
+		consolev1.CLIDownloadLink{
+			Href: "https://" + routeUrl + "/linux/s390x/hcp.tar.gz",
+			Text: "Download hcp CLI for Linux for IBM Z",
+		})
 
 	cliDownload.Spec.Links = links
 

--- a/pkg/manager/cli_download_install_test.go
+++ b/pkg/manager/cli_download_install_test.go
@@ -119,7 +119,7 @@ func TestEnableHypershiftCLIDownload(t *testing.T) {
 
 	// Check hypershift CLI deployment
 	cliDeployment := &appsv1.Deployment{}
-	cliDeploymentNN := types.NamespacedName{Namespace: "multicluster-engine", Name: "hypershift-cli-download"}
+	cliDeploymentNN := types.NamespacedName{Namespace: "multicluster-engine", Name: "hcp-cli-download"}
 	err = o.Client.Get(context.TODO(), cliDeploymentNN, cliDeployment)
 	assert.Nil(t, err, "err nil when hypershift CLI download deployment exists")
 	assert.Equal(t, "hypershift-addon-manager", cliDeployment.OwnerReferences[0].Name)
@@ -132,21 +132,21 @@ func TestEnableHypershiftCLIDownload(t *testing.T) {
 
 	// Check hypershift CLI service
 	cliService := &corev1.Service{}
-	cliServiceNN := types.NamespacedName{Namespace: "multicluster-engine", Name: "hypershift-cli-download"}
+	cliServiceNN := types.NamespacedName{Namespace: "multicluster-engine", Name: "hcp-cli-download"}
 	err = o.Client.Get(context.TODO(), cliServiceNN, cliService)
 	assert.Nil(t, err, "err nil when hypershift CLI download service exists")
 	assert.Equal(t, "hypershift-addon-manager", cliService.OwnerReferences[0].Name)
 
 	// Check hypershift CLI route
 	cliRoute := &routev1.Route{}
-	cliRouteNN := types.NamespacedName{Namespace: "multicluster-engine", Name: "hypershift-cli-download"}
+	cliRouteNN := types.NamespacedName{Namespace: "multicluster-engine", Name: "hcp-cli-download"}
 	err = o.Client.Get(context.TODO(), cliRouteNN, cliRoute)
 	assert.Nil(t, err, "err nil when hypershift CLI download route exists")
 	assert.Equal(t, "hypershift-addon-manager", cliRoute.OwnerReferences[0].Name)
 
 	// Check hypershift CLI ConsoleCLIDownload
 	cliDownload := &consolev1.ConsoleCLIDownload{}
-	cliDownloadNN := types.NamespacedName{Name: "hypershift-cli-download"}
+	cliDownloadNN := types.NamespacedName{Name: "hcp-cli-download"}
 	err = o.Client.Get(context.TODO(), cliDownloadNN, cliDownload)
 	assert.Nil(t, err, "err nil when hypershift CLI download ConsoleCLIDownload exists")
 	assert.Equal(t, "open-cluster-management:hypershift-preview:hypershift-addon-manager", cliDownload.OwnerReferences[0].Name)
@@ -238,7 +238,7 @@ func TestEnableHypershiftCLIDownloadNoConsole(t *testing.T) {
 
 	// Check hypershift CLI deployment
 	cliDeployment := &appsv1.Deployment{}
-	cliDeploymentNN := types.NamespacedName{Namespace: "multicluster-engine", Name: "hypershift-cli-download"}
+	cliDeploymentNN := types.NamespacedName{Namespace: "multicluster-engine", Name: "hcp-cli-download"}
 	err = o.Client.Get(context.TODO(), cliDeploymentNN, cliDeployment)
 	assert.Nil(t, err, "err nil when hypershift CLI download deployment exists")
 	assert.Equal(t, "hypershift-addon-manager", cliDeployment.OwnerReferences[0].Name)
@@ -251,23 +251,23 @@ func TestEnableHypershiftCLIDownloadNoConsole(t *testing.T) {
 
 	// Check hypershift CLI service
 	cliService := &corev1.Service{}
-	cliServiceNN := types.NamespacedName{Namespace: "multicluster-engine", Name: "hypershift-cli-download"}
+	cliServiceNN := types.NamespacedName{Namespace: "multicluster-engine", Name: "hcp-cli-download"}
 	err = o.Client.Get(context.TODO(), cliServiceNN, cliService)
 	assert.Nil(t, err, "err nil when hypershift CLI download service exists")
 	assert.Equal(t, "hypershift-addon-manager", cliService.OwnerReferences[0].Name)
 
 	// Check hypershift CLI route
 	cliRoute := &routev1.Route{}
-	cliRouteNN := types.NamespacedName{Namespace: "multicluster-engine", Name: "hypershift-cli-download"}
+	cliRouteNN := types.NamespacedName{Namespace: "multicluster-engine", Name: "hcp-cli-download"}
 	err = o.Client.Get(context.TODO(), cliRouteNN, cliRoute)
 	assert.Nil(t, err, "err nil when hypershift CLI download route exists")
 	assert.Equal(t, "hypershift-addon-manager", cliRoute.OwnerReferences[0].Name)
 
 	// Check hypershift CLI ConsoleCLIDownload
 	cliDownload := &consolev1.ConsoleCLIDownload{}
-	cliDownloadNN := types.NamespacedName{Name: "hypershift-cli-download"}
+	cliDownloadNN := types.NamespacedName{Name: "hcp-cli-download"}
 	err = o.Client.Get(context.TODO(), cliDownloadNN, cliDownload)
-	assert.EqualError(t, err, "consoleclidownloads.console.openshift.io \"hypershift-cli-download\" not found")
+	assert.EqualError(t, err, "consoleclidownloads.console.openshift.io \"hcp-cli-download\" not found")
 }
 
 func TestRetryCSV(t *testing.T) {

--- a/pkg/manager/manifests/cli/consoledownload.yaml
+++ b/pkg/manager/manifests/cli/consoledownload.yaml
@@ -1,10 +1,10 @@
 apiVersion: console.openshift.io/v1
 kind: ConsoleCLIDownload
 metadata:
-  name: hypershift-cli-download
+  name: hcp-cli-download
 spec:
   description: |
-    With the Hosted Openshift Control Plane command line interface, you can create and manage hosted OpenShift control planes.
+    With the Hosted Control Plane command line interface, you can create and manage OpenShift hosted clusters.
 
 
-  displayName: hypershift - Hosted Openshift Control Plane (HyperShift) Command Line Interface (CLI)
+  displayName: hcp - Hosted Control Plane Command Line Interface (CLI)

--- a/pkg/manager/manifests/cli/deployment.yaml
+++ b/pkg/manager/manifests/cli/deployment.yaml
@@ -2,8 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: hypershift-cli-download
-  name: hypershift-cli-download
+    app: hcp-cli-download
+  name: hcp-cli-download
   namespace: multicluster-engine
 spec:
   progressDeadlineSeconds: 600
@@ -11,13 +11,13 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app: hypershift-cli-download
+      app: hcp-cli-download
   template:
     metadata:
       creationTimestamp: null
       labels:
-        app: hypershift-cli-download
-        ocm-antiaffinity-selector: hypershift-cli-download
+        app: hcp-cli-download
+        ocm-antiaffinity-selector: hcp-cli-download
     spec:
       affinity:
         nodeAffinity:
@@ -45,7 +45,7 @@ spec:
                 - key: ocm-antiaffinity-selector
                   operator: In
                   values:
-                  - hypershift-cli-download
+                  - hcp-cli-download
               topologyKey: topology.kubernetes.io/zone
             weight: 70
           - podAffinityTerm:
@@ -54,13 +54,13 @@ spec:
                 - key: ocm-antiaffinity-selector
                   operator: In
                   values:
-                  - hypershift-cli-download
+                  - hcp-cli-download
               topologyKey: kubernetes.io/hostname
             weight: 35
       containers:
       - image: docker.io/rokejung/hypershift-addon-operator:1130f
         imagePullPolicy: IfNotPresent
-        name: hypershift-cli-download
+        name: hcp-cli-download
         ports:
         - containerPort: 8080
           name: file-server

--- a/pkg/manager/manifests/cli/route.yaml
+++ b/pkg/manager/manifests/cli/route.yaml
@@ -1,7 +1,7 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: hypershift-cli-download
+  name: hcp-cli-download
   namespace: multicluster-engine
 spec:
   port:
@@ -11,6 +11,6 @@ spec:
     termination: edge
   to:
     kind: Service
-    name: hypershift-cli-download
+    name: hcp-cli-download
     weight: 100
   wildcardPolicy: None

--- a/pkg/manager/manifests/cli/service.yaml
+++ b/pkg/manager/manifests/cli/service.yaml
@@ -3,8 +3,8 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
-    app: hypershift-cli-download
-  name: hypershift-cli-download
+    app: hcp-cli-download
+  name: hcp-cli-download
   namespace: multicluster-engine
 spec:
   ports:
@@ -13,6 +13,6 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    app: hypershift-cli-download
+    app: hcp-cli-download
 status:
   loadBalancer: {}


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Switch to making productized `hcp cli` downloadable

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  We want MCE and ACM users to use the `hcp cli` instead of the internal-dev `hypershift cli`. 

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-6105

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?   	github.com/stolostron/hypershift-addon-operator/cmd	[no test files]
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	31.249s	coverage: 71.9% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	176.186s	coverage: 86.1% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	121.269s	coverage: 61.7% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	1.111s	coverage: 100.0% of statements
?   	github.com/stolostron/hypershift-addon-operator/pkg/util	[no test files]
```

<img width="773" alt="image" src="https://github.com/stolostron/hypershift-addon-operator/assets/41969005/edb53aa4-eab4-4dc1-8c1b-089cd13301aa">

