### PR TITLE
ACM-15992: add hcp timestamp metrics

### DIFF
--- a/pkg/metrics/hosted-clusters-metrics.go
+++ b/pkg/metrics/hosted-clusters-metrics.go
@@ -32,6 +32,21 @@ var ThresholdNumHostedClustersGauge = prometheus.NewGauge(prometheus.GaugeOpts{
 	Help: "Threshold number of hosted clusters",
 })
 
+var HCPAPIServerAvailableTSGaugeVec = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "mce_hcp_api_server_avail_ts_gauge",
+		Help: "Hosted control plane API server ready timestamp",
+	},
+	[]string{"hc_namespace", "hcp_name", "infra_id"},
+)
+var ExtManagedKubeconfigCreatedTSGaugeVec = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "mce_hcp_ext_managed_kubeconfig_ts_gauge",
+		Help: "external-managed-kubeconfig creation timestamp",
+	},
+	[]string{"hc_namespace", "hcp_name", "infra_id"},
+)
+
 func init() {
 	CollectorsForRegistration = append(CollectorsForRegistration,
 		TotalHostedClusterGauge,
@@ -39,5 +54,7 @@ func init() {
 		HostedClusterAvailableGauge,
 		HostedClusterBeingDeletedGauge,
 		MaxNumHostedClustersGauge,
-		ThresholdNumHostedClustersGauge)
+		ThresholdNumHostedClustersGauge,
+		HCPAPIServerAvailableTSGaugeVec,
+		ExtManagedKubeconfigCreatedTSGaugeVec)
 }


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Using the following metrics, you can find out when the external-managed-kubeconfig secret was created by the hypershift addon agent.

_mce_hcp_ext_managed_kubeconfig_ts_gauge{hcp_name="virt-4", infra_id="virt-4"}_

* Using the following metrics, you can find out when the hosted cluster API server became ready by the metrics timestamp value but also you can find when the hypershift addon agent detected this condition by looking at the metrics value transition time.

_mce_hcp_api_server_avail_ts_gauge{hcp_name="virt-4", infra_id="virt-4"}_

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  These metrics can be used to determine when these conditions were detected by the hypershift addon agent.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-15992
* 
<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
