### PR TITLE
HOSTEDCP-1429: Allow hypershift addon access to scheduling.hypershift.openshift.io

### DIFF
--- a/pkg/manager/manifests/templates/clusterrole.yaml
+++ b/pkg/manager/manifests/templates/clusterrole.yaml
@@ -78,3 +78,6 @@ rules:
   - apiGroups: ["route.openshift.io"]
     resources: ["routes"]
     verbs: ["get", "list"]
+  - apiGroups: [ "scheduling.hypershift.openshift.io" ]
+    resources: [ "*" ]
+    verbs: [ "*" ]


### PR DESCRIPTION
Allow hypershift addon access to scheduling.hypershift.openshift.io. This is related to work done in [HOSTEDCP-1429](https://issues.redhat.com//browse/HOSTEDCP-1429).