### PR TITLE
ACM-16840: added missing ManagedCluster auto-detect labels (#384)

### DIFF
--- a/docs/advanced/running_mce_acm_addons_hostedmode.md
+++ b/docs/advanced/running_mce_acm_addons_hostedmode.md
@@ -62,7 +62,7 @@ metadata:
     cloud: auto-detect
     cluster.open-cluster-management.io/clusterset: default
     name: my-hosted-cluster-12345
-    vendor: OpenShift
+    vendor: auto-detect
 spec:
   hubAcceptsClient: true
   leaseDurationSeconds: 60

--- a/docs/discovering_hostedclusters.md
+++ b/docs/discovering_hostedclusters.md
@@ -203,6 +203,9 @@ kind: ManagedCluster
 metadata:
   annotations:
     agent.open-cluster-management.io/klusterlet-config: mce-import-klusterlet-config
+  labels:
+    cloud: auto-detect
+    vendor: auto-detect
   name: mce-a
 spec:
   hubAcceptsClient: true

--- a/docs/provision_hosted_cluster_on_mce_local_cluster.md
+++ b/docs/provision_hosted_cluster_on_mce_local_cluster.md
@@ -318,7 +318,7 @@ You can also import the hosted cluster into MCE using custom resources in comman
         cloud: auto-detect    
         cluster.open-cluster-management.io/clusterset: default    
         name: $CLUSTER_NAME   
-        vendor: OpenShift  
+        vendor: auto-detect  
       name: $CLUSTER_NAME
     spec:  
       hubAcceptsClient: true  

--- a/pkg/agent/auto_import_controller.go
+++ b/pkg/agent/auto_import_controller.go
@@ -32,6 +32,7 @@ const (
 	createdViaAnno            = "open-cluster-management/created-via"
 	clusterSetLabel           = "cluster.open-cluster-management.io/clusterset"
 	createdViaHypershift      = "hypershift"
+	autoDetect                = "auto-detect"
 )
 
 type AutoImportController struct {
@@ -145,8 +146,8 @@ func populateManagedClusterData(mc *clusterv1.ManagedCluster, hc *hyperv1beta1.H
 	}
 	labels := map[string]string{
 		"name":          mc.Name,
-		"vendor":        "OpenShift",   // This is always true
-		"cloud":         "auto-detect", // Work addon will use this to detect cloud provider, like: GCP,AWS
+		"vendor":        autoDetect,
+		"cloud":         autoDetect, // Work addon will use this to detect cloud provider, like: GCP,AWS
 		clusterSetLabel: "default",
 	}
 
@@ -207,8 +208,8 @@ func (c *AutoImportController) createKlusterletAddonConfig(hcName string, ctx co
 	if kac.Spec.ClusterLabels == nil {
 		kac.Spec.ClusterLabels = make(map[string]string)
 	}
-	kac.Spec.ClusterLabels["cloud"] = "Amazon"
-	kac.Spec.ClusterLabels["vendor"] = "Openshift"
+	kac.Spec.ClusterLabels["cloud"] = autoDetect
+	kac.Spec.ClusterLabels["vendor"] = autoDetect
 
 	kac.Spec.ApplicationManagerConfig.Enabled = true
 	kac.Spec.SearchCollectorConfig.Enabled = true


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Added missing ManagedCluster vendor and cloud auto-detect labels

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Some custom or ACM logics might depend on auto-detected vendor and cloud.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-16840

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```

