### PR TITLE
fix canary to use no-cgo hypershift CLI

### DIFF
--- a/test/canary/run_canary_test.sh
+++ b/test/canary/run_canary_test.sh
@@ -652,11 +652,17 @@ installHypershiftBinary() {
     exit 1
   fi
 
-  # Extract the hypershift CLI from the hypershift operator pod
-  ${OC_COMMAND} rsync ${HO_POD_NAME}:/usr/bin/hypershift /tmp
+  # Extract the hypershift CLI from the hypershift operator pod. hypershift-no-cgo is built with no CGO enabled.
+  ${OC_COMMAND} rsync ${HO_POD_NAME}:/usr/bin/hypershift-no-cgo /tmp
   if [ $? -ne 0 ]; then
       echo "$(date) failed to extract hypershift CLI from the hypershift operator pod"
       exit 1
+  fi
+
+  mv /tmp/hypershift-no-cgo /tmp/hypershift
+  if [ $? -ne 0 ]; then
+    echo "$(date) failed to mv /tmp/hypershift-no-cgo /tmp/hypershift"
+    exit 1
   fi
 
   chmod +x /tmp/hypershift


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* fix canary test to use no-cgo hypershift CLI

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://github.com/stolostron/backlog/issues/27571

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
