### PR TITLE
ACM-9229: fix HO installation issue

### DIFF
--- a/pkg/manager/manifests/templates/clusterrole.yaml
+++ b/pkg/manager/manifests/templates/clusterrole.yaml
@@ -73,7 +73,7 @@ rules:
     resources: ["managedclusters/accept"]
     verbs: ["update"]
   - apiGroups: ["admissionregistration.k8s.io"]
-    resources: ["mutatingwebhookconfigurations"]
+    resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
     verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
   - apiGroups: ["route.openshift.io"]
     resources: ["routes"]


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Allow hypershift-addon-agent SA access to `validatingwebhookconfigurations.admissionregistration.k8s.io`.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  A recent hypershift operator 4.15 started to create a `validatingwebhookconfigurations.admissionregistration.k8s.io` resource as part of the HO installation and the install user hypershift-addon-agent SA does not have role permission to create that. This PR is to fix the hypershift operator installation error due to this lack of RBAC.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-9229

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
N/A
```
