### PR TITLE
update clusterrole with podmonitors resource

### DIFF
--- a/pkg/manager/manifests/templates/clusterrole.yaml
+++ b/pkg/manager/manifests/templates/clusterrole.yaml
@@ -58,7 +58,7 @@ rules:
     resources: ["servicemonitors", "prometheusrules"]
     verbs: ["update", "patch", "create"]
   - apiGroups: ["monitoring.rhobs"]
-    resources: ["servicemonitors", "prometheusrules"]
+    resources: ["servicemonitors", "prometheusrules", "podmonitors"]
     verbs: ["get", "list", "watch", "create", "patch", "update", "delete"] 
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* a change in the SD environment, now requires update permission in the hypershift addon install job. This change adds the new permission to the role. 

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  without this change, the install starts, but then fails, retrying every 2m, leading to many failed jobs/pods.
* with this behavior, a HCP created will be able to upgrade the control plane, but the nodepools will fail to upgrade, most likely due to restarting the HO operator every 2m.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://redhat-internal.slack.com/archives/C04EUL1DRHC/p1718630065455979

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
