### PR TITLE
ACM-15500: configuring name prefix of discovered hcps

### DIFF
--- a/docs/discovering_hostedclusters.md
+++ b/docs/discovering_hostedclusters.md
@@ -259,6 +259,15 @@ This hypershift addon deployed by ACM acts as a discovery agent that discovers h
 
 <img width="1483" alt="image" src="./images/discovery2.png">
 
+### Naming Convention 
+
+When a discovered hosted cluster is auto-imported into the ACM hub, it becomes ACM's managed cluster and the naming convention of the managed cluster is `mce-cluster-name`-`hosted-cluster-name`. If all the hosted clusters are named uniquely across the fleet, you can configure `discoveryPrefix` in the `hypershift-addon-deploy-config` `addondeploymentconfig` in the previous step so that no prefix is used to name the discovered cluster.
+
+```
+% oc patch addondeploymentconfig hypershift-addon-deploy-config -n multicluster-engine --type=merge -p '{"spec":{"customizedVariables":[{"name":"disableMetrics","value": "true"},{"name":"disableHOManagement","value": "true"},{"name":"discoveryPrefix","value": ""}]}}'
+```
+
+You can also set the `discoveryPrefix` to some other string to use it as a prefix replacing `mce-cluster-name`.
 
 
 ## Auto-importing the discovered hosted clusters

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.63.0
 	github.com/prometheus/client_golang v1.19.0
 	github.com/prometheus/common v0.48.0
+	github.com/rung/go-safecast v1.0.1
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace
 	github.com/stolostron/backplane-operator v0.0.0-20240209003542-4def396a0ac1

--- a/go.sum
+++ b/go.sum
@@ -510,6 +510,8 @@ github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/f
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
+github.com/rung/go-safecast v1.0.1 h1:7rkt2qO4JGdOkWKdPEBFLaEwQy20y0IhhWJNFxmH0p0=
+github.com/rung/go-safecast v1.0.1/go.mod h1:dzUcUS2UMtbfVc7w6mx/Ur3UYcpXEZC+WilISksJ4P8=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -485,7 +485,7 @@ func (c *agentController) generateExtManagedKubeconfigSecret(ctx context.Context
 	}
 
 	if !strings.EqualFold(os.Getenv("DISABLE_HC_DISCOVERY"), "true") && !strings.EqualFold(c.clusterName, c.localClusterName) {
-		managedClusterName = getDiscoveredClusterName(c.clusterName, hc.Name)
+		managedClusterName = getDiscoveredClusterName(c.clusterName, hc.Name, c.log)
 		c.log.Info(fmt.Sprintf("Hosted cluster discovery is enabled. Using klusterlet-%s as the hosted cluster's klusterlet namespace.", managedClusterName))
 	}
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -42,6 +42,7 @@ import (
 	operatorv1 "github.com/operator-framework/api/pkg/operators/v1"
 	prometheusapi "github.com/prometheus/client_golang/api"
 	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	safecast "github.com/rung/go-safecast"
 	discoveryv1 "github.com/stolostron/discovery/api/v1"
 	"github.com/stolostron/hypershift-addon-operator/pkg/install"
 	"github.com/stolostron/hypershift-addon-operator/pkg/metrics"
@@ -1001,10 +1002,16 @@ func (c *agentController) SyncAddOnPlacementScore(ctx context.Context, startup b
 		}
 	} else {
 		hcCount := len(hcList.Items)
+		hcCountValue, err := safecast.Int32(hcCount)
+		if err != nil {
+			c.log.Error(err, "failed to convert HC count to int32")
+			metrics.PlacementScoreFailureCount.Inc()
+			return err
+		}
 		scores := []clusterv1alpha1.AddOnPlacementScoreItem{
 			{
 				Name:  util.HostedClusterScoresScoreName,
-				Value: int32(hcCount),
+				Value: hcCountValue,
 			},
 		}
 

--- a/pkg/agent/discovery_agent.go
+++ b/pkg/agent/discovery_agent.go
@@ -167,7 +167,7 @@ func (c *DiscoveryAgent) getDiscoveredCluster(hc hyperv1beta1.HostedCluster) *di
 		},
 		Spec: discoveryv1.DiscoveredClusterSpec{
 			APIURL:                 getAPIServerURL(hc.Status),
-			DisplayName:            getDiscoveredClusterName(c.clusterName, hc.Name),
+			DisplayName:            getDiscoveredClusterName(c.clusterName, hc.Name, c.log),
 			Name:                   hc.Spec.ClusterID,
 			IsManagedCluster:       false,
 			ImportAsManagedCluster: false,
@@ -261,6 +261,20 @@ func (c *DiscoveryAgent) getOCPVersion(status hyperv1beta1.HostedClusterStatus) 
 	return ""
 }
 
-func getDiscoveredClusterName(spokeClusterName, hcName string) string {
+func getDiscoveredClusterName(spokeClusterName, hcName string, log logr.Logger) string {
+	prefix, set := os.LookupEnv("DISCOVERY_PREFIX")
+
+	if set {
+		if len(prefix) > 0 {
+			log.Info(fmt.Sprintf("The prefix of discovered hosted clusters is set to %s", prefix))
+			log.Info(fmt.Sprintf("Setting the discovered hosted cluster name to %s", prefix+"-"+hcName))
+			return prefix + "-" + hcName
+		}
+
+		log.Info("No prefix option was configured for discovered hosted clusters")
+		log.Info(fmt.Sprintf("Setting the discovered hosted cluster name to %s", hcName))
+		return hcName
+	}
+
 	return spokeClusterName + "-" + hcName
 }

--- a/pkg/manager/manifests/templates/deployment.yaml
+++ b/pkg/manager/manifests/templates/deployment.yaml
@@ -98,7 +98,7 @@ spec:
         - name: ENABLE_HC_DISCOVERY
           value: "{{ .enableHCDiscovery }}"
 {{- end }}
-{{- if .discoveryPrefix }}
+{{- if or (eq .discoveryPrefix "") (.discoveryPrefix)}}
         - name: DISCOVERY_PREFIX
           value: "{{ .discoveryPrefix }}"
 {{- end }}

--- a/pkg/manager/manifests/templates/deployment.yaml
+++ b/pkg/manager/manifests/templates/deployment.yaml
@@ -98,6 +98,10 @@ spec:
         - name: ENABLE_HC_DISCOVERY
           value: "{{ .enableHCDiscovery }}"
 {{- end }}
+{{- if .discoveryPrefix }}
+        - name: DISCOVERY_PREFIX
+          value: "{{ .discoveryPrefix }}"
+{{- end }}
 {{- if ne .disableMetrics "true" }}
         ports:
         - name: metrics


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* This PR allows users to configure the prefix for discovered hosted cluster names.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Discovered hosted clusters are auto-imported with [hosting-cluster-name]-[hosted-cluster-name] naming convention but some users do not want the `[hosting-cluster-name]-` prefix because hosted clusters across the fleet have unique names, etc. 

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-15500

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
	github.com/stolostron/hypershift-addon-operator/cmd		coverage: 0.0% of statements
	github.com/stolostron/hypershift-addon-operator/pkg/util		coverage: 0.0% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	54.440s	coverage: 69.1% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	176.213s	coverage: 85.0% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	128.920s	coverage: 60.1% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	1.291s	coverage: 35.7% of statements

```
