### PR TITLE
ACM-15978: Add creation timestamp metrics

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -556,6 +556,17 @@ func (c *agentController) generateExtManagedKubeconfigSecret(ctx context.Context
 
 	c.log.Info("createOrUpdate external-managed-kubeconfig secret", "secret", client.ObjectKeyFromObject(secret))
 
+	// Get the CreationTimestamp
+	extKubeconfigSecret := &corev1.Secret{}
+	secretNamespaceNsn := types.NamespacedName{Namespace: "klusterlet-" + managedClusterName, Name: "external-managed-kubeconfig"}
+	if err := c.spokeClient.Get(ctx, secretNamespaceNsn, extKubeconfigSecret); err != nil {
+		c.log.Error(err, fmt.Sprintf("failed to find the external-managed-kubeconfig secret in the klusterlet namespace: %s ", klusterletNamespaceNsn.Name))
+		return err
+	}
+	if !extKubeconfigSecret.CreationTimestamp.IsZero() {
+		metrics.ExtManagedKubeconfigCreatedTSGaugeVec.WithLabelValues(hc.Namespace, hc.Name, hc.Spec.InfraID).Set(float64(extKubeconfigSecret.CreationTimestamp.Unix()))
+	}
+
 	return nil
 }
 
@@ -653,7 +664,7 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	}
 
 	if hc.Status.Conditions == nil || len(hc.Status.Conditions) == 0 ||
-		!isHostedControlPlaneAvailable(hc.Status) {
+		!isHostedControlPlaneAvailable(*hc) {
 		// Wait for secrets to exist
 		c.log.Info(fmt.Sprintf("hostedcluster %s's control plane is not ready yet.", hc.Name))
 		return ctrl.Result{}, nil
@@ -790,9 +801,13 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	return ctrl.Result{}, nil
 }
 
-func isHostedControlPlaneAvailable(status hyperv1beta1.HostedClusterStatus) bool {
+func isHostedControlPlaneAvailable(hc hyperv1beta1.HostedCluster) bool {
+	status := hc.Status
 	for _, condition := range status.Conditions {
 		if condition.Reason == hyperv1beta1.AsExpectedReason && condition.Status == metav1.ConditionTrue && condition.Type == string(hyperv1beta1.HostedClusterAvailable) {
+			if !condition.LastTransitionTime.IsZero() {
+				metrics.HCPAPIServerAvailableTSGaugeVec.WithLabelValues(hc.Namespace, hc.Name, hc.Spec.InfraID).Set(float64(condition.LastTransitionTime.Unix()))
+			}
 			return true
 		}
 	}
@@ -1016,7 +1031,7 @@ func (c *agentController) SyncAddOnPlacementScore(ctx context.Context, startup b
 		deletingHcNum := 0
 
 		for _, hc := range hcList.Items {
-			if hc.Status.Conditions == nil || len(hc.Status.Conditions) == 0 || isHostedControlPlaneAvailable(hc.Status) {
+			if hc.Status.Conditions == nil || len(hc.Status.Conditions) == 0 || isHostedControlPlaneAvailable(hc) {
 				availableHcpNum++
 			}
 

--- a/pkg/agent/auto_import_controller.go
+++ b/pkg/agent/auto_import_controller.go
@@ -87,7 +87,7 @@ func (c *AutoImportController) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	// check if controlplane is available, if not then requeue until it is
-	if hc.Status.Conditions == nil || len(hc.Status.Conditions) == 0 || !isHostedControlPlaneAvailable(hc.Status) {
+	if hc.Status.Conditions == nil || len(hc.Status.Conditions) == 0 || !isHostedControlPlaneAvailable(*hc) {
 		// wait for cluster to become available, check again in a minute
 		c.log.Info(fmt.Sprintf("hosted control plane of (%s) is unavailable, retrying in 1 minute", req.NamespacedName))
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Duration(1) * time.Minute}, nil

--- a/pkg/agent/discovery_agent.go
+++ b/pkg/agent/discovery_agent.go
@@ -94,7 +94,7 @@ func (c *DiscoveryAgent) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		}
 	} else {
 		// check if controlplane is available, if not then requeue until it is
-		if hc.Status.Conditions == nil || len(hc.Status.Conditions) == 0 || !isHostedControlPlaneAvailable(hc.Status) {
+		if hc.Status.Conditions == nil || len(hc.Status.Conditions) == 0 || !isHostedControlPlaneAvailable(*hc) {
 			// wait for HCP API server to become available
 			c.log.Info(fmt.Sprintf("hosted control plane of (%s) is unavailable", req.NamespacedName))
 			return ctrl.Result{}, nil

--- a/pkg/metrics/hosted-clusters-metrics.go
+++ b/pkg/metrics/hosted-clusters-metrics.go
@@ -40,6 +40,21 @@ var HostedControlPlaneStatusGaugeVec = prometheus.NewGaugeVec(
 	[]string{"hcp_namespace", "hcp_name", "ready", "version"},
 )
 
+var HCPAPIServerAvailableTSGaugeVec = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "mce_hcp_api_server_avail_ts_gauge",
+		Help: "Hosted control plane API server ready timestamp",
+	},
+	[]string{"hc_namespace", "hcp_name", "infra_id"},
+)
+var ExtManagedKubeconfigCreatedTSGaugeVec = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "mce_hcp_ext_managed_kubeconfig_ts_gauge",
+		Help: "external-managed-kubeconfig creation timestamp",
+	},
+	[]string{"hc_namespace", "hcp_name", "infra_id"},
+)
+
 func init() {
 	CollectorsForRegistration = append(CollectorsForRegistration,
 		TotalHostedClusterGauge,
@@ -48,5 +63,7 @@ func init() {
 		HostedClusterBeingDeletedGauge,
 		MaxNumHostedClustersGauge,
 		ThresholdNumHostedClustersGauge,
-		HostedControlPlaneStatusGaugeVec)
+		HostedControlPlaneStatusGaugeVec,
+		HCPAPIServerAvailableTSGaugeVec,
+		ExtManagedKubeconfigCreatedTSGaugeVec)
 }


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Using the following metrics, you can find out when the external-managed-kubeconfig secret was created by the hypershift addon agent.

_mce_hcp_ext_managed_kubeconfig_ts_gauge{hcp_name="virt-4", infra_id="virt-4"}_

* Using the following metrics, you can find out when the hosted cluster API server became ready by the metrics timestamp value but also you can find when the hypershift addon agent detected this condition by looking at the metrics value transition time.

_mce_hcp_api_server_avail_ts_gauge{hcp_name="virt-4", infra_id="virt-4"}_

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  These metrics can be used to determine when these conditions were detected by the hypershift addon agent.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-15978

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
