### PR TITLE
[CNV-34094] Enable validating webhook for hypershift operator with self managed

### DIFF
--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -461,10 +461,11 @@ func (c *UpgradeController) buildOtherInstallFlags(installFlagsCM corev1.ConfigM
 		// Self Managed specific args. These are set when RHOBS_MONITORING is not in use
 		//
 		// add --enable-uwm-telemetry-remote-write only if RHOBS monitoring is not enabled
-		// add --enable-defaulting-webhook when in self managed mode
+		// add --enable-defaulting-webhook and --enable-validating-webhook when in self managed mode
 		selfManagedArgs := []string{
 			"--enable-uwm-telemetry-remote-write",
 			"--enable-defaulting-webhook",
+			"--enable-validating-webhook",
 		}
 		for _, flag := range selfManagedArgs {
 			if contains(flagsToRemove, flag) {

--- a/pkg/install/hypershift_test.go
+++ b/pkg/install/hypershift_test.go
@@ -877,6 +877,7 @@ func TestRunHypershiftInstallPrivateLinkExternalDNS(t *testing.T) {
 				"--platform-monitoring", "OperatorOnly",
 				"--enable-uwm-telemetry-remote-write",
 				"--enable-defaulting-webhook",
+				"--enable-validating-webhook",
 			}
 			assert.Equal(t, expectArgs, installJob.Spec.Template.Spec.Containers[0].Args, "mismatched container arguments")
 		}
@@ -1136,6 +1137,7 @@ func TestRunHypershiftInstallExternalDNSDifferentSecret(t *testing.T) {
 				"--platform-monitoring", "OperatorOnly",
 				"--enable-uwm-telemetry-remote-write",
 				"--enable-defaulting-webhook",
+				"--enable-validating-webhook",
 			}
 			assert.Equal(t, expectArgs, installJob.Spec.Template.Spec.Containers[0].Args, "mismatched container arguments")
 		}

--- a/pkg/install/upgrade_test.go
+++ b/pkg/install/upgrade_test.go
@@ -570,6 +570,7 @@ func TestInstallFlagChanges(t *testing.T) {
 				"--hypershift-image", "my-test-image",
 				"--platform-monitoring", "AWS",
 				"--enable-defaulting-webhook",
+				"--enable-validating-webhook",
 				"--exclude-etcd",
 				"--metrics-set", "SRE",
 			}


### PR DESCRIPTION

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Add the `--enable-validating-webhook` flag the installation of a self managed hypershift

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  This PR enables the optional validating webhook for the hypershift operator. This webhook is used by self managed Hypershift in order to validate the make sure the selected openshift-virtualization infrastructure cluster is with sufficient kubernetes and openshift virtualization versions.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* CNV-34094

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?   	github.com/stolostron/hypershift-addon-operator/cmd	[no test files]
?   	github.com/stolostron/hypershift-addon-operator/pkg/util	[no test files]
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	12.338s	coverage: 71.9% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	175.531s	coverage: 86.1% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	120.058s	coverage: 62.3% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	0.007s	coverage: 100.0% of statements
```
