### PR TITLE
ACM-7280: remove old CLI download resources

### DIFF
--- a/pkg/manager/cli_download_install.go
+++ b/pkg/manager/cli_download_install.go
@@ -17,6 +17,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -241,6 +242,10 @@ func removeHypershiftCLIDownload(hubclient client.Client, installNamespace strin
 		if deleteErr != nil {
 			log.Error(err, "failed to delete hypershift-cli-download ConsoleCLIDownload")
 		}
+	} else {
+		if !apierrors.IsNotFound(err) {
+			log.Error(err, "failed to find hypershift-cli-download ConsoleCLIDownload")
+		}
 	}
 
 	// Remove the old route if exists
@@ -250,6 +255,10 @@ func removeHypershiftCLIDownload(hubclient client.Client, installNamespace strin
 		deleteErr := hubclient.Delete(context.TODO(), cliRoute)
 		if deleteErr != nil {
 			log.Error(err, "failed to delete hypershift-cli-download Route")
+		}
+	} else {
+		if !apierrors.IsNotFound(err) {
+			log.Error(err, "failed to find hypershift-cli-download Route")
 		}
 	}
 
@@ -261,6 +270,10 @@ func removeHypershiftCLIDownload(hubclient client.Client, installNamespace strin
 		if deleteErr != nil {
 			log.Error(err, "failed to delete hypershift-cli-download Service")
 		}
+	} else {
+		if !apierrors.IsNotFound(err) {
+			log.Error(err, "failed to find hypershift-cli-download Service")
+		}
 	}
 
 	// Remove the old deployment if exists
@@ -270,6 +283,10 @@ func removeHypershiftCLIDownload(hubclient client.Client, installNamespace strin
 		deleteErr := hubclient.Delete(context.TODO(), cliDeployment)
 		if deleteErr != nil {
 			log.Error(err, "failed to delete hypershift-cli-download Deployment")
+		}
+	} else {
+		if !apierrors.IsNotFound(err) {
+			log.Error(err, "failed to find hypershift-cli-download Deployment")
 		}
 	}
 }

--- a/pkg/manager/cli_download_install.go
+++ b/pkg/manager/cli_download_install.go
@@ -24,6 +24,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+const (
+	NewCLIDownloadResourceName = "hcp-cli-download"
+	OldCLIDownloadResourceName = "hypershift-cli-download"
+)
+
 func EnableHypershiftCLIDownload(hubclient client.Client, log logr.Logger) error {
 	// get the current version of MCE CSV from multicluster-engine namespace
 
@@ -55,7 +60,7 @@ func EnableHypershiftCLIDownload(hubclient client.Client, log logr.Logger) error
 		return nil
 	}
 
-	err = deployHypershiftCLIDownload(hubclient, cliDownloadImage, log)
+	err = deployHCPCLIDownload(hubclient, cliDownloadImage, log)
 	if err != nil {
 		log.Error(err, "failed to deploy HypershiftCLIDownload")
 		return err
@@ -119,7 +124,7 @@ func getHypershiftCLIDownloadImage(csv *operatorsv1alpha1.ClusterServiceVersion,
 	return ""
 }
 
-func deployHypershiftCLIDownload(hubclient client.Client, cliImage string, log logr.Logger) error {
+func deployHCPCLIDownload(hubclient client.Client, cliImage string, log logr.Logger) error {
 	// Set owner reference to the addon manager deployment so that when the feature is disabled, HypershiftCLIDownload
 	// is uninstalled
 	ownerRef, envVars, installNamespace, err := getOwnerRef(hubclient, log)
@@ -127,6 +132,9 @@ func deployHypershiftCLIDownload(hubclient client.Client, cliImage string, log l
 		log.Error(err, "failed to get owner reference for hcp-cli-download. abort.")
 		return err
 	}
+
+	// CLI download resources are renamed. Remove resources with old names
+	removeHypershiftCLIDownload(hubclient, installNamespace, log)
 
 	log.Info("deploying hcp CLI download in namespace " + installNamespace)
 
@@ -220,6 +228,50 @@ func deployHypershiftCLIDownload(hubclient client.Client, cliImage string, log l
 	}
 
 	return nil
+}
+
+func removeHypershiftCLIDownload(hubclient client.Client, installNamespace string, log logr.Logger) {
+	// Remove the old version of hypershift CLI resources
+
+	// Remove the old ConsoleCLIDownload if exists
+	cliDownload := &consolev1.ConsoleCLIDownload{}
+	err := hubclient.Get(context.TODO(), types.NamespacedName{Name: OldCLIDownloadResourceName}, cliDownload)
+	if err == nil {
+		deleteErr := hubclient.Delete(context.TODO(), cliDownload)
+		if deleteErr != nil {
+			log.Error(err, "failed to delete hypershift-cli-download ConsoleCLIDownload")
+		}
+	}
+
+	// Remove the old route if exists
+	cliRoute := &routev1.Route{}
+	err = hubclient.Get(context.TODO(), types.NamespacedName{Namespace: installNamespace, Name: OldCLIDownloadResourceName}, cliRoute)
+	if err == nil {
+		deleteErr := hubclient.Delete(context.TODO(), cliRoute)
+		if deleteErr != nil {
+			log.Error(err, "failed to delete hypershift-cli-download Route")
+		}
+	}
+
+	// Remove the old service if exists
+	cliService := &corev1.Service{}
+	err = hubclient.Get(context.TODO(), types.NamespacedName{Namespace: installNamespace, Name: OldCLIDownloadResourceName}, cliService)
+	if err == nil {
+		deleteErr := hubclient.Delete(context.TODO(), cliService)
+		if deleteErr != nil {
+			log.Error(err, "failed to delete hypershift-cli-download Service")
+		}
+	}
+
+	// Remove the old deployment if exists
+	cliDeployment := &appsv1.Deployment{}
+	err = hubclient.Get(context.TODO(), types.NamespacedName{Namespace: installNamespace, Name: OldCLIDownloadResourceName}, cliDeployment)
+	if err == nil {
+		deleteErr := hubclient.Delete(context.TODO(), cliDeployment)
+		if deleteErr != nil {
+			log.Error(err, "failed to delete hypershift-cli-download Deployment")
+		}
+	}
 }
 
 func getCLIDeployment(cliImage string, envVars []corev1.EnvVar, log logr.Logger, installNamespace string) (*appsv1.Deployment, error) {


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* When MCE with hypershift-preview feature enabled is upgraded, the old hypershift CLI download resources (deployment, service, route and ConsoleCLIDownload) with name `hypershift-cli-download` remain while the new resources with new name `hcp-cli-download` are created.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  The old resources are unnecessary and need to be removed on MCE upgrade.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-7280

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?   	github.com/stolostron/hypershift-addon-operator/cmd	[no test files]
?   	github.com/stolostron/hypershift-addon-operator/pkg/util	[no test files]
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	35.179s	coverage: 71.7% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	176.458s	coverage: 86.1% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	121.973s	coverage: 62.6% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	1.362s	coverage: 100.0% of statements
```
