### PR TITLE
ACM-11298: Fixed external secret controller for discovery

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -273,7 +273,7 @@ func (o *AgentOptions) runControllerManager(ctx context.Context) error {
 	}
 
 	externalSecretController := &ExternalSecretController{
-		hubClient: hubClient, spokeClient: spokeKubeClient, log: o.Log.WithName("external-secret-controller"),
+		hubClient: hubClient, spokeClient: spokeKubeClient, clusterName: aCtrl.clusterName, log: o.Log.WithName("external-secret-controller"),
 	}
 
 	if err = externalSecretController.SetupWithManager(mgr); err != nil {

--- a/pkg/agent/external_secret_controller_test.go
+++ b/pkg/agent/external_secret_controller_test.go
@@ -36,6 +36,7 @@ func TestKlusterletReconcile(t *testing.T) {
 	ESCtrl := &ExternalSecretController{
 		spokeClient: client,
 		hubClient:   client,
+		clusterName: "local-cluster",
 		log:         zapr.NewLogger(zapLog),
 	}
 


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Fixed the external secret controller to handle a klusterlet for a discovered hosted cluster from ACM

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  In order to auto-import a MCE discovered hosted cluster into ACM

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-11298

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
