### PR TITLE
ACM-11604: Fixed RBAC verbs on managed cluster namespace

### DIFF
--- a/pkg/manager/manifests/permission/role.yaml
+++ b/pkg/manager/manifests/permission/role.yaml
@@ -18,4 +18,4 @@ rules:
     verbs: ["get", "list", "watch", "create", "delete", "update", patch]
   - apiGroups: [ "discovery.open-cluster-management.io" ]
     resources: [ "discoveredclusters" ]
-    verbs: [ "*" ]
+    verbs: [ "get", "list", "watch", "create", "update", "delete", "deletecollection", "patch" ]


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Updated the RBAC verbs on `DiscoveredClusters` resources for managed cluster namespaces to match the RBAC verbs that the hypershift addon manager allows.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-11604

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
