### PR TITLE
ACM-14690: HCP CLI download fix

### DIFF
--- a/docs/advanced/provision_hypershift_clusters_by_manifestwork.md
+++ b/docs/advanced/provision_hypershift_clusters_by_manifestwork.md
@@ -2,7 +2,7 @@
 
 ## Pre-reqs
 
-1. Enable hypershift-preview feature in MCE. https://github.com/stolostron/hypershift-deployment-controller/blob/main/docs/provision_hypershift_clusters_by_mce.md#enable-the-hosted-control-planes-related-components-on-the-hub-cluster
+1. Enable hypershift feature in MCE. https://github.com/stolostron/hypershift-deployment-controller/blob/main/docs/provision_hypershift_clusters_by_mce.md#enable-the-hosted-control-planes-related-components-on-the-hub-cluster
 
 2. Enable hypershift addon to turn an ACM managed cluster into a hypershift management cluster. https://github.com/stolostron/hypershift-deployment-controller/blob/main/docs/provision_hypershift_clusters_by_mce.md#turn-one-of-the-managed-clusters-into-the-hypershift-management-cluster
 

--- a/pkg/manager/cli_download_install.go
+++ b/pkg/manager/cli_download_install.go
@@ -501,9 +501,9 @@ func getOwnerRef(hubclient client.Client, log logr.Logger) (*metav1.OwnerReferen
 
 func getClusterScopedOwnerRef(hubclient client.Client, log logr.Logger) (*metav1.OwnerReference, error) {
 	clusterRole := &rbacv1.ClusterRole{}
-	err := hubclient.Get(context.TODO(), types.NamespacedName{Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager"}, clusterRole)
+	err := hubclient.Get(context.TODO(), types.NamespacedName{Name: "open-cluster-management:hypershift:hypershift-addon-manager"}, clusterRole)
 	if err != nil {
-		log.Error(err, "failed to get open-cluster-management:hypershift-preview:hypershift-addon-manager clusterrole")
+		log.Error(err, "failed to get open-cluster-management:hypershift:hypershift-addon-manager clusterrole")
 		return nil, err
 	}
 

--- a/pkg/manager/cli_download_install_test.go
+++ b/pkg/manager/cli_download_install_test.go
@@ -272,7 +272,7 @@ func (suite *CLIDownloadTestSuite) TestEnableHypershiftCLIDownload() {
 	cliDownloadNN := types.NamespacedName{Name: NewCLIDownloadResourceName}
 	err = o.Client.Get(context.TODO(), cliDownloadNN, cliDownload)
 	suite.Nil(err, "err nil when hypershift CLI download ConsoleCLIDownload exists")
-	suite.Equal("open-cluster-management:hypershift-preview:hypershift-addon-manager", cliDownload.OwnerReferences[0].Name)
+	suite.Equal("open-cluster-management:hypershift:hypershift-addon-manager", cliDownload.OwnerReferences[0].Name)
 
 	// Check the old hypershift-cli-download resources are deleted
 	removedCliDeployment := &appsv1.Deployment{}
@@ -729,7 +729,7 @@ func getTestClusterRole() *rbacv1.ClusterRole {
 			APIVersion: "rbac.authorization.k8s.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "open-cluster-management:hypershift-preview:hypershift-addon-manager",
+			Name: "open-cluster-management:hypershift:hypershift-addon-manager",
 		},
 	}
 	return clusterRole

--- a/quickstart/start.sh
+++ b/quickstart/start.sh
@@ -83,7 +83,7 @@ if [ $? -ne 0 ]; then
 fi
 
 oc create secret generic hypershift-operator-oidc-provider-s3-credentials --from-file=credentials=${S3_CREDS} --from-literal=bucket=${BUCKET_NAME} --from-literal=region=${BUCKET_REGION} -n local-cluster
-oc patch multiclusterengine ${mce_name} --type=merge -p '{"spec":{"overrides":{"components":[{"name":"hypershift-preview","enabled": true}]}}}'
+oc patch multiclusterengine ${mce_name} --type=merge -p '{"spec":{"overrides":{"components":[{"name":"hypershift","enabled": true}]}}}'
 
 echo "Waiting for the local-cluster managed cluster to be available ..."
 oc wait --for=condition=ManagedClusterConditionAvailable managedcluster/local-cluster --timeout=600s

--- a/test/canary/run_canary_test.sh
+++ b/test/canary/run_canary_test.sh
@@ -559,9 +559,9 @@ enableHypershiftForLocalCluster() {
     fi
 
     # Enable the hypershift feature. This also installs the hypershift addon for local-cluster
-    ${KUBECTL_COMMAND} patch mce multiclusterengine --type=merge -p '{"spec":{"overrides":{"components":[{"name":"hypershift-preview","enabled": true}]}}}'
+    ${KUBECTL_COMMAND} patch mce multiclusterengine --type=merge -p '{"spec":{"overrides":{"components":[{"name":"hypershift","enabled": true}]}}}'
     if [ $? -ne 0 ]; then
-        echo "$(date) failed to enable hypershift-preview in MCE"
+        echo "$(date) failed to enable hypershift in MCE"
         exit 1
     fi
 


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Removing `-preview` from the hypershift addon chart in https://github.com/stolostron/backplane-operator/pull/990 removed `-preview` from some addon resource names. This broke the code that looks for these resources to enable the hcp cli download. 

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-14690

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
	github.com/stolostron/hypershift-addon-operator/cmd		coverage: 0.0% of statements
	github.com/stolostron/hypershift-addon-operator/pkg/util		coverage: 0.0% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	54.128s	coverage: 69.6% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	176.774s	coverage: 85.0% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	128.927s	coverage: 60.1% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	1.022s	coverage: 35.7% of statements
```
