### PR TITLE
ACM-13163: Remove hard-coded local-cluster

### DIFF
--- a/pkg/agent/agent_helper.go
+++ b/pkg/agent/agent_helper.go
@@ -1,0 +1,51 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	localClusterLabelName  = "local-cluster"
+	localClusterLabelValue = "true"
+)
+
+// gets the self-managed cluster with label local-cluster=true
+func getSelfManagedClusterName(ctx context.Context, spokeClient client.Client, log logr.Logger) string {
+	localClusterSelector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			localClusterLabelName: localClusterLabelValue,
+		},
+	})
+	if err != nil {
+		log.Error(err, err.Error())
+		return ""
+	}
+
+	listopts := &client.ListOptions{}
+	listopts.LabelSelector = localClusterSelector
+	localClusterList := &clusterv1.ManagedClusterList{}
+	err = spokeClient.List(ctx, localClusterList, listopts)
+	if err != nil {
+		log.Error(err, fmt.Sprintf("failed to list managed clusters with label: %s=%s", localClusterLabelName, localClusterLabelValue))
+		return ""
+	}
+
+	if len(localClusterList.Items) == 0 {
+		log.Error(err, "no local cluster found")
+		return ""
+	}
+
+	if len(localClusterList.Items) > 1 {
+		log.Info("There are more than one local clusters. Using the first one in the list.")
+	}
+
+	log.Info(fmt.Sprintf("local cluster name is %s", localClusterList.Items[0].Name))
+
+	return localClusterList.Items[0].Name
+}

--- a/pkg/agent/agent_helper_test.go
+++ b/pkg/agent/agent_helper_test.go
@@ -1,0 +1,75 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/zapr"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+)
+
+func Test_getSelfManagedClusterName(t *testing.T) {
+	ctx := context.Background()
+	client := initClient()
+	zapLog, _ := zap.NewDevelopment()
+	logger := zapr.NewLogger(zapLog)
+
+	localClusterName := getSelfManagedClusterName(ctx, client, logger)
+	assert.Equal(t, "", localClusterName)
+
+	managedCluster := &clusterv1.ManagedCluster{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mc1",
+		},
+		Spec: clusterv1.ManagedClusterSpec{
+			HubAcceptsClient:     false,
+			LeaseDurationSeconds: 0,
+		},
+	}
+	err := client.Create(ctx, managedCluster)
+	assert.Nil(t, err, "err nil when managedcluster is created successfully")
+
+	localClusterName = getSelfManagedClusterName(ctx, client, logger)
+	assert.Equal(t, "", localClusterName)
+
+	localCluster := &clusterv1.ManagedCluster{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "mc2",
+			Labels: map[string]string{"local-cluster": "true"},
+		},
+		Spec: clusterv1.ManagedClusterSpec{
+			HubAcceptsClient:     false,
+			LeaseDurationSeconds: 0,
+		},
+	}
+	err = client.Create(ctx, localCluster)
+	assert.Nil(t, err, "err nil when local cluster managedcluster is created successfully")
+
+	localClusterName = getSelfManagedClusterName(ctx, client, logger)
+	assert.Equal(t, "mc2", localClusterName)
+
+	// If there are more than one local clusters??
+	// Return the first local cluster
+	localCluster2 := &clusterv1.ManagedCluster{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "mc3",
+			Labels: map[string]string{"local-cluster": "true"},
+		},
+		Spec: clusterv1.ManagedClusterSpec{
+			HubAcceptsClient:     false,
+			LeaseDurationSeconds: 0,
+		},
+	}
+	err = client.Create(ctx, localCluster2)
+	assert.Nil(t, err, "err nil when local cluster managedcluster is created successfully")
+
+	localClusterName = getSelfManagedClusterName(ctx, client, logger)
+	assert.Equal(t, "mc2", localClusterName)
+
+}

--- a/pkg/agent/agent_suite_test.go
+++ b/pkg/agent/agent_suite_test.go
@@ -87,6 +87,7 @@ func (suite *AgentTestSuite) SetupSuite() {
 		hubClient:           suite.testKubeClient,
 		log:                 zapr.NewLogger(zapLog),
 		clusterName:         "local-cluster",
+		localClusterName:    "local-cluster",
 	}
 
 	errClient := initReconcileErrorClient()

