### PR TITLE
ACM-9345: disabling hosted cluster auto-import should work on remote …

### DIFF
--- a/pkg/agent/auto_import_controller.go
+++ b/pkg/agent/auto_import_controller.go
@@ -15,7 +15,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -111,26 +110,6 @@ func (c *AutoImportController) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	return ctrl.Result{}, nil
-}
-
-func isAutoImportDisabled() bool {
-	disableAutoImport := os.Getenv("DISABLE_AUTO_IMPORT")
-	if disableAutoImport == "" {
-		return false
-	}
-	os.Setenv("DISABLE_AUTO_IMPORT", "false")
-
-	return strings.EqualFold(disableAutoImport, "true")
-}
-
-// returns string value if flag is found in list, otherwise ""
-func containsFlag(flagToFind string, list []addonv1alpha1.CustomizedVariable) string {
-	for _, flag := range list {
-		if flag.Name == flagToFind {
-			return flag.Value
-		}
-	}
-	return ""
 }
 
 // check if hosted control plane is available

--- a/pkg/agent/auto_import_controller_test.go
+++ b/pkg/agent/auto_import_controller_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -220,11 +221,6 @@ func TestToggleAutoImport(t *testing.T) {
 	assert.Nil(t, err, "err nil when kube-apiserver service is created successfully")
 	defer AICtrl.hubClient.Delete(ctx, apiService)
 
-	// create addondeployment config
-	aodc := getAddonDeploymentConfig(false)
-	err = AICtrl.hubClient.Create(ctx, aodc)
-	assert.Nil(t, err, "err nil when addondeploymentconfig is created successfully")
-
 	// create acm operator
 	acmOperator := operatorv1.Operator{
 		ObjectMeta: metav1.ObjectMeta{Name: acmOperatorNamePrefix + ".ocm"}}
@@ -254,11 +250,7 @@ func TestToggleAutoImport(t *testing.T) {
 	assert.Nil(t, err, "err not nil if klusterletaddonconfig is found")
 
 	// disable auto import
-	AICtrl.hubClient.Delete(ctx, aodc)
-	assert.Nil(t, err, "err  nil if addondeploymentconfig is deleted")
-	aodc = getAddonDeploymentConfig(true)
-	err = AICtrl.hubClient.Create(ctx, aodc) // could just update but too lazy
-	assert.Nil(t, err, "err nil when addondeploymentconfig is updated successfully")
+	os.Setenv("DISABLE_AUTO_IMPORT", "true")
 
 	// create hosted cluster
 	hcDisableNN := types.NamespacedName{Name: "auto-import-disable", Namespace: "clusters"}
@@ -273,6 +265,8 @@ func TestToggleAutoImport(t *testing.T) {
 	err = AICtrl.hubClient.Get(ctx, types.NamespacedName{Name: hcDisableNN.Name}, gotMC)
 	assert.NotNil(t, err, "err not nil if managed cluster is not found")
 
+	// re-enable auto import
+	os.Setenv("DISABLE_AUTO_IMPORT", "false")
 }
 
 func TestHCPUnavailable(t *testing.T) {

--- a/pkg/manager/manifests/templates/deployment.yaml
+++ b/pkg/manager/manifests/templates/deployment.yaml
@@ -80,6 +80,10 @@ spec:
         - name: RHOBS_MONITORING
           value: "{{ .enableRHOBSMonitoring }}"
 {{- end }}
+{{- if eq .autoImportDisabled "true" }}
+        - name: DISABLE_AUTO_IMPORT
+          value: "{{ .autoImportDisabled }}"
+{{- end }}
 {{- if ne .disableMetrics "true" }}
         ports:
         - name: metrics


### PR DESCRIPTION
…hosting clusters

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* The hypershift addon agent auto-imports hosted clusters but there is a way to configure the hub cluster to disable this auto-import. This does not work if the agent is deployed to a remote spoke cluster because the agent checks the configuration from the AddOnDeploymentConfig resource locally which does not get propagated to spoke clusters.


<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  For disabling the auto-import configuration to work globally, the disable flag should be visible by the hypershift addon agents from spoke clusters as well. 

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-9345

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?   	github.com/stolostron/hypershift-addon-operator/cmd	[no test files]
?   	github.com/stolostron/hypershift-addon-operator/pkg/util	[no test files]
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	31.212s	coverage: 69.8% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	177.016s	coverage: 86.1% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	121.836s	coverage: 62.3% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	1.294s	coverage: 100.0% of statements
```
