### PR TITLE
ACM-7681: Move acm-hypershift-addon-agent-metrics ServiceMonitor to M…

### DIFF
--- a/pkg/manager/manifests/templates/metrics-servicemonitor.yaml
+++ b/pkg/manager/manifests/templates/metrics-servicemonitor.yaml
@@ -2,8 +2,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: acm-{{ .AddonName }}-metrics
-  namespace: openshift-monitoring
+  name: mce-{{ .AddonName }}-metrics
+  namespace: {{ .AddonInstallNamespace }}
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/pkg/manager/manifests/templates/namespace.yaml
+++ b/pkg/manager/manifests/templates/namespace.yaml
@@ -1,0 +1,10 @@
+{{- if ne .disableMetrics "true" }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .AddonInstallNamespace }}
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  annotations:
+    addon.open-cluster-management.io/deletion-orphan: ""
+{{- end }}


### PR DESCRIPTION

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Moving the hypershift addon agent service monitor from openshift-monitoring namespace to the addon agent install namespace and adding `openshift.io/cluster-monitoring: "true"` label to the addon agent install namespace to avoid using the openshift default monitoring namespace.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Housekeeping, segregation of cluster monitoring spaces by operators/components.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-7681

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
