### PR TITLE
ACM-9269: fix HCP capacity calculation during the agent startup

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -785,7 +785,11 @@ func (c *agentController) SetHCPSizingBaseline(ctx context.Context) {
 	cmKey := types.NamespacedName{Name: util.HCPSizingBaselineCM, Namespace: c.clusterName}
 	err := c.hubClient.Get(context.TODO(), cmKey, cm)
 	if err != nil {
-		c.log.Error(err, "failed to get configmap from the hub. Setting the HCP sizing baseline with default values.")
+		if apierrors.IsNotFound(err) {
+			c.log.Info("Baseline override configmap hcp-sizing-baseline not found. Setting the HCP sizing baseline with default values.")
+		} else {
+			c.log.Error(err, "failed to get configmap from the hub. Setting the HCP sizing baseline with default values.")
+		}
 	} else {
 		if cm.Data["cpuRequestPerHCP"] != "" {
 			cpuRequestPerHCP, err := strconv.ParseFloat(strings.TrimSpace(cm.Data["cpuRequestPerHCP"]), 64)

--- a/pkg/agent/hcp_capacity_calculation.go
+++ b/pkg/agent/hcp_capacity_calculation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/prometheus/common/model"
@@ -72,8 +73,12 @@ func (c *agentController) calculateCapacitiesToHostHCPs() error {
 	hcpList := &hyperv1beta1.HostedControlPlaneList{}
 	err := c.spokeUncachedClient.List(context.TODO(), hcpList, listopts)
 	if err != nil {
-		c.log.Error(err, "failed to list hosted control planes")
-		return err
+		if strings.HasPrefix(err.Error(), "no matches for kind") {
+			c.log.Info("No HostedControlPlane kind exists yet.")
+		} else {
+			c.log.Error(err, "failed to list hosted control planes")
+			return err
+		}
 	}
 
 	totalHCPQPS := c.hcpSizingBaseline.minimumQPSPerHCP


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* During the hypershift addon agent startup, the Hypershift operator has not been installed yet. Therefore, the HCP capacity calculation that tries to query the number of HostedControlPlane fails. The agent should be able to continue the calculation assuming there is zero HostedControlPlane in this case.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  We need this fix for the agent to be able to calculate how many HCPs the cluster can host during the agent startup time when the hypershift operator is absent in the cluster.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-9269

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