--- a/pkg/agent/auto_import_controller_test.go
+++ b/pkg/agent/auto_import_controller_test.go
@@ -42,10 +42,11 @@ func TestNoACMAutoImport(t *testing.T) {
 	zapLog, _ := zap.NewDevelopment()
 
 	AICtrl := &AutoImportController{
-		spokeClient: client,
-		hubClient:   client,
-		clusterName: "local-cluster",
-		log:         zapr.NewLogger(zapLog),
+		spokeClient:      client,
+		hubClient:        client,
+		clusterName:      "local-cluster",
+		localClusterName: "local-cluster",
+		log:              zapr.NewLogger(zapLog),
 	}
 
 	apiService := &corev1.Service{
@@ -117,10 +118,11 @@ func TestACMAutoImport(t *testing.T) {
 	zapLog, _ := zap.NewDevelopment()
 
 	AICtrl := &AutoImportController{
-		spokeClient: client,
-		hubClient:   client,
-		clusterName: "local-cluster",
-		log:         zapr.NewLogger(zapLog),
+		spokeClient:      client,
+		hubClient:        client,
+		clusterName:      "local-cluster",
+		localClusterName: "local-cluster",
+		log:              zapr.NewLogger(zapLog),
 	}
 
 	apiService := &corev1.Service{
@@ -197,10 +199,11 @@ func TestToggleAutoImport(t *testing.T) {
 	zapLog, _ := zap.NewDevelopment()
 
 	AICtrl := &AutoImportController{
-		spokeClient: client,
-		hubClient:   client,
-		clusterName: "local-cluster",
-		log:         zapr.NewLogger(zapLog),
+		spokeClient:      client,
+		hubClient:        client,
+		clusterName:      "local-cluster",
+		localClusterName: "local-cluster",
+		log:              zapr.NewLogger(zapLog),
 	}
 
 	apiService := &corev1.Service{
@@ -285,10 +288,11 @@ func TestHCPUnavailable(t *testing.T) {
 	zapLog, _ := zap.NewDevelopment()
 
 	AICtrl := &AutoImportController{
-		spokeClient: client,
-		hubClient:   client,
-		clusterName: "local-cluster",
-		log:         zapr.NewLogger(zapLog),
+		spokeClient:      client,
+		hubClient:        client,
+		clusterName:      "local-cluster",
+		localClusterName: "local-cluster",
+		log:              zapr.NewLogger(zapLog),
 	}
 
 	apiService := &corev1.Service{

--- a/pkg/agent/discovery_agent.go
+++ b/pkg/agent/discovery_agent.go
@@ -24,10 +24,11 @@ import (
 )
 
 type DiscoveryAgent struct {
-	hubClient   client.Client
-	spokeClient client.Client
-	clusterName string
-	log         logr.Logger
+	hubClient        client.Client
+	spokeClient      client.Client
+	clusterName      string
+	localClusterName string
+	log              logr.Logger
 }
 
 // This predicate is used as an event filter
@@ -64,8 +65,8 @@ func (c *DiscoveryAgent) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 
 	// if this agent is for self managed cluster aka local-cluster, skip discovery
-	if strings.EqualFold(c.clusterName, "local-cluster") { // we can use hardcoded local-cluster for now
-		c.log.Info("this is local-cluster agent, skip discovering")
+	if strings.EqualFold(c.clusterName, c.localClusterName) {
+		c.log.Info("this is local cluster agent, skip discovering")
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/agent/external_secret_controller.go
+++ b/pkg/agent/external_secret_controller.go
@@ -22,10 +22,11 @@ const (
 )
 
 type ExternalSecretController struct {
-	hubClient   client.Client
-	spokeClient client.Client
-	clusterName string
-	log         logr.Logger
+	hubClient        client.Client
+	spokeClient      client.Client
+	clusterName      string
+	localClusterName string
+	log              logr.Logger
 }
 
 var ExternalSecretPredicateFunctions = predicate.Funcs{
@@ -92,7 +93,7 @@ func (c *ExternalSecretController) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	}
 
-	if hostedClusterObj.Name == "" && c.clusterName != "local-cluster" {
+	if hostedClusterObj.Name == "" && !strings.EqualFold(c.clusterName, c.localClusterName) {
 		// Loop over the list of HostedCluster objects and find the one with the specified name
 		for index, hc := range hostedClusters.Items {
 			if hc.Name == discoveredHostedClusterName {


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* The hypershift addon agent makes some decisions based on whether the agent is for the local cluster or not by checking the hard-coded cluster name `local-cluster`. This PR is to remove the hard-coded local cluster name `local-cluster` and use the `local-cluster=true` label in a ManagedCluster CR to determine the name of the local cluster.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-13163

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
