### PR TITLE
ACM-15162: optimize the agent reconciliation rate

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -35,8 +36,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	hyperv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	operatorv1 "github.com/operator-framework/api/pkg/operators/v1"
@@ -315,6 +318,15 @@ func (o *AgentOptions) runControllerManager(ctx context.Context) error {
 	if err = discoveryAgent.SetupWithManager(mgr); err != nil {
 		metrics.AddonAgentFailedToStartBool.Set(1)
 		return fmt.Errorf("unable to create discovery controller: %s, err: %w", util.DiscoveryAgentName, err)
+	}
+
+	HcpKubeconfigChangeWatcher := &HcpKubeconfigChangeWatcher{
+		hubClient: hubClient, spokeClient: spokeKubeClient, log: o.Log.WithName("hcp-kubeconfig-watcher"),
+	}
+
+	if err = HcpKubeconfigChangeWatcher.SetupWithManager(mgr); err != nil {
+		metrics.AddonAgentFailedToStartBool.Set(1)
+		return fmt.Errorf("unable to create hcp kubeconfig watcher: %s, err: %w", "HcpKubeconfigChangeWatcher", err)
 	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
@@ -1191,8 +1203,76 @@ func (c *agentController) deleteManagedCluster(ctx context.Context, hc *hyperv1b
 func (c *agentController) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&hyperv1beta1.HostedCluster{}).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 10}).
+		WithEventFilter(hostedClusterEventFilters()).
 		Complete(c)
