### PR TITLE
ACM-17667: update external-managed-kubeconfig correctly (#395)

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -506,10 +506,13 @@ func (c *agentController) generateExtManagedKubeconfigSecret(ctx context.Context
 
 	c.log.Info("Set the cluster server URL in external-managed-kubeconfig secret", "apiServerURL", apiServerURL)
 
-	nilFunc := func() error { return nil }
-
 	// 3. Create the admin kubeconfig secret as external-managed-kubeconfig in klusterlet-<infraID> namespace
-	_, err = controllerutil.CreateOrUpdate(ctx, c.spokeClient, secret, nilFunc)
+	_, err = controllerutil.CreateOrUpdate(ctx, c.spokeClient, secret, func() error {
+		secret.Data = map[string][]byte{
+			"kubeconfig": newKubeconfig,
+		}
+		return nil
+	})
 	if err != nil {
 		c.log.Error(err, "failed to createOrUpdate external-managed-kubeconfig secret", "secret", client.ObjectKeyFromObject(secret))
 		return err


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* The agent does not properly update the external-managed-kubeconfig secret data.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  When a hosted cluster's KAS cert is rotated, the kubeconfig data in the external-managed-kubeconfig secret becomes invalid. This causes the klusterlet agents to loose connection and become unhealthy.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-17828

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
