### PR TITLE
ACM-7330: fixing authorization error in kube proxy container

### DIFF
--- a/pkg/manager/manifests/templates/metrics-clusterrole.yaml
+++ b/pkg/manager/manifests/templates/metrics-clusterrole.yaml
@@ -1,0 +1,11 @@
+{{- if ne .disableMetrics "true" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .SpokeRolebindingName }}-metrics
+  namespace: {{ .AddonInstallNamespace }}
+rules:
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["subjectaccessreviews"]
+    verbs: ["*"]
+{{- end }}

--- a/pkg/manager/manifests/templates/metrics-clusterrolebinging.yaml
+++ b/pkg/manager/manifests/templates/metrics-clusterrolebinging.yaml
@@ -1,0 +1,15 @@
+{{- if ne .disableMetrics "true" }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .SpokeRolebindingName }}-metrics
+  namespace: {{ .AddonInstallNamespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .SpokeRolebindingName }}-metrics
+subjects:
+- kind: ServiceAccount
+  name: {{ .AgentServiceAccountName }}
+  namespace: {{ .AddonInstallNamespace }}
+{{- end }}


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Adds RBAC rule in the cluster role binding for the kube proxy container.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  To fix the following authorization error

```
E0905 19:26:47.931331       1 proxy.go:96] Authorization error (user=system:serviceaccount:openshift-monitoring:prometheus-k8s, verb=get, resource=, subresource=): subjectaccessreviews.authorization.k8s.io is forbidden: User "system:serviceaccount:open-cluster-management-agent-addon:hypershift-addon-agent-sa" cannot create resource "subjectaccessreviews" in API group "authorization.k8s.io" at the cluster scope
I0905 19:27:01.045017       1 round_trippers.go:443] POST [https://172.30.0.1:443/apis/authorization.k8s.io/v1/subjectaccessreviews](https://172.30.0.1/apis/authorization.k8s.io/v1/subjectaccessreviews) 403 Forbidden in 1 milliseconds
E0905 19:27:01.045132       1 webhook.go:199] Failed to make webhook authorizer request: subjectaccessreviews.authorization.k8s.io is forbidden: User "system:serviceaccount:open-cluster-management-agent-addon:hypershift-addon-agent-sa" cannot create resource "subjectaccessreviews" in API group "authorization.k8s.io" at the cluster scope
```

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-7330

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
