### PR TITLE
ACM-12995: Fix hcp cli upgrade

### DIFF
--- a/pkg/manager/cli_download_install.go
+++ b/pkg/manager/cli_download_install.go
@@ -290,6 +290,21 @@ func removeHypershiftCLIDownload(hubclient client.Client, installNamespace strin
 			log.Error(err, "failed to find hypershift-cli-download Deployment")
 		}
 	}
+
+	// Remove the current deployment if exists
+	// This ensures that the hcp cli gets upgraded
+	currentCliDeployment := &appsv1.Deployment{}
+	err = hubclient.Get(context.TODO(), types.NamespacedName{Namespace: installNamespace, Name: "hcp-cli-download"}, currentCliDeployment)
+	if err == nil {
+		deleteErr := hubclient.Delete(context.TODO(), currentCliDeployment)
+		if deleteErr != nil {
+			log.Error(err, "failed to delete hcp-cli-download Deployment")
+		}
+	} else {
+		if !apierrors.IsNotFound(err) {
+			log.Error(err, "failed to find hcp-cli-download Deployment")
+		}
+	}
 }
 
 func getCLIDeployment(cliImage string, envVars []corev1.EnvVar, log logr.Logger, installNamespace string, hubclient client.Client) (*appsv1.Deployment, error) {


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* The hypershift addon manager code was updated to delete and re-create, if already exists, the hcp-cli-download deployment when the manger starts up.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  In order to ensure that the hcp-cli-download gets upgraded when MCE is upgraded.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-12995

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
