### PR TITLE
ACM-11298: hypershift addon agent dual hub mode

### DIFF
--- a/pkg/manager/manifests/templates/deployment.yaml
+++ b/pkg/manager/manifests/templates/deployment.yaml
@@ -88,6 +88,10 @@ spec:
         - name: DISABLE_AUTO_IMPORT
           value: "{{ .autoImportDisabled }}"
 {{- end }}
+{{- if eq .disableHOManagement "true" }}
+        - name: DISABLE_HO_MANAGEMENT
+          value: "{{ .disableHOManagement }}"
+{{- end }}
 {{- if eq .enableHCDiscovery "true" }}
         - name: ENABLE_HC_DISCOVERY
           value: "{{ .enableHCDiscovery }}"


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Configurable addon agent installation namespace is added

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  When a cluster is imported to multiple hubs, this avoids agent installation namespace collision.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-11298

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
