### PR TITLE
ACM-11298: local-cluster hypershift addon agent co-exists with managed agent

### DIFF
--- a/pkg/agent/agent_suite_test.go
+++ b/pkg/agent/agent_suite_test.go
@@ -107,6 +107,13 @@ func (suite *AgentTestSuite) SetupSuite() {
 	}
 
 	err = suite.testKubeClient.Create(context.TODO(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "spoke-1"},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = suite.testKubeClient.Create(context.TODO(), &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: "clusters"},
 	})
 	if err != nil {
@@ -262,8 +269,6 @@ func (suite *AgentTestSuite) TestReconcileRequeue() {
 }
 
 func (suite *AgentTestSuite) TestReconcile() {
-	fmt.Println("From TestAddOne")
-
 	hcName := "test-2"
 
 	suite.createHCResources(hcName, nil, &hyperv1beta1.ClusterConfiguration{})
@@ -493,6 +498,109 @@ func (suite *AgentTestSuite) TestReconcileWithAnnotation() {
 	err = suite.controller.hubClient.Get(ctx, kcSecretNN, secret)
 	suite.True(err != nil && errors.IsNotFound(err), "is true when the admin kubeconfig secret is deleted")
 	err = suite.controller.hubClient.Get(ctx, pwdSecretNN, secret)
+	suite.True(err != nil && errors.IsNotFound(err), "is nil when the kubeadmin password secret is deleted")
+}
+
+func (suite *AgentTestSuite) TestReconcileDiscovery() {
+	hcName := "test-5"
+
+	suite.controller.clusterName = "spoke-1"
+
+	suite.createHCResources(hcName, nil, &hyperv1beta1.ClusterConfiguration{})
+
+	hc := &hyperv1beta1.HostedCluster{}
+	err := suite.controller.hubClient.Get(context.TODO(), types.NamespacedName{Name: hcName, Namespace: "clusters"}, hc)
+	suite.Nil(err, "err nil when hosted cluster is found successfully")
+
+	newStatus := &hyperv1beta1.HostedClusterStatus{
+		Conditions: []metav1.Condition{{Type: string(hyperv1beta1.HostedClusterAvailable), Status: metav1.ConditionTrue, Reason: hyperv1beta1.AsExpectedReason, LastTransitionTime: metav1.NewTime(time.Now())}},
+		KubeConfig: &corev1.LocalObjectReference{Name: "kubeconfig"},
+		Version: &hyperv1beta1.ClusterVersionStatus{
+			History: []configv1.UpdateHistory{{State: configv1.CompletedUpdate, StartedTime: metav1.NewTime(time.Now())}},
+		},
+	}
+
+	hc.Status = *newStatus
+
+	err = suite.controller.hubClient.Status().Update(context.TODO(), hc, &client.SubResourceUpdateOptions{})
+	suite.Nil(err, "err nil when hosted cluster status is found successfully")
+
+	// Create klusterlet namespace
+	klusterletNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "klusterlet-spoke-1-" + hc.Name,
+		},
+	}
+	err = suite.controller.hubClient.Create(context.TODO(), klusterletNamespace)
+	suite.Nil(err, "err nil when klusterletNamespace was created successfully")
+
+	// Reconcile with annotation
+	_, err = suite.controller.Reconcile(context.TODO(), ctrl.Request{NamespacedName: types.NamespacedName{Name: hcName, Namespace: "clusters"}})
+	suite.Nil(err, "err nil when reconcile was successfully")
+
+	// Secret for kubconfig is created
+	secret := &corev1.Secret{}
+	kcSecretNN := types.NamespacedName{Name: fmt.Sprintf("%s-admin-kubeconfig", hc.Name), Namespace: suite.controller.clusterName}
+	err = suite.controller.hubClient.Get(context.TODO(), kcSecretNN, secret)
+	suite.Nil(err, "is nil when the admin kubeconfig secret is found")
+
+	// The hosted cluster does not have status.KubeadminPassword so the kubeadmin-password is not expected to be copied
+	pwdSecretNN := types.NamespacedName{Name: fmt.Sprintf("%s-kubeadmin-password", hc.Name), Namespace: suite.controller.clusterName}
+	err = suite.controller.hubClient.Get(context.TODO(), pwdSecretNN, secret)
+	suite.True(err != nil && errors.IsNotFound(err), "is true when the kubeadmin-password secret is not copied")
+
+	kcExtSecretNN := types.NamespacedName{Name: "external-managed-kubeconfig", Namespace: "klusterlet-spoke-1-" + hc.Name}
+	err = suite.controller.hubClient.Get(context.TODO(), kcExtSecretNN, secret)
+	suite.Nil(err, "is nil when external-managed-kubeconfig secret is found")
+
+	kubeconfig, err := clientcmd.Load(secret.Data["kubeconfig"])
+	suite.Nil(err, "is nil when kubeconfig data can be loaded")
+	suite.Equal(kubeconfig.Clusters["cluster"].Server, "https://kube-apiserver."+hc.Namespace+"-"+hc.Name+".svc.cluster.local:443")
+
+	suite.Equal(float64(0), testutil.ToFloat64(metrics.KubeconfigSecretCopyFailureCount))
+	suite.Equal(float64(1), testutil.ToFloat64(metrics.TotalHostedClusterGauge))
+	suite.Equal(float64(1), testutil.ToFloat64(metrics.HostedClusterAvailableGauge))
+
+	hc1 := &hyperv1beta1.HostedCluster{}
+	err = suite.controller.hubClient.Get(context.TODO(), types.NamespacedName{Namespace: hc.Namespace, Name: hc.Name}, hc1)
+	suite.Nil(err, "err nil when hosted cluster is found successfully")
+
+	// Add the kubeadmin password to the hosted cluster CR to test that the kubeadmin-password is copied
+	newStatus = &hyperv1beta1.HostedClusterStatus{
+		Conditions: []metav1.Condition{{Type: string(hyperv1beta1.HostedClusterAvailable), Status: metav1.ConditionTrue, Reason: hyperv1beta1.AsExpectedReason, LastTransitionTime: metav1.NewTime(time.Now())}},
+		KubeConfig: &corev1.LocalObjectReference{Name: "kubeconfig"},
+		Version: &hyperv1beta1.ClusterVersionStatus{
+			History: []configv1.UpdateHistory{{State: configv1.CompletedUpdate, StartedTime: metav1.NewTime(time.Now())}},
+		},
+		KubeadminPassword: &corev1.LocalObjectReference{Name: "kubeadmin-password"},
+	}
+	hc1.Status = *newStatus
+
+	err = suite.controller.hubClient.Status().Update(context.TODO(), hc1, &client.SubResourceUpdateOptions{})
+	suite.Nil(err, "err nil when hosted cluster was updated successfully")
+
+	_, err = suite.controller.Reconcile(context.TODO(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: hc.Namespace, Name: hc.Name}})
+	suite.Nil(err, "err nil when reconcile was successfully")
+
+	// The hosted cluster now has status.KubeadminPassword so the kubeadmin-password is expected to be copied
+	err = suite.controller.hubClient.Get(context.TODO(), pwdSecretNN, secret)
+	suite.Nil(err, "is nil when the kubeadmin-password secret is found")
+
+	// Delete hosted cluster and reconcile
+	suite.controller.hubClient.Delete(context.TODO(), hc)
+
+	suite.Eventually(func() bool {
+		hcToDelete := &hyperv1beta1.HostedCluster{}
+		err := suite.controller.hubClient.Get(context.TODO(), types.NamespacedName{Namespace: "clusters", Name: hcName}, hcToDelete)
+		return err != nil && errors.IsNotFound(err)
+	}, 5*time.Second, 500*time.Millisecond)
+
+	_, err = suite.controller.Reconcile(context.TODO(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: hc.Namespace, Name: hc.Name}})
+	suite.Nil(err, "err nil when reconcile was successfully")
+
+	err = suite.controller.hubClient.Get(context.TODO(), kcSecretNN, secret)
+	suite.True(err != nil && errors.IsNotFound(err), "is true when the admin kubeconfig secret is deleted")
+	err = suite.controller.hubClient.Get(context.TODO(), pwdSecretNN, secret)
 	suite.True(err != nil && errors.IsNotFound(err), "is nil when the kubeadmin password secret is deleted")
 }
 

