### PR TITLE
ACM-9278: Graceful prometheus client init failure

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -179,11 +179,8 @@ func (o *AgentOptions) runControllerManager(ctx context.Context) error {
 		spokeClient: mgr.GetClient(), spokeClustersClient: spokeClusterClient,
 	}
 
-	aCtrl.prometheusClient, err = newPrometheusClient(ctx, spokeKubeClient)
-	if err != nil {
-		metrics.AddonAgentFailedToStartBool.Set(1)
-		return fmt.Errorf("failed to create prometheus client, err: %w", err)
-	}
+	aCtrl.prometheusClient, _ = newPrometheusClient(ctx, spokeKubeClient)
+	// Failing to initialize the prometheus client should not prevent the agent to start.
 
 	o.Log = o.Log.WithName("agent-reconciler")
 	aCtrl.plugInOption(o)


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* There could be situations where initializing the Prometheus API client can fail due to environment problems. The client is used to query and calculate the average KubeAPI QPS by all HCPs in the cluster and use it to calculate the cluster's capacity for hosting HCPs. Today, the agent fails to start if it fails to create this client.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  The prometheus client and the average KubeAPI QPS by all HCPs is not mandatory for the agent. Report the unavailability of the client in the log and let the agent continue to start.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-9278

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
