### PR TITLE
ACM-17106: fix the management of mirrored admin secrets (#389)

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -602,7 +602,7 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	}
 
 	// Delete HC secrets on the hub using labels for HC and the hosting NS
-	deleteMirrorSecrets := func() error {
+	deleteMirrorSecrets := func(secretName string) error {
 		secretSelector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
 			MatchLabels: map[string]string{
 				util.HypershiftClusterNameLabel:      req.Name,
@@ -628,9 +628,12 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		for i := range hcHubSecretList.Items {
 			se := hcHubSecretList.Items[i]
 			c.log.V(4).Info(fmt.Sprintf("deleting secret(%s) on hub", client.ObjectKeyFromObject(&se)))
-			if err := c.hubClient.Delete(ctx, &se); err != nil && !apierrors.IsNotFound(err) {
-				lastErr = err
-				c.log.Error(err, fmt.Sprintf("failed to delete secret(%s) on hub", client.ObjectKeyFromObject(&se)))
+			// Delete both kubeconfig and password secrets or only the specified one
+			if secretName == "" || strings.HasSuffix(se.Name, secretName) {
+				if err := c.hubClient.Delete(ctx, &se); err != nil && !apierrors.IsNotFound(err) {
+					lastErr = err
+					c.log.Error(err, fmt.Sprintf("failed to delete secret(%s) on hub", client.ObjectKeyFromObject(&se)))
+				}
 			}
 		}
 
@@ -642,7 +645,7 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		if apierrors.IsNotFound(err) {
 			c.log.Info(fmt.Sprintf("remove hostedcluster(%s) secrets on hub, since hostedcluster is gone", req.NamespacedName))
 
-			return ctrl.Result{}, deleteMirrorSecrets()
+			return ctrl.Result{}, deleteMirrorSecrets("")
 		}
 
 		c.log.Error(err, "failed to get the hostedcluster")
@@ -697,6 +700,7 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 					// this secret will not be created if a custom identity provider
 					// is configured in configuration.oauth.identityProviders
 					c.log.Info("cannot find the kubeadmin password secret yet.")
+					_ = deleteMirrorSecrets("kubeadmin-password") // delete the mirrorred kubeadmin-password secrets it exists
 					continue
 				}
 			}


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* The agent copies the hosted cluster's kubeadmin password and kubeconfig secrets to the hub cluster. When OAuth is configured in the hosted cluster, the hypershift operator deletes the kubeadmin password secret from the hosted cluster but the mirrored kubeadmin password secret that the agent initially copied over to the hub remains in the hub. This change ensures that the secret gets deleted or re-created depending on the OAuth configuration in the hosted cluster.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-17572

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
