### PR TITLE
ACM-11332: Support non-default agent install namespace

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -39,6 +39,7 @@ import (
 	"open-cluster-management.io/addon-framework/pkg/addonmanager"
 	frameworkagent "open-cluster-management.io/addon-framework/pkg/agent"
 	"open-cluster-management.io/addon-framework/pkg/utils"
+	addonutil "open-cluster-management.io/addon-framework/pkg/utils"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	addonv1alpha1client "open-cluster-management.io/api/client/addon/clientset/versioned"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
@@ -177,11 +178,13 @@ func getAgentAddon(componentName string, o *override, controllerContext *control
 		WithGetValuesFuncs(
 			o.getValueForAgentTemplate,
 			addonfactory.GetValuesFromAddonAnnotation,
-			addonfactory.GetAddOnDeloymentConfigValues(
-				addonfactory.NewAddOnDeloymentConfigGetter(addonClient),
-				addonfactory.ToAddOnDeloymentConfigValues,
+			addonfactory.GetAddOnDeploymentConfigValues(
+				addonutil.NewAddOnDeploymentConfigGetter(addonClient),
+				addonfactory.ToAddOnDeploymentConfigValues,
 			)).
 		WithAgentRegistrationOption(registrationOption).
+		WithAgentInstallNamespace(addonutil.AgentInstallNamespaceFromDeploymentConfigFunc(
+			addonutil.NewAddOnDeploymentConfigGetter(addonClient))).
 		WithScheme(genericScheme).
 		BuildTemplateAgentAddon()
 }


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Make the hypershift addon agent install namespace to be configurable via a addonDeploymentConfig. 

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  This allows the hypershift addon to be enabled for the same managed cluster by multiple hub clusters (multiple hypershift addon agents in different namespaces in a managed cluster).

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-11332

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