--- a/pkg/agent/auto_import_controller.go
+++ b/pkg/agent/auto_import_controller.go
@@ -37,6 +37,7 @@ const (
 type AutoImportController struct {
 	hubClient   client.Client
 	spokeClient client.Client
+	clusterName string
 	log         logr.Logger
 }
 
@@ -68,6 +69,12 @@ func (c *AutoImportController) Reconcile(ctx context.Context, req ctrl.Request) 
 	// skip auto import if disabled
 	if strings.EqualFold(os.Getenv("DISABLE_AUTO_IMPORT"), "true") {
 		c.log.Info("auto import is disabled, skip auto importing")
+		return ctrl.Result{}, nil
+	}
+
+	// if this agent is not for self managed cluster aka local-cluster, skip auto-import
+	if !strings.EqualFold(c.clusterName, "local-cluster") { // we can use hardcoded local-cluster for now
+		c.log.Info("this is local-cluster agent, skip discovering")
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/agent/auto_import_controller_test.go
+++ b/pkg/agent/auto_import_controller_test.go
@@ -44,6 +44,7 @@ func TestNoACMAutoImport(t *testing.T) {
 	AICtrl := &AutoImportController{
 		spokeClient: client,
 		hubClient:   client,
+		clusterName: "local-cluster",
 		log:         zapr.NewLogger(zapLog),
 	}
 
@@ -113,6 +114,7 @@ func TestACMAutoImport(t *testing.T) {
 	AICtrl := &AutoImportController{
 		spokeClient: client,
 		hubClient:   client,
+		clusterName: "local-cluster",
 		log:         zapr.NewLogger(zapLog),
 	}
 
@@ -192,6 +194,7 @@ func TestToggleAutoImport(t *testing.T) {
 	AICtrl := &AutoImportController{
 		spokeClient: client,
 		hubClient:   client,
+		clusterName: "local-cluster",
 		log:         zapr.NewLogger(zapLog),
 	}
 
@@ -279,6 +282,7 @@ func TestHCPUnavailable(t *testing.T) {
 	AICtrl := &AutoImportController{
 		spokeClient: client,
 		hubClient:   client,
+		clusterName: "local-cluster",
 		log:         zapr.NewLogger(zapLog),
 	}
 

--- a/pkg/agent/discovery_agent.go
+++ b/pkg/agent/discovery_agent.go
@@ -166,7 +166,7 @@ func (c *DiscoveryAgent) getDiscoveredCluster(hc hyperv1beta1.HostedCluster) *di
 		},
 		Spec: discoveryv1.DiscoveredClusterSpec{
 			APIURL:                 getAPIServerURL(hc.Status),
-			DisplayName:            c.clusterName + "-" + hc.Name,
+			DisplayName:            getDiscoveredClusterName(c.clusterName, hc.Name),
 			Name:                   hc.Name,
 			IsManagedCluster:       false,
 			ImportAsManagedCluster: false,
@@ -174,6 +174,7 @@ func (c *DiscoveryAgent) getDiscoveredCluster(hc hyperv1beta1.HostedCluster) *di
 			OpenshiftVersion:       c.getOCPVersion(hc.Status),
 			CreationTimestamp:      &hc.CreationTimestamp,
 			CloudProvider:          strings.ToLower(string(hc.Spec.Platform.Type)),
+			Status:                 "Active",
 		},
 	}
 
@@ -257,4 +258,8 @@ func (c *DiscoveryAgent) getOCPVersion(status hyperv1beta1.HostedClusterStatus) 
 		}
 	}
 	return ""
+}
+
+func getDiscoveredClusterName(spokeClusterName, hcName string) string {
+	return spokeClusterName + "-" + hcName
 }

--- a/pkg/manager/manifests/templates/deployment.yaml
+++ b/pkg/manager/manifests/templates/deployment.yaml
@@ -88,6 +88,10 @@ spec:
         - name: DISABLE_AUTO_IMPORT
           value: "{{ .autoImportDisabled }}"
 {{- end }}
+{{- if eq .disableHOManagement "true" }}
+        - name: DISABLE_HO_MANAGEMENT
+          value: "{{ .disableHOManagement }}"
+{{- end }}
 {{- if eq .enableHCDiscovery "true" }}
         - name: ENABLE_HC_DISCOVERY
           value: "{{ .enableHCDiscovery }}"


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* This change is to support running two copies of hypershift addon agent in an MCE cluster. One agent is deployed for MCE local-cluster responsible for everything it normally does. The other agent is deployed by ACM mainly as a HCP discovery agent who is responsible to discover hosted clusters from MCE and manage corresponding DiscoveredCluster resources in ACM hub for auto-import. This discovery agent should not do any duplicate work such as generating metrics data and managing the hypershift operator.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  We need this PR so ACM can deploy the hypershift addon agent as a HCP discovery agent for MCE clusters.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-11298

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
