### PR TITLE
ACM-9569: Do not auto-delete managed clusters that are not for hosted…

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1068,12 +1068,18 @@ func (c *agentController) deleteManagedCluster(ctx context.Context, hc *hyperv1b
 	}
 
 	if mc != nil {
-		if err := c.hubClient.Delete(ctx, mc); err != nil {
-			c.log.Info(fmt.Sprintf("failed to delete the managedCluster %v", managedClusterName))
-			return err
-		}
+		createdVia, _ := mc.GetAnnotations()["open-cluster-management/created-via"]
+		deployMode, _ := mc.GetAnnotations()["import.open-cluster-management.io/klusterlet-deploy-mode"]
+		if createdVia == "hive" || deployMode != "Hosted" {
+			c.log.Info(fmt.Sprintf("The managed cluster %v is not a hosted cluster. It will not be deleted.", managedClusterName))
+		} else {
+			if err := c.hubClient.Delete(ctx, mc); err != nil {
+				c.log.Info(fmt.Sprintf("failed to delete the managedCluster %v", managedClusterName))
+				return err
+			}
 
-		c.log.Info(fmt.Sprintf("deleted managedCluster %v", managedClusterName))
+			c.log.Info(fmt.Sprintf("deleted managedCluster %v", managedClusterName))
+		}
 	}
 
 	klusterletName := "klusterlet-" + managedClusterName


### PR DESCRIPTION
… clusters

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* The agent detects hosted cluster deletion and tries to auto-delete the associated ManagedCluster. The code change ensures that a managed cluster with the matching the name is deleted only if it is for a hosted cluster. 

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  A hive cluster or other manually imported clusters can have the same name as a hosted cluster and we do not want to delete ManagedCluster for those clusters by accident.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-9569

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
?   	github.com/stolostron/hypershift-addon-operator/cmd	[no test files]
?   	github.com/stolostron/hypershift-addon-operator/pkg/util	[no test files]
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	36.209s	coverage: 70.3% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	177.744s	coverage: 86.1% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	124.000s	coverage: 62.3% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	2.797s	coverage: 100.0% of statements
```
