### PR TITLE
ACM-11310: Set hcp cli deployment with the same tolerations 

### DIFF
--- a/docs/discovering_hostedclusters.md
+++ b/docs/discovering_hostedclusters.md
@@ -127,11 +127,36 @@ spec:
     type: Placements
 ```
 
+Do the same update for `cluster-proxy` addon.
+
+```
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  name: cluster-proxy
+spec:
+  addOnMeta:
+    displayName: cluster-proxy
+  installStrategy:
+    placements:
+    - name: global
+      namespace: open-cluster-management-global-set
+      rolloutStrategy:
+        type: All
+      configs:
+      - group: addon.open-cluster-management.io
+        name: addon-ns-config
+        namespace: multicluster-engine
+        resource: addondeploymentconfigs
+    type: Placements
+```
+
 Once you make these changes in ACM, you will notice that these addons for ACM's `local-cluster` and all other managed clusters are re-installed into the specified namespace.
 
 ```
 % oc get deployment -n open-cluster-management-agent-addon-discovery
 NAME                                 READY   UP-TO-DATE   AVAILABLE   AGE
+cluster-proxy-proxy-agent            1/1     1            1           24h
 klusterlet-addon-workmgr             1/1     1            1           24h
 managed-serviceaccount-addon-agent   1/1     1            1           24h
 ```

--- a/pkg/manager/manifests/cli/deployment.yaml
+++ b/pkg/manager/manifests/cli/deployment.yaml
@@ -89,10 +89,3 @@ spec:
       serviceAccount: hypershift-addon-manager-sa
       serviceAccountName: hypershift-addon-manager-sa
       terminationGracePeriodSeconds: 30
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/infra
-        operator: Exists
-      - effect: NoSchedule
-        key: dedicated
-        operator: Exists


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* MCE installation could be configured with additional tolerations to be installed on specific nodes. When the hypershift addon manager programatically installs the hcp CLI download deployment, the CLI deployment should inherit the tolerations from the adddon manager.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Without this change, MCE installation will be stuck.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-11310

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
