### PR TITLE
ACM-11977: Use HC cluster ID as DiscoverdCluster name

### DIFF
--- a/pkg/agent/auto_import_controller_test.go
+++ b/pkg/agent/auto_import_controller_test.go
@@ -438,7 +438,8 @@ func getHostedCluster(hcNN types.NamespacedName) *hyperv1beta1.HostedCluster {
 			Etcd: hyperv1beta1.EtcdSpec{
 				ManagementType: hyperv1beta1.Managed,
 			},
-			InfraID: hcNN.Name + "-abcdef",
+			InfraID:   hcNN.Name + "-abcdef",
+			ClusterID: clusterID,
 		},
 		Status: hyperv1beta1.HostedClusterStatus{
 			KubeConfig: &corev1.LocalObjectReference{Name: "kubeconfig"},

--- a/pkg/agent/discovery_agent.go
+++ b/pkg/agent/discovery_agent.go
@@ -157,7 +157,7 @@ func (c *DiscoveryAgent) getDiscoveredCluster(hc hyperv1beta1.HostedCluster) *di
 			APIVersion: "discovery.open-cluster-management.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      hc.Name,
+			Name:      hc.Spec.ClusterID,
 			Namespace: c.clusterName,
 			Labels: map[string]string{
 				util.HostedClusterNameLabel:      hc.Name,
@@ -167,7 +167,7 @@ func (c *DiscoveryAgent) getDiscoveredCluster(hc hyperv1beta1.HostedCluster) *di
 		Spec: discoveryv1.DiscoveredClusterSpec{
 			APIURL:                 getAPIServerURL(hc.Status),
 			DisplayName:            getDiscoveredClusterName(c.clusterName, hc.Name),
-			Name:                   hc.Name,
+			Name:                   hc.Spec.ClusterID,
 			IsManagedCluster:       false,
 			ImportAsManagedCluster: false,
 			Type:                   "MultiClusterEngineHCP",

--- a/pkg/agent/discovery_agent_test.go
+++ b/pkg/agent/discovery_agent_test.go
@@ -20,6 +20,7 @@ import (
 const managedMCEClusterName = "managed-mce"
 const hcNamespace = "clusters"
 const hcName = "hc-1"
+const clusterID = "89693e2e-1198-4710-a254-c8277db50779"
 
 var _ = Describe("Hosted cluster discovery agent", Ordered, func() {
 	ctx := context.Background()
@@ -86,7 +87,7 @@ var _ = Describe("Hosted cluster discovery agent", Ordered, func() {
 
 			Eventually(func() bool {
 				if err := k8sClient.Get(ctx,
-					types.NamespacedName{Namespace: managedMCEClusterName, Name: hcName},
+					types.NamespacedName{Namespace: managedMCEClusterName, Name: clusterID},
 					discoveredCluster); err != nil {
 					return false
 				}
@@ -120,7 +121,7 @@ var _ = Describe("Hosted cluster discovery agent", Ordered, func() {
 			discoveredCluster := &discoveryv1.DiscoveredCluster{}
 			Eventually(func() bool {
 				if err := k8sClient.Get(ctx,
-					types.NamespacedName{Namespace: managedMCEClusterName, Name: hcName},
+					types.NamespacedName{Namespace: managedMCEClusterName, Name: clusterID},
 					discoveredCluster); err != nil {
 					return false
 				}
@@ -133,7 +134,7 @@ var _ = Describe("Hosted cluster discovery agent", Ordered, func() {
 					return false
 				}
 
-				return discoveredCluster.Name == hcName
+				return discoveredCluster.Name == clusterID
 			}).Should(BeTrue())
 		})
 	})
@@ -152,7 +153,7 @@ var _ = Describe("Hosted cluster discovery agent", Ordered, func() {
 			discoveredCluster := &discoveryv1.DiscoveredCluster{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx,
-					types.NamespacedName{Namespace: managedMCEClusterName, Name: hcName},
+					types.NamespacedName{Namespace: managedMCEClusterName, Name: clusterID},
 					discoveredCluster)
 
 				return apierrors.IsNotFound(err)
@@ -186,7 +187,7 @@ var _ = Describe("Hosted cluster discovery agent", Ordered, func() {
 			discoveredCluster := &discoveryv1.DiscoveredCluster{}
 			Consistently(func() bool {
 				err := k8sClient.Get(ctx,
-					types.NamespacedName{Namespace: managedMCEClusterName, Name: hcName},
+					types.NamespacedName{Namespace: managedMCEClusterName, Name: clusterID},
 					discoveredCluster)
 
 				return apierrors.IsNotFound(err)


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Use hosted cluster's cluster ID as discovered cluster's `spec.name` and `metadata.name` 

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-11977

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
