### PR TITLE
ACM-8466: Set container SCC

### DIFF
--- a/pkg/install/install_job.go
+++ b/pkg/install/install_job.go
@@ -19,6 +19,9 @@ import (
 func (c *UpgradeController) runHyperShiftInstallJob(ctx context.Context, image, mountPath string, imageStreamCMData map[string]string, args []string) (*kbatch.Job, error) {
 	c.log.Info(fmt.Sprintf("HyperShift install args: %v", args))
 
+	privileged := false
+	readOnly := true
+
 	jobPodSpec := corev1.PodSpec{
 		Containers: []corev1.Container{
 			{
@@ -26,6 +29,10 @@ func (c *UpgradeController) runHyperShiftInstallJob(ctx context.Context, image, 
 				Image:   image,
 				Command: []string{"hypershift", "install"},
 				Args:    args,
+				SecurityContext: &corev1.SecurityContext{
+					Privileged:             &privileged,
+					ReadOnlyRootFilesystem: &readOnly,
+				},
 			},
 		},
 		RestartPolicy:      "Never",

--- a/pkg/manager/manifests/templates/deployment.yaml
+++ b/pkg/manager/manifests/templates/deployment.yaml
@@ -23,6 +23,13 @@ spec:
       - name: kube-rbac-proxy
         image: {{ .KubeRbacProxyImage }}
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
         args:
         - --upstream=http://127.0.0.1:8383/
         - --logtostderr=true
@@ -49,7 +56,7 @@ spec:
             drop:
             - ALL
           privileged: false
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
         args:
           - "./hypershift-addon"
           - "agent"


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
*  To ensure that the Pod runs with the 'readonlyrootfilesystem' and 'privileged' settings

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  In order to enhance the security and functionality of our application.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-8466

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
KUBEBUILDER_ASSETS="/Users/rokej/Library/Application Support/io.kubebuilder.envtest/k8s/1.22.1-darwin-amd64" go test github.com/stolostron/hypershift-addon-operator/cmd github.com/stolostron/hypershift-addon-operator/pkg/agent github.com/stolostron/hypershift-addon-operator/pkg/install github.com/stolostron/hypershift-addon-operator/pkg/manager github.com/stolostron/hypershift-addon-operator/pkg/metrics github.com/stolostron/hypershift-addon-operator/pkg/util -coverprofile cover.out
?   	github.com/stolostron/hypershift-addon-operator/cmd	[no test files]
?   	github.com/stolostron/hypershift-addon-operator/pkg/util	[no test files]
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	32.714s	coverage: 71.7% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	176.925s	coverage: 86.1% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	121.923s	coverage: 62.3% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	1.344s	coverage: 100.0% of statements
```