+}
+
+func hostedClusterEventFilters() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			newHc, newOK := e.ObjectNew.(*hyperv1beta1.HostedCluster)
+			oldHc, oldOK := e.ObjectOld.(*hyperv1beta1.HostedCluster)
+
+			if !newOK || !oldOK {
+				return false
+			}
+
+			if newHc.DeletionTimestamp != nil {
+				return false
+			}
+
+			newKASCondition := metav1.Condition{}
+			oldKASCondition := metav1.Condition{}
+
+			for _, condition := range newHc.Status.Conditions {
+				if condition.Type == string(hyperv1beta1.HostedClusterAvailable) {
+					newKASCondition = condition
+					break
+				}
+			}
+
+			for _, condition := range oldHc.Status.Conditions {
+				if condition.Type == string(hyperv1beta1.HostedClusterAvailable) {
+					oldKASCondition = condition
+					break
+				}
+			}
+
+			if newKASCondition.Status == metav1.ConditionTrue && (newKASCondition.Status != oldKASCondition.Status) {
+				return true
+			}
+
+			if !reflect.DeepEqual(oldHc.GetAnnotations(), newHc.GetAnnotations()) {
+				return true
+			}
+
+			if !reflect.DeepEqual(oldHc.Status.KubeConfig, newHc.Status.KubeConfig) {
+				return true
+			}
+
+			if !reflect.DeepEqual(oldHc.Status.KubeadminPassword, newHc.Status.KubeadminPassword) {
+				return true
+			}
+
+			if oldHc.Status.Version != nil && newHc.Status.Version != nil {
+				if !reflect.DeepEqual(oldHc.Status.Version.History, newHc.Status.Version.History) {
+					return true
+				}
+			}
+
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return true
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
 }
 
 func NewCleanupCommand(addonName string, logger logr.Logger) *cobra.Command {

--- a/pkg/agent/auto_import_controller.go
+++ b/pkg/agent/auto_import_controller.go
@@ -19,8 +19,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 const (
@@ -43,27 +41,12 @@ type AutoImportController struct {
 	log              logr.Logger
 }
 
-var AutoImportPredicateFunctions = predicate.Funcs{
-	CreateFunc: func(e event.CreateEvent) bool {
-		return true
-	},
-	UpdateFunc: func(e event.UpdateEvent) bool {
-		return false
-	},
-	DeleteFunc: func(e event.DeleteEvent) bool {
-		return false
-	},
-	GenericFunc: func(e event.GenericEvent) bool {
-		return false
-	},
-}
-
 // SetupWithManager sets up the controller with the Manager.
 func (c *AutoImportController) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&hyperv1beta1.HostedCluster{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
-		WithEventFilter(AutoImportPredicateFunctions).
+		WithEventFilter(hostedClusterEventFilters()).
 		Complete(c)
 }
 
@@ -89,10 +72,10 @@ func (c *AutoImportController) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	// check if controlplane is available, if not then requeue until it is
 	if hc.Status.Conditions == nil || len(hc.Status.Conditions) == 0 || !isHostedControlPlaneAvailable(*hc) {
-		// wait for cluster to become available, check again in a minute
-		c.log.Info(fmt.Sprintf("hosted control plane of (%s) is unavailable, retrying in 1 minute", req.NamespacedName))
-		return ctrl.Result{Requeue: true, RequeueAfter: time.Duration(1) * time.Minute}, nil
+		c.log.Info(fmt.Sprintf("hostedcluster %s's control plane is not ready yet.", hc.Name))
+		return ctrl.Result{}, nil
 	}
+
 	// once available, create managed cluster
 	if err := c.createManagedCluster(*hc, ctx); err != nil {
 		c.log.Error(err, fmt.Sprintf("could not create managed cluster for hosted cluster (%s)", hc.Name))

--- a/pkg/agent/auto_import_controller_test.go
+++ b/pkg/agent/auto_import_controller_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/go-logr/zapr"
 	configv1 "github.com/openshift/api/config/v1"
@@ -332,8 +331,8 @@ func TestHCPUnavailable(t *testing.T) {
 
 	res, err := AICtrl.Reconcile(ctx, ctrl.Request{NamespacedName: hcNN})
 	assert.Nil(t, err, "no error when waiting for control plane")
-	checkRes := ctrl.Result{Requeue: true, RequeueAfter: time.Duration(1) * time.Minute}
-	assert.EqualValues(t, checkRes, res, "should requeue")
+	checkRes := ctrl.Result{}
+	assert.EqualValues(t, checkRes, res, "should not requeue")
 
 }
 

--- a/pkg/agent/discovery_agent.go
+++ b/pkg/agent/discovery_agent.go
@@ -19,8 +19,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 type DiscoveryAgent struct {
@@ -31,29 +29,12 @@ type DiscoveryAgent struct {
 	log              logr.Logger
 }
 
-// This predicate is used as an event filter
-var DiscoveryPredicateFunctions = predicate.Funcs{
-	CreateFunc: func(e event.CreateEvent) bool {
-		return true
-	},
-	UpdateFunc: func(e event.UpdateEvent) bool {
-		return true
-	},
-	DeleteFunc: func(e event.DeleteEvent) bool {
-		return true
-	},
-	//GenericEvent is an event where the operation type is unknown in which case, do not request reconciliation
-	GenericFunc: func(e event.GenericEvent) bool {
-		return false
-	},
-}
-
 // SetupWithManager sets up the controller with the Manager.
 func (c *DiscoveryAgent) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&hyperv1beta1.HostedCluster{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
-		WithEventFilter(DiscoveryPredicateFunctions).
+		WithEventFilter(hostedClusterEventFilters()).
 		Complete(c)
 }
 

--- a/pkg/agent/discovery_agent_test.go
+++ b/pkg/agent/discovery_agent_test.go
@@ -87,6 +87,16 @@ var _ = Describe("Hosted cluster discovery agent", Ordered, func() {
 				LastTransitionTime: metav1.Time{Time: time.Now()},
 			}}
 			newHC.Status.Conditions = newCondition
+
+			newHC.Status.ControlPlaneEndpoint.Host = "test.com"
+			newHC.Status.ControlPlaneEndpoint.Port = 6444
+			newHC.Status.Version = &hyperv1beta1.ClusterVersionStatus{
+				History: []configv1.UpdateHistory{{
+					State:       configv1.CompletedUpdate,
+					Version:     "4.15.12",
+					StartedTime: metav1.Time{Time: time.Now()},
+				}},
+			}
 			Expect(k8sClient.Status().Update(ctx, newHC)).Should(Succeed())
 
 			Eventually(func() bool {

--- a/pkg/agent/external_secret_controller.go
+++ b/pkg/agent/external_secret_controller.go
@@ -31,7 +31,14 @@ type ExternalSecretController struct {
 
 var ExternalSecretPredicateFunctions = predicate.Funcs{
 	CreateFunc: func(e event.CreateEvent) bool {
-		return true
+		newKlusterlet, newOK := e.Object.(*operatorapiv1.Klusterlet)
+
+		if !newOK {
+			return false
+		}
+
+		// Only for hosted cluster klusterlets
+		return newKlusterlet.Spec.DeployOption.Mode == operatorapiv1.InstallModeSingletonHosted
 	},
 	UpdateFunc: func(e event.UpdateEvent) bool {
 		return false

--- a/pkg/agent/external_secret_controller.go
+++ b/pkg/agent/external_secret_controller.go
@@ -73,11 +73,6 @@ func (c *ExternalSecretController) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{Requeue: false}, err
 	}
 
-	if klusterlet.Spec.DeployOption.Mode != operatorapiv1.InstallModeSingletonHosted {
-		c.log.Info("this klusterlet's install mode is not SingletonHosted. Skip reconciling.")
-		return ctrl.Result{}, nil
-	}
-
 	_, hostedClusterName, _ := strings.Cut(req.Name, "klusterlet-")
 
 	_, discoveredHostedClusterName, _ := strings.Cut(req.Name, "klusterlet-"+c.clusterName+"-")

--- a/pkg/agent/hcp_kubeconfig_watcher.go
+++ b/pkg/agent/hcp_kubeconfig_watcher.go
@@ -1,0 +1,112 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	hyperv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+const (
+	adminKubeconfigSuffix = "admin-kubeconfig"
+	ownerRefKind          = "HostedCluster"
+)
+
+type HcpKubeconfigChangeWatcher struct {
+	hubClient   client.Client
+	spokeClient client.Client
+	log         logr.Logger
+}
+
+var HcpKubeconfigChangeWatcherPredicateFunctions = predicate.Funcs{
+	CreateFunc: func(e event.CreateEvent) bool {
+		return false
+	},
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		if !strings.HasSuffix(e.ObjectNew.GetName(), adminKubeconfigSuffix) {
+			return false
+		}
+
+		ownerRefs := e.ObjectNew.GetOwnerReferences()
+
+		for _, owner := range ownerRefs {
+			if owner.Kind == ownerRefKind {
+				return true
+			}
+		}
+
+		return false
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return false
+	},
+	GenericFunc: func(e event.GenericEvent) bool {
+		return false
+	},
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (c *HcpKubeconfigChangeWatcher) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Secret{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 5}).
+		WithEventFilter(HcpKubeconfigChangeWatcherPredicateFunctions).
+		Complete(c)
+}
+
+func (c *HcpKubeconfigChangeWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	c.log.Info(fmt.Sprintf("Hosted Cluster admin kubeconfig %s updated.", req.Name))
+
+	theSecret := &corev1.Secret{}
+	err := c.spokeClient.Get(ctx, req.NamespacedName, theSecret)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	hcFound := false
+	hostedClusterObj := &hyperv1beta1.HostedCluster{}
+	secretOwners := theSecret.GetOwnerReferences()
+	for _, owner := range secretOwners {
+		if owner.Kind == ownerRefKind {
+			hcNN := types.NamespacedName{Namespace: req.Namespace, Name: owner.Name}
+			err = c.spokeClient.Get(ctx, hcNN, hostedClusterObj)
+			if err != nil {
+				c.log.Error(err, fmt.Sprintf("Failed to find the owning hosted cluster %s.", owner.Name))
+				return ctrl.Result{}, err
+			}
+			hcFound = true
+		}
+	}
+
+	if !hcFound {
+		c.log.Error(err, fmt.Sprintf("Failed to find an owning hosted cluster for this admin kubeconfig %s.", req.Name))
+		return ctrl.Result{}, err
+	}
+
+	originalHC := hostedClusterObj.DeepCopy()
+
+	// Add/update the annotation to the hostedcluster
+	if hostedClusterObj.ObjectMeta.Annotations == nil { // Create the annotation map if it doesn't exist
+		hostedClusterObj.ObjectMeta.Annotations = make(map[string]string)
+	}
+
+	currentTime := time.Now()
+	hostedClusterObj.Annotations[hcAnnotation] = currentTime.Format(time.RFC3339)
+	c.log.Info(fmt.Sprintf("Annotated %s with %s", hostedClusterObj.Name, hcAnnotation))
+
+	if err := c.spokeClient.Patch(ctx, hostedClusterObj, client.MergeFromWithOptions(originalHC)); err != nil { //Add/update hostedcluster annotation
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/pkg/agent/hcp_kubeconfig_watcher_test.go
+++ b/pkg/agent/hcp_kubeconfig_watcher_test.go
@@ -1,0 +1,148 @@
+package agent
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	hyperv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const testHcNamespace = "hc-test-1"
+const testHcName = "hc-test-1"
+const adminKubeconfigSecret = testHcName + "-admin-kubeconfig"
+
+var _ = Describe("Hosted cluster kubeconfig secret change watcher", Ordered, func() {
+	ctx := context.Background()
+
+	BeforeAll(func() {
+		ctx = context.TODO()
+		By("Create the hosted cluster namespace")
+		hcNs := corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testHcNamespace,
+			},
+		}
+		Expect(k8sClient.Create(ctx, &hcNs)).Should(Succeed())
+
+		By("creating a hosted cluster")
+
+		hc := getHostedCluster(types.NamespacedName{Namespace: testHcNamespace, Name: testHcName})
+		hsStatus := &hyperv1beta1.HostedClusterStatus{
+			KubeConfig: &corev1.LocalObjectReference{Name: "kubeconfig"},
+			Conditions: []metav1.Condition{{Type: string(hyperv1beta1.HostedClusterAvailable), Status: metav1.ConditionTrue, Reason: hyperv1beta1.AsExpectedReason}},
+			Version: &hyperv1beta1.ClusterVersionStatus{
+				History: []configv1.UpdateHistory{{State: configv1.CompletedUpdate}},
+			},
+		}
+		hc.Status = *hsStatus
+		Expect(k8sClient.Create(ctx, hc)).Should(Succeed())
+	})
+
+	Context("When the hosted cluster admin kubeconfig secret is created", func() {
+		It("Should not do add the annotation to the hosted cluster", func() {
+
+			By("creating the admin kubeconfig")
+
+			kubeconfig := getAdminKubeconfigSecret(types.NamespacedName{Namespace: testHcNamespace, Name: adminKubeconfigSecret})
+			Expect(k8sClient.Create(ctx, kubeconfig)).Should(Succeed())
+
+			time.Sleep(time.Second * 5)
+
+			hostedCluster := &hyperv1beta1.HostedCluster{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: testHcNamespace, Name: testHcName}, hostedCluster)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hostedCluster.Annotations).To(BeNil())
+		})
+	})
+
+	Context("When the hosted cluster admin kubeconfig secret is deleted", func() {
+		It("Should not do add the annotation to the hosted cluster", func() {
+
+			By("deleting the admin kubeconfig")
+
+			kubeconfig := &corev1.Secret{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: testHcNamespace, Name: adminKubeconfigSecret}, kubeconfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Delete(ctx, kubeconfig)).Should(Succeed())
+
+			time.Sleep(time.Second * 5)
+
+			hostedCluster := &hyperv1beta1.HostedCluster{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Namespace: testHcNamespace, Name: testHcName}, hostedCluster)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hostedCluster.Annotations).To(BeNil())
+		})
+	})
+
+	Context("When the hosted cluster admin kubeconfig secret is updated", func() {
+		It("Should add the annotation to the hosted cluster", func() {
+
+			By("creating the admin kubeconfig")
+
+			kubeconfig := getAdminKubeconfigSecret(types.NamespacedName{Namespace: testHcNamespace, Name: adminKubeconfigSecret})
+			Expect(k8sClient.Create(ctx, kubeconfig)).Should(Succeed())
+
+			time.Sleep(time.Second * 5)
+
+			hostedCluster := &hyperv1beta1.HostedCluster{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: testHcNamespace, Name: testHcName}, hostedCluster)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hostedCluster.Annotations).To(BeNil())
+
+			newKubeconfig := &corev1.Secret{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Namespace: testHcNamespace, Name: adminKubeconfigSecret}, newKubeconfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			newKubeconfig.Data = map[string][]byte{
+				"kubeadmin": []byte("newkubeconfig"),
+			}
+			Expect(k8sClient.Update(ctx, newKubeconfig)).Should(Succeed())
+
+			Eventually(func() string {
+				if err := k8sClient.Get(ctx,
+					types.NamespacedName{Namespace: testHcNamespace, Name: testHcName},
+					hostedCluster); err != nil {
+					return ""
+				}
+				return hostedCluster.Annotations[hcAnnotation]
+			}).WithTimeout(10 * time.Second).ShouldNot(Equal(""))
+		})
+	})
+})
+
+func getAdminKubeconfigSecret(secretNN types.NamespacedName) *corev1.Secret {
+	hostedCluster := &hyperv1beta1.HostedCluster{}
+	err := k8sClient.Get(ctx, types.NamespacedName{Namespace: testHcNamespace, Name: testHcName}, hostedCluster)
+	Expect(err).NotTo(HaveOccurred())
+
+	hc := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretNN.Name,
+			Namespace: secretNN.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "hypershift.openshift.io/v1beta1",
+					Kind:       "HostedCluster",
+					Name:       testHcName,
+					UID:        hostedCluster.UID,
+				},
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"kubeadmin": []byte("test"),
+		},
+	}
+	return hc
+}

--- a/pkg/agent/suite_test.go
+++ b/pkg/agent/suite_test.go
@@ -90,6 +90,13 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
+	err = (&HcpKubeconfigChangeWatcher{
+		spokeClient: k8sManager.GetClient(),
+		hubClient:   k8sManager.GetClient(),
+		log:         zapLogger.WithName("hcp-kubeconfig-watcher-test"),
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
 	go func() {
 		defer GinkgoRecover()
 		err = k8sManager.Start(ctx)


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* This optimizes the agent's reconciliation rate by filtering out unimportant HostedCluster resource events. This change reduces the number of reconciliations by 82% percent per hosted cluster. 

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  When there are a large number of hosted clusters, the resource events can create a bottleneck in the agent controller's reconciliation queue causing some of the important events to be lost in the queue. 

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-15162

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
	github.com/stolostron/hypershift-addon-operator/cmd		coverage: 0.0% of statements
	github.com/stolostron/hypershift-addon-operator/pkg/util		coverage: 0.0% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	67.027s	coverage: 70.1% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	176.140s	coverage: 85.0% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	127.504s	coverage: 60.1% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	0.858s	coverage: 35.7% of statements
```
