### PR TITLE
Sync labels to mc

### DIFF
--- a/pkg/agent/auto_import_controller_test.go
+++ b/pkg/agent/auto_import_controller_test.go
@@ -99,6 +99,11 @@ func TestNoACMAutoImport(t *testing.T) {
 	annotations := gotMC.GetAnnotations()
 	assert.Equal(t, createdViaHypershift, annotations[createdViaAnno])
 
+	// Check to make sure the addition of custom labels on the HC
+	// are synced to the MC
+	labels := gotMC.GetLabels()
+	assert.Equal(t, "CustomLabelValue", labels["CustomLabelKey"])
+
 	//check klusterletaddonconfing doesnt exist
 	gotKAC := &agentv1.KlusterletAddonConfig{}
 	err = AICtrl.hubClient.Get(ctx, types.NamespacedName{Name: hcNN.Name, Namespace: hcNN.Name}, gotKAC)
@@ -421,6 +426,9 @@ func getHostedCluster(hcNN types.NamespacedName) *hyperv1beta1.HostedCluster {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      hcNN.Name,
 			Namespace: hcNN.Namespace,
+			Labels: map[string]string{
+				"CustomLabelKey": "CustomLabelValue",
+			},
 		},
 		Spec: hyperv1beta1.HostedClusterSpec{
 			Platform: hyperv1beta1.PlatformSpec{


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):

This change allows users who are creating HostedClusters to place labels on the hosted cluster which are then synced to the ManagedCluster during the auto import stage. 

By syncing the labels from the HC to the MC, it allows people to influence what addons are installed into the HCP cluster when creating the HCP from the `hcp` cli tool. 

Related to https://github.com/openshift/hypershift/pull/4451


## Test API/Unit - Success
```script
$ make test
which: no clusteradm in (/home/dvossel/.krew/bin:/usr/lib64/qt-3.3/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/home/dvossel/.local/bin:/home/dvossel/bin:/bin:/home/dvossel/go/bin:/home/dvossel/go/bin)
go fmt ./...
go vet ./...
KUBEBUILDER_ASSETS="/home/dvossel/.local/share/kubebuilder-envtest/k8s/1.22.1-linux-amd64" go test github.com/stolostron/hypershift-addon-operator/cmd github.com/stolostron/hypershift-addon-operator/pkg/agent github.com/stolostron/hypershift-addon-operator/pkg/install github.com/stolostron/hypershift-addon-operator/pkg/manager github.com/stolostron/hypershift-addon-operator/pkg/metrics github.com/stolostron/hypershift-addon-operator/pkg/util -coverprofile cover.out
	github.com/stolostron/hypershift-addon-operator/cmd		coverage: 0.0% of statements
	github.com/stolostron/hypershift-addon-operator/pkg/util		coverage: 0.0% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	36.643s	coverage: 69.7% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	175.773s	coverage: 84.5% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	128.114s	coverage: 62.1% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	0.008s	coverage: 35.7% of statements

```
