### PR TITLE
ACM-18288: optimize the agent reconciliation rate

### DIFF
--- a/hack/crds/hypershift.openshift.io_hostedclusters.yaml
+++ b/hack/crds/hypershift.openshift.io_hostedclusters.yaml
@@ -1,0 +1,8233 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.12.0
+  name: hostedclusters.hypershift.openshift.io
+spec:
+  group: hypershift.openshift.io
+  names:
+    kind: HostedCluster
+    listKind: HostedClusterList
+    plural: hostedclusters
+    shortNames:
+    - hc
+    - hcs
+    singular: hostedcluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Version
+      jsonPath: .status.version.history[?(@.state=="Completed")].version
+      name: Version
+      type: string
+    - description: KubeConfig Secret
+      jsonPath: .status.kubeconfig.name
+      name: KubeConfig
+      type: string
+    - description: Progress
+      jsonPath: .status.version.history[?(@.state!="")].state
+      name: Progress
+      type: string
+    - description: Available
+      jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - description: Progressing
+      jsonPath: .status.conditions[?(@.type=="Progressing")].status
+      name: Progressing
+      type: string
+    - description: Message
+      jsonPath: .status.conditions[?(@.type=="Available")].message
+      name: Message
+      type: string
+    deprecated: true
+    deprecationWarning: v1alpha1 is a deprecated version for HostedCluster
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: HostedCluster is the primary representation of a HyperShift cluster
+          and encapsulates the control plane and common data plane configuration.
+          Creating a HostedCluster results in a fully functional OpenShift control
+          plane with no attached nodes. To support workloads (e.g. pods), a HostedCluster
+          may have one or more associated NodePool resources.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec is the desired behavior of the HostedCluster.
+            properties:
+              additionalTrustBundle:
+                description: AdditionalTrustBundle is a reference to a ConfigMap containing
+                  a PEM-encoded X.509 certificate bundle that will be added to the
+                  hosted controlplane and nodes
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              auditWebhook:
+                description: AuditWebhook contains metadata for configuring an audit
+                  webhook endpoint for a cluster to process cluster audit events.
+                  It references a secret that contains the webhook information for
+                  the audit webhook endpoint. It is a secret because if the endpoint
+                  has mTLS the kubeconfig will contain client keys. The kubeconfig
+                  needs to be stored in the secret with a secret key name that corresponds
+                  to the constant AuditWebhookKubeconfigKey.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              autoscaling:
+                description: Autoscaling specifies auto-scaling behavior that applies
+                  to all NodePools associated with the control plane.
+                properties:
+                  maxNodeProvisionTime:
+                    description: MaxNodeProvisionTime is the maximum time to wait
+                      for node provisioning before considering the provisioning to
+                      be unsuccessful, expressed as a Go duration string. The default
+                      is 15 minutes.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                    type: string
+                  maxNodesTotal:
+                    description: MaxNodesTotal is the maximum allowable number of
+                      nodes across all NodePools for a HostedCluster. The autoscaler
+                      will not grow the cluster beyond this number.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  maxPodGracePeriod:
+                    description: MaxPodGracePeriod is the maximum seconds to wait
+                      for graceful pod termination before scaling down a NodePool.
+                      The default is 600 seconds.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  podPriorityThreshold:
+                    description: "PodPriorityThreshold enables users to schedule \"best-effort\"
+                      pods, which shouldn't trigger autoscaler actions, but only run
+                      when there are spare resources available. The default is -10.
+                      \n See the following for more details: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption"
+                    format: int32
+                    type: integer
+                type: object
+              channel:
+                description: channel is an identifier for explicitly requesting that
+                  a non-default set of updates be applied to this cluster. The default
+                  channel will be contain stable updates that are appropriate for
+                  production clusters.
+                type: string
+              clusterID:
+                description: ClusterID uniquely identifies this cluster. This is expected
+                  to be an RFC4122 UUID value (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+                  in hexadecimal values). As with a Kubernetes metadata.uid, this
+                  ID uniquely identifies this cluster in space and time. This value
+                  identifies the cluster in metrics pushed to telemetry and metrics
+                  produced by the control plane operators. If a value is not specified,
+                  an ID is generated. After initial creation, the value is immutable.
+                pattern: '[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}'
+                type: string
+              configuration:
+                description: Configuration specifies configuration for individual
+                  OCP components in the cluster, represented as embedded resources
+                  that correspond to the openshift configuration API.
+                properties:
+                  apiServer:
+                    description: APIServer holds configuration (like serving certificates,
+                      client CA and CORS domains) shared by all API servers in the
+                      system, among them especially kube-apiserver and openshift-apiserver.
+                    properties:
+                      additionalCORSAllowedOrigins:
+                        description: additionalCORSAllowedOrigins lists additional,
+                          user-defined regular expressions describing hosts for which
+                          the API server allows access using the CORS headers. This
+                          may be needed to access the API and the integrated OAuth
+                          server from JavaScript applications. The values are regular
+                          expressions that correspond to the Golang regular expression
+                          language.
+                        items:
+                          type: string
+                        type: array
+                      audit:
+                        default:
+                          profile: Default
+                        description: audit specifies the settings for audit configuration
+                          to be applied to all OpenShift-provided API servers in the
+                          cluster.
+                        properties:
+                          customRules:
+                            description: customRules specify profiles per group. These
+                              profile take precedence over the top-level profile field
+                              if they apply. They are evaluation from top to bottom
+                              and the first one that matches, applies.
+                            items:
+                              description: AuditCustomRule describes a custom rule
+                                for an audit profile that takes precedence over the
+                                top-level profile.
+                              properties:
+                                group:
+                                  description: group is a name of group a request
+                                    user must be member of in order to this profile
+                                    to apply.
+                                  minLength: 1
+                                  type: string
+                                profile:
+                                  description: "profile specifies the name of the
+                                    desired audit policy configuration to be deployed
+                                    to all OpenShift-provided API servers in the cluster.
+                                    \n The following profiles are provided: - Default:
+                                    the existing default policy. - WriteRequestBodies:
+                                    like 'Default', but logs request and response
+                                    HTTP payloads for write requests (create, update,
+                                    patch). - AllRequestBodies: like 'WriteRequestBodies',
+                                    but also logs request and response HTTP payloads
+                                    for read requests (get, list). - None: no requests
+                                    are logged at all, not even oauthaccesstokens
+                                    and oauthauthorizetokens. \n If unset, the 'Default'
+                                    profile is used as the default."
+                                  enum:
+                                  - Default
+                                  - WriteRequestBodies
+                                  - AllRequestBodies
+                                  - None
+                                  type: string
+                              required:
+                              - group
+                              - profile
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - group
+                            x-kubernetes-list-type: map
+                          profile:
+                            default: Default
+                            description: "profile specifies the name of the desired
+                              top-level audit profile to be applied to all requests
+                              sent to any of the OpenShift-provided API servers in
+                              the cluster (kube-apiserver, openshift-apiserver and
+                              oauth-apiserver), with the exception of those requests
+                              that match one or more of the customRules. \n The following
+                              profiles are provided: - Default: default policy which
+                              means MetaData level logging with the exception of events
+                              (not logged at all), oauthaccesstokens and oauthauthorizetokens
+                              (both logged at RequestBody level). - WriteRequestBodies:
+                              like 'Default', but logs request and response HTTP payloads
+                              for write requests (create, update, patch). - AllRequestBodies:
+                              like 'WriteRequestBodies', but also logs request and
+                              response HTTP payloads for read requests (get, list).
+                              - None: no requests are logged at all, not even oauthaccesstokens
+                              and oauthauthorizetokens. \n Warning: It is not recommended
+                              to disable audit logging by using the `None` profile
+                              unless you are fully aware of the risks of not logging
+                              data that can be beneficial when troubleshooting issues.
+                              If you disable audit logging and a support situation
+                              arises, you might need to enable audit logging and reproduce
+                              the issue in order to troubleshoot properly. \n If unset,
+                              the 'Default' profile is used as the default."
+                            enum:
+                            - Default
+                            - WriteRequestBodies
+                            - AllRequestBodies
+                            - None
+                            type: string
+                        type: object
+                      clientCA:
+                        description: 'clientCA references a ConfigMap containing a
+                          certificate bundle for the signers that will be recognized
+                          for incoming client certificates in addition to the operator
+                          managed signers. If this is empty, then only operator managed
+                          signers are valid. You usually only have to set this if
+                          you have your own PKI you wish to honor client certificates
+                          from. The ConfigMap must exist in the openshift-config namespace
+                          and contain the following required fields: - ConfigMap.Data["ca-bundle.crt"]
+                          - CA bundle.'
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      encryption:
+                        description: encryption allows the configuration of encryption
+                          of resources at the datastore layer.
+                        properties:
+                          type:
+                            description: "type defines what encryption type should
+                              be used to encrypt resources at the datastore layer.
+                              When this field is unset (i.e. when it is set to the
+                              empty string), identity is implied. The behavior of
+                              unset can and will change over time.  Even if encryption
+                              is enabled by default, the meaning of unset may change
+                              to a different encryption type based on changes in best
+                              practices. \n When encryption is enabled, all sensitive
+                              resources shipped with the platform are encrypted. This
+                              list of sensitive resources can and will change over
+                              time.  The current authoritative list is: \n 1. secrets
+                              2. configmaps 3. routes.route.openshift.io 4. oauthaccesstokens.oauth.openshift.io
+                              5. oauthauthorizetokens.oauth.openshift.io"
+                            enum:
+                            - ""
+                            - identity
+                            - aescbc
+                            - aesgcm
+                            type: string
+                        type: object
+                      servingCerts:
+                        description: servingCert is the TLS cert info for serving
+                          secure traffic. If not specified, operator managed certificates
+                          will be used for serving secure traffic.
+                        properties:
+                          namedCertificates:
+                            description: namedCertificates references secrets containing
+                              the TLS cert info for serving secure traffic to specific
+                              hostnames. If no named certificates are provided, or
+                              no named certificates match the server name as understood
+                              by a client, the defaultServingCertificate will be used.
+                            items:
+                              description: APIServerNamedServingCert maps a server
+                                DNS name, as understood by a client, to a certificate.
+                              properties:
+                                names:
+                                  description: names is a optional list of explicit
+                                    DNS names (leading wildcards allowed) that should
+                                    use this certificate to serve secure traffic.
+                                    If no names are provided, the implicit names will
+                                    be extracted from the certificates. Exact names
+                                    trump over wildcard names. Explicit names defined
+                                    here trump over extracted implicit names.
+                                  items:
+                                    type: string
+                                  type: array
+                                servingCertificate:
+                                  description: 'servingCertificate references a kubernetes.io/tls
+                                    type secret containing the TLS cert info for serving
+                                    secure traffic. The secret must exist in the openshift-config
+                                    namespace and contain the following required fields:
+                                    - Secret.Data["tls.key"] - TLS private key. -
+                                    Secret.Data["tls.crt"] - TLS certificate.'
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced secret
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                      tlsSecurityProfile:
+                        description: "tlsSecurityProfile specifies settings for TLS
+                          connections for externally exposed servers. \n If unset,
+                          a default (which may change between releases) is chosen.
+                          Note that only Old, Intermediate and Custom profiles are
+                          currently supported, and the maximum available minTLSVersion
+                          is VersionTLS12."
+                        properties:
+                          custom:
+                            description: "custom is a user-defined TLS security profile.
+                              Be extremely careful using a custom profile as invalid
+                              configurations can be catastrophic. An example custom
+                              profile looks like this: \n ciphers: - ECDHE-ECDSA-CHACHA20-POLY1305
+                              - ECDHE-RSA-CHACHA20-POLY1305 - ECDHE-RSA-AES128-GCM-SHA256
+                              - ECDHE-ECDSA-AES128-GCM-SHA256 minTLSVersion: VersionTLS11"
+                            nullable: true
+                            properties:
+                              ciphers:
+                                description: "ciphers is used to specify the cipher
+                                  algorithms that are negotiated during the TLS handshake.
+                                  \ Operators may remove entries their operands do
+                                  not support.  For example, to use DES-CBC3-SHA  (yaml):
+                                  \n ciphers: - DES-CBC3-SHA"
+                                items:
+                                  type: string
+                                type: array
+                              minTLSVersion:
+                                description: "minTLSVersion is used to specify the
+                                  minimal version of the TLS protocol that is negotiated
+                                  during the TLS handshake. For example, to use TLS
+                                  versions 1.1, 1.2 and 1.3 (yaml): \n minTLSVersion:
+                                  VersionTLS11 \n NOTE: currently the highest minTLSVersion
+                                  allowed is VersionTLS12"
+                                enum:
+                                - VersionTLS10
+                                - VersionTLS11
+                                - VersionTLS12
+                                - VersionTLS13
+                                type: string
+                            type: object
+                          intermediate:
+                            description: "intermediate is a TLS security profile based
+                              on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
+                              \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256
+                              - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256
+                              - ECDHE-ECDSA-AES128-GCM-SHA256 - ECDHE-RSA-AES128-GCM-SHA256
+                              - ECDHE-ECDSA-AES256-GCM-SHA384 - ECDHE-RSA-AES256-GCM-SHA384
+                              - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305
+                              - DHE-RSA-AES128-GCM-SHA256 - DHE-RSA-AES256-GCM-SHA384
+                              minTLSVersion: VersionTLS12"
+                            nullable: true
+                            type: object
+                          modern:
+                            description: "modern is a TLS security profile based on:
+                              \n https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
+                              \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256
+                              - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256
+                              minTLSVersion: VersionTLS13 \n NOTE: Currently unsupported."
+                            nullable: true
+                            type: object
+                          old:
+                            description: "old is a TLS security profile based on:
+                              \n https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
+                              \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256
+                              - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256
+                              - ECDHE-ECDSA-AES128-GCM-SHA256 - ECDHE-RSA-AES128-GCM-SHA256
+                              - ECDHE-ECDSA-AES256-GCM-SHA384 - ECDHE-RSA-AES256-GCM-SHA384
+                              - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305
+                              - DHE-RSA-AES128-GCM-SHA256 - DHE-RSA-AES256-GCM-SHA384
+                              - DHE-RSA-CHACHA20-POLY1305 - ECDHE-ECDSA-AES128-SHA256
+                              - ECDHE-RSA-AES128-SHA256 - ECDHE-ECDSA-AES128-SHA -
+                              ECDHE-RSA-AES128-SHA - ECDHE-ECDSA-AES256-SHA384 - ECDHE-RSA-AES256-SHA384
+                              - ECDHE-ECDSA-AES256-SHA - ECDHE-RSA-AES256-SHA - DHE-RSA-AES128-SHA256
+                              - DHE-RSA-AES256-SHA256 - AES128-GCM-SHA256 - AES256-GCM-SHA384
+                              - AES128-SHA256 - AES256-SHA256 - AES128-SHA - AES256-SHA
+                              - DES-CBC3-SHA minTLSVersion: VersionTLS10"
+                            nullable: true
+                            type: object
+                          type:
+                            description: "type is one of Old, Intermediate, Modern
+                              or Custom. Custom provides the ability to specify individual
+                              TLS security profile parameters. Old, Intermediate and
+                              Modern are TLS security profiles based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations
+                              \n The profiles are intent based, so they may change
+                              over time as new ciphers are developed and existing
+                              ciphers are found to be insecure.  Depending on precisely
+                              which ciphers are available to a process, the list may
+                              be reduced. \n Note that the Modern profile is currently
+                              not supported because it is not yet well adopted by
+                              common software libraries."
+                            enum:
+                            - Old
+                            - Intermediate
+                            - Modern
+                            - Custom
+                            type: string
+                        type: object
+                    type: object
+                  authentication:
+                    description: Authentication specifies cluster-wide settings for
+                      authentication (like OAuth and webhook token authenticators).
+                    properties:
+                      oauthMetadata:
+                        description: 'oauthMetadata contains the discovery endpoint
+                          data for OAuth 2.0 Authorization Server Metadata for an
+                          external OAuth server. This discovery document can be viewed
+                          from its served location: oc get --raw ''/.well-known/oauth-authorization-server''
+                          For further details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2
+                          If oauthMetadata.name is non-empty, this value has precedence
+                          over any metadata reference stored in status. The key "oauthMetadata"
+                          is used to locate the data. If specified and the config
+                          map or expected key is not found, no metadata is served.
+                          If the specified metadata is not valid, no metadata is served.
+                          The namespace for this config map is openshift-config.'
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      oidcProviders:
+                        description: "OIDCProviders are OIDC identity providers that
+                          can issue tokens for this cluster Can only be set if \"Type\"
+                          is set to \"OIDC\". \n At most one provider can be configured."
+                        items:
+                          properties:
+                            claimMappings:
+                              description: ClaimMappings describes rules on how to
+                                transform information from an ID token into a cluster
+                                identity
+                              properties:
+                                groups:
+                                  description: Groups is a name of the claim that
+                                    should be used to construct groups for the cluster
+                                    identity. The referenced claim must use array
+                                    of strings values.
+                                  properties:
+                                    claim:
+                                      description: Claim is a JWT token claim to be
+                                        used in the mapping
+                                      type: string
+                                    prefix:
+                                      description: "Prefix is a string to prefix the
+                                        value from the token in the result of the
+                                        claim mapping. \n By default, no prefixing
+                                        occurs. \n Example: if `prefix` is set to
+                                        \"myoidc:\"\" and the `claim` in JWT contains
+                                        an array of strings \"a\", \"b\" and  \"c\",
+                                        the mapping will result in an array of string
+                                        \"myoidc:a\", \"myoidc:b\" and \"myoidc:c\"."
+                                      type: string
+                                  required:
+                                  - claim
+                                  type: object
+                                username:
+                                  description: "Username is a name of the claim that
+                                    should be used to construct usernames for the
+                                    cluster identity. \n Default value: \"sub\""
+                                  properties:
+                                    claim:
+                                      description: Claim is a JWT token claim to be
+                                        used in the mapping
+                                      type: string
+                                    prefix:
+                                      properties:
+                                        prefixString:
+                                          minLength: 1
+                                          type: string
+                                      required:
+                                      - prefixString
+                                      type: object
+                                    prefixPolicy:
+                                      description: "PrefixPolicy specifies how a prefix
+                                        should apply. \n By default, claims other
+                                        than `email` will be prefixed with the issuer
+                                        URL to prevent naming clashes with other plugins.
+                                        \n Set to \"NoPrefix\" to disable prefixing.
+                                        \n Example: (1) `prefix` is set to \"myoidc:\"
+                                        and `claim` is set to \"username\". If the
+                                        JWT claim `username` contains value `userA`,
+                                        the resulting mapped value will be \"myoidc:userA\".
+                                        (2) `prefix` is set to \"myoidc:\" and `claim`
+                                        is set to \"email\". If the JWT `email` claim
+                                        contains value \"userA@myoidc.tld\", the resulting
+                                        mapped value will be \"myoidc:userA@myoidc.tld\".
+                                        (3) `prefix` is unset, `issuerURL` is set
+                                        to `https://myoidc.tld`, the JWT claims include
+                                        \"username\":\"userA\" and \"email\":\"userA@myoidc.tld\",
+                                        and `claim` is set to: (a) \"username\": the
+                                        mapped value will be \"https://myoidc.tld#userA\"
+                                        (b) \"email\": the mapped value will be \"userA@myoidc.tld\""
+                                      enum:
+                                      - ""
+                                      - NoPrefix
+                                      - Prefix
+                                      type: string
+                                  required:
+                                  - claim
+                                  type: object
+                                  x-kubernetes-validations:
+                                  - message: prefix must be set if prefixPolicy is
+                                      'Prefix', but must remain unset otherwise
+                                    rule: 'has(self.prefixPolicy) && self.prefixPolicy
+                                      == ''Prefix'' ? (has(self.prefix) && size(self.prefix.prefixString)
+                                      > 0) : !has(self.prefix)'
+                              type: object
+                            claimValidationRules:
+                              description: ClaimValidationRules are rules that are
+                                applied to validate token claims to authenticate users.
+                              items:
+                                properties:
+                                  requiredClaim:
+                                    description: RequiredClaim allows configuring
+                                      a required claim name and its expected value
+                                    properties:
+                                      claim:
+                                        description: Claim is a name of a required
+                                          claim. Only claims with string values are
+                                          supported.
+                                        minLength: 1
+                                        type: string
+                                      requiredValue:
+                                        description: RequiredValue is the required
+                                          value for the claim.
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - claim
+                                    - requiredValue
+                                    type: object
+                                  type:
+                                    default: RequiredClaim
+                                    description: Type sets the type of the validation
+                                      rule
+                                    enum:
+                                    - RequiredClaim
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            issuer:
+                              description: Issuer describes atributes of the OIDC
+                                token issuer
+                              properties:
+                                audiences:
+                                  description: Audiences is an array of audiences
+                                    that the token was issued for. Valid tokens must
+                                    include at least one of these values in their
+                                    "aud" claim. Must be set to exactly one value.
+                                  items:
+                                    minLength: 1
+                                    type: string
+                                  maxItems: 10
+                                  minItems: 1
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                issuerCertificateAuthority:
+                                  description: CertificateAuthority is a reference
+                                    to a config map in the configuration namespace.
+                                    The .data of the configMap must contain the "ca-bundle.crt"
+                                    key. If unset, system trust is used instead.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced config map
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                issuerURL:
+                                  description: URL is the serving URL of the token
+                                    issuer. Must use the https:// scheme.
+                                  pattern: ^https:\/\/[^\s]
+                                  type: string
+                              required:
+                              - audiences
+                              - issuerURL
+                              type: object
+                            name:
+                              description: Name of the OIDC provider
+                              minLength: 1
+                              type: string
+                            oidcClients:
+                              description: OIDCClients contains configuration for
+                                the platform's clients that need to request tokens
+                                from the issuer
+                              items:
+                                properties:
+                                  clientID:
+                                    description: ClientID is the identifier of the
+                                      OIDC client from the OIDC provider
+                                    minLength: 1
+                                    type: string
+                                  clientSecret:
+                                    description: ClientSecret refers to a secret in
+                                      the `openshift-config` namespace that contains
+                                      the client secret in the `clientSecret` key
+                                      of the `.data` field
+                                    properties:
+                                      name:
+                                        description: name is the metadata.name of
+                                          the referenced secret
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  componentName:
+                                    description: ComponentName is the name of the
+                                      component that is supposed to consume this client
+                                      configuration
+                                    maxLength: 256
+                                    minLength: 1
+                                    type: string
+                                  componentNamespace:
+                                    description: ComponentNamespace is the namespace
+                                      of the component that is supposed to consume
+                                      this client configuration
+                                    maxLength: 63
+                                    minLength: 1
+                                    type: string
+                                  extraScopes:
+                                    description: ExtraScopes is an optional set of
+                                      scopes to request tokens with.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - clientID
+                                - componentName
+                                - componentNamespace
+                                type: object
+                              maxItems: 20
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - componentNamespace
+                              - componentName
+                              x-kubernetes-list-type: map
+                          required:
+                          - issuer
+                          - name
+                          type: object
+                        maxItems: 1
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      serviceAccountIssuer:
+                        description: 'serviceAccountIssuer is the identifier of the
+                          bound service account token issuer. The default is https://kubernetes.default.svc
+                          WARNING: Updating this field will not result in immediate
+                          invalidation of all bound tokens with the previous issuer
+                          value. Instead, the tokens issued by previous service account
+                          issuer will continue to be trusted for a time period chosen
+                          by the platform (currently set to 24h). This time period
+                          is subject to change over time. This allows internal components
+                          to transition to use new service account issuer without
+                          service distruption.'
+                        type: string
+                      type:
+                        description: type identifies the cluster managed, user facing
+                          authentication mode in use. Specifically, it manages the
+                          component that responds to login attempts. The default is
+                          IntegratedOAuth.
+                        type: string
+                      webhookTokenAuthenticator:
+                        description: "webhookTokenAuthenticator configures a remote
+                          token reviewer. These remote authentication webhooks can
+                          be used to verify bearer tokens via the tokenreviews.authentication.k8s.io
+                          REST API. This is required to honor bearer tokens that are
+                          provisioned by an external authentication service. \n Can
+                          only be set if \"Type\" is set to \"None\"."
+                        properties:
+                          kubeConfig:
+                            description: "kubeConfig references a secret that contains
+                              kube config file data which describes how to access
+                              the remote webhook service. The namespace for the referenced
+                              secret is openshift-config. \n For further details,
+                              see: \n https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication
+                              \n The key \"kubeConfig\" is used to locate the data.
+                              If the secret or expected key is not found, the webhook
+                              is not honored. If the specified kube config data is
+                              not valid, the webhook is not honored."
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        required:
+                        - kubeConfig
+                        type: object
+                      webhookTokenAuthenticators:
+                        description: webhookTokenAuthenticators is DEPRECATED, setting
+                          it has no effect.
+                        items:
+                          description: deprecatedWebhookTokenAuthenticator holds the
+                            necessary configuration options for a remote token authenticator.
+                            It's the same as WebhookTokenAuthenticator but it's missing
+                            the 'required' validation on KubeConfig field.
+                          properties:
+                            kubeConfig:
+                              description: 'kubeConfig contains kube config file data
+                                which describes how to access the remote webhook service.
+                                For further details, see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication
+                                The key "kubeConfig" is used to locate the data. If
+                                the secret or expected key is not found, the webhook
+                                is not honored. If the specified kube config data
+                                is not valid, the webhook is not honored. The namespace
+                                for this secret is determined by the point of use.'
+                              properties:
+                                name:
+                                  description: name is the metadata.name of the referenced
+                                    secret
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  configMapRefs:
+                    description: "ConfigMapRefs holds references to any configmaps
+                      referenced by configuration entries. Entries can reference the
+                      configmaps using local object references. \n Deprecated This
+                      field is deprecated and will be removed in a future release"
+                    items:
+                      description: LocalObjectReference contains enough information
+                        to let you locate the referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                  featureGate:
+                    description: FeatureGate holds cluster-wide information about
+                      feature gates.
+                    properties:
+                      customNoUpgrade:
+                        description: customNoUpgrade allows the enabling or disabling
+                          of any feature. Turning this feature set on IS NOT SUPPORTED,
+                          CANNOT BE UNDONE, and PREVENTS UPGRADES. Because of its
+                          nature, this setting cannot be validated.  If you have any
+                          typos or accidentally apply invalid combinations your cluster
+                          may fail in an unrecoverable way.  featureSet must equal
+                          "CustomNoUpgrade" must be set to use this field.
+                        nullable: true
+                        properties:
+                          disabled:
+                            description: disabled is a list of all feature gates that
+                              you want to force off
+                            items:
+                              description: FeatureGateName is a string to enforce
+                                patterns on the name of a FeatureGate
+                              pattern: ^([A-Za-z0-9-]+\.)*[A-Za-z0-9-]+\.?$
+                              type: string
+                            type: array
+                          enabled:
+                            description: enabled is a list of all feature gates that
+                              you want to force on
+                            items:
+                              description: FeatureGateName is a string to enforce
+                                patterns on the name of a FeatureGate
+                              pattern: ^([A-Za-z0-9-]+\.)*[A-Za-z0-9-]+\.?$
+                              type: string
+                            type: array
+                        type: object
+                      featureSet:
+                        description: featureSet changes the list of features in the
+                          cluster.  The default is empty.  Be very careful adjusting
+                          this setting. Turning on or off features may cause irreversible
+                          changes in your cluster which cannot be undone.
+                        type: string
+                    type: object
+                  image:
+                    description: Image governs policies related to imagestream imports
+                      and runtime configuration for external registries. It allows
+                      cluster admins to configure which registries OpenShift is allowed
+                      to import images from, extra CA trust bundles for external registries,
+                      and policies to block or allow registry hostnames. When exposing
+                      OpenShift's image registry to the public, this also lets cluster
+                      admins specify the external hostname.
+                    properties:
+                      additionalTrustedCA:
+                        description: additionalTrustedCA is a reference to a ConfigMap
+                          containing additional CAs that should be trusted during
+                          imagestream import, pod image pull, build image pull, and
+                          imageregistry pullthrough. The namespace for this config
+                          map is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      allowedRegistriesForImport:
+                        description: allowedRegistriesForImport limits the container
+                          image registries that normal users may import images from.
+                          Set this list to the registries that you trust to contain
+                          valid Docker images and that you want applications to be
+                          able to import from. Users with permission to create Images
+                          or ImageStreamMappings via the API are not affected by this
+                          policy - typically only administrators or system integrations
+                          will have those permissions.
+                        items:
+                          description: RegistryLocation contains a location of the
+                            registry specified by the registry domain name. The domain
+                            name might include wildcards, like '*' or '??'.
+                          properties:
+                            domainName:
+                              description: domainName specifies a domain name for
+                                the registry In case the registry use non-standard
+                                (80 or 443) port, the port should be included in the
+                                domain name as well.
+                              type: string
+                            insecure:
+                              description: insecure indicates whether the registry
+                                is secure (https) or insecure (http) By default (if
+                                not specified) the registry is assumed as secure.
+                              type: boolean
+                          type: object
+                        type: array
+                      externalRegistryHostnames:
+                        description: externalRegistryHostnames provides the hostnames
+                          for the default external image registry. The external hostname
+                          should be set only when the image registry is exposed externally.
+                          The first value is used in 'publicDockerImageRepository'
+                          field in ImageStreams. The value must be in "hostname[:port]"
+                          format.
+                        items:
+                          type: string
+                        type: array
+                      registrySources:
+                        description: registrySources contains configuration that determines
+                          how the container runtime should treat individual registries
+                          when accessing images for builds+pods. (e.g. whether or
+                          not to allow insecure access).  It does not contain configuration
+                          for the internal cluster registry.
+                        properties:
+                          allowedRegistries:
+                            description: "allowedRegistries are the only registries
+                              permitted for image pull and push actions. All other
+                              registries are denied. \n Only one of BlockedRegistries
+                              or AllowedRegistries may be set."
+                            items:
+                              type: string
+                            type: array
+                          blockedRegistries:
+                            description: "blockedRegistries cannot be used for image
+                              pull and push actions. All other registries are permitted.
+                              \n Only one of BlockedRegistries or AllowedRegistries
+                              may be set."
+                            items:
+                              type: string
+                            type: array
+                          containerRuntimeSearchRegistries:
+                            description: 'containerRuntimeSearchRegistries are registries
+                              that will be searched when pulling images that do not
+                              have fully qualified domains in their pull specs. Registries
+                              will be searched in the order provided in the list.
+                              Note: this search list only works with the container
+                              runtime, i.e CRI-O. Will NOT work with builds or imagestream
+                              imports.'
+                            format: hostname
+                            items:
+                              type: string
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
+                          insecureRegistries:
+                            description: insecureRegistries are registries which do
+                              not have a valid TLS certificates or only support HTTP
+                              connections.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                    type: object
+                  ingress:
+                    description: Ingress holds cluster-wide information about ingress,
+                      including the default ingress domain used for routes.
+                    properties:
+                      appsDomain:
+                        description: appsDomain is an optional domain to use instead
+                          of the one specified in the domain field when a Route is
+                          created without specifying an explicit host. If appsDomain
+                          is nonempty, this value is used to generate default host
+                          values for Route. Unlike domain, appsDomain may be modified
+                          after installation. This assumes a new ingresscontroller
+                          has been setup with a wildcard certificate.
+                        type: string
+                      componentRoutes:
+                        description: "componentRoutes is an optional list of routes
+                          that are managed by OpenShift components that a cluster-admin
+                          is able to configure the hostname and serving certificate
+                          for. The namespace and name of each route in this list should
+                          match an existing entry in the status.componentRoutes list.
+                          \n To determine the set of configurable Routes, look at
+                          namespace and name of entries in the .status.componentRoutes
+                          list, where participating operators write the status of
+                          configurable routes."
+                        items:
+                          description: ComponentRouteSpec allows for configuration
+                            of a route's hostname and serving certificate.
+                          properties:
+                            hostname:
+                              description: hostname is the hostname that should be
+                                used by the route.
+                              pattern: ^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
+                              type: string
+                            name:
+                              description: "name is the logical name of the route
+                                to customize. \n The namespace and name of this componentRoute
+                                must match a corresponding entry in the list of status.componentRoutes
+                                if the route is to be customized."
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                            namespace:
+                              description: "namespace is the namespace of the route
+                                to customize. \n The namespace and name of this componentRoute
+                                must match a corresponding entry in the list of status.componentRoutes
+                                if the route is to be customized."
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            servingCertKeyPairSecret:
+                              description: servingCertKeyPairSecret is a reference
+                                to a secret of type `kubernetes.io/tls` in the openshift-config
+                                namespace. The serving cert/key pair must match and
+                                will be used by the operator to fulfill the intent
+                                of serving with this name. If the custom hostname
+                                uses the default routing suffix of the cluster, the
+                                Secret specification for a serving certificate will
+                                not be needed.
+                              properties:
+                                name:
+                                  description: name is the metadata.name of the referenced
+                                    secret
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                          required:
+                          - hostname
+                          - name
+                          - namespace
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - namespace
+                        - name
+                        x-kubernetes-list-type: map
+                      domain:
+                        description: "domain is used to generate a default host name
+                          for a route when the route's host name is empty. The generated
+                          host name will follow this pattern: \"<route-name>.<route-namespace>.<domain>\".
+                          \n It is also used as the default wildcard domain suffix
+                          for ingress. The default ingresscontroller domain will follow
+                          this pattern: \"*.<domain>\". \n Once set, changing domain
+                          is not currently supported."
+                        type: string
+                      loadBalancer:
+                        description: loadBalancer contains the load balancer details
+                          in general which are not only specific to the underlying
+                          infrastructure provider of the current cluster and are required
+                          for Ingress Controller to work on OpenShift.
+                        properties:
+                          platform:
+                            description: platform holds configuration specific to
+                              the underlying infrastructure provider for the ingress
+                              load balancers. When omitted, this means the user has
+                              no opinion and the platform is left to choose reasonable
+                              defaults. These defaults are subject to change over
+                              time.
+                            properties:
+                              aws:
+                                description: aws contains settings specific to the
+                                  Amazon Web Services infrastructure provider.
+                                properties:
+                                  type:
+                                    description: "type allows user to set a load balancer
+                                      type. When this field is set the default ingresscontroller
+                                      will get created using the specified LBType.
+                                      If this field is not set then the default ingress
+                                      controller of LBType Classic will be created.
+                                      Valid values are: \n * \"Classic\": A Classic
+                                      Load Balancer that makes routing decisions at
+                                      either the transport layer (TCP/SSL) or the
+                                      application layer (HTTP/HTTPS). See the following
+                                      for additional details: \n https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#clb
+                                      \n * \"NLB\": A Network Load Balancer that makes
+                                      routing decisions at the transport layer (TCP/SSL).
+                                      See the following for additional details: \n
+                                      https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#nlb"
+                                    enum:
+                                    - NLB
+                                    - Classic
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              type:
+                                description: type is the underlying infrastructure
+                                  provider for the cluster. Allowed values are "AWS",
+                                  "Azure", "BareMetal", "GCP", "Libvirt", "OpenStack",
+                                  "VSphere", "oVirt", "KubeVirt", "EquinixMetal",
+                                  "PowerVS", "AlibabaCloud", "Nutanix" and "None".
+                                  Individual components may not support all platforms,
+                                  and must handle unrecognized platforms as None if
+                                  they do not support that platform.
+                                enum:
+                                - ""
+                                - AWS
+                                - Azure
+                                - BareMetal
+                                - GCP
+                                - Libvirt
+                                - OpenStack
+                                - None
+                                - VSphere
+                                - oVirt
+                                - IBMCloud
+                                - KubeVirt
+                                - EquinixMetal
+                                - PowerVS
+                                - AlibabaCloud
+                                - Nutanix
+                                - External
+                                type: string
+                            type: object
+                        type: object
+                      requiredHSTSPolicies:
+                        description: "requiredHSTSPolicies specifies HSTS policies
+                          that are required to be set on newly created  or updated
+                          routes matching the domainPattern/s and namespaceSelector/s
+                          that are specified in the policy. Each requiredHSTSPolicy
+                          must have at least a domainPattern and a maxAge to validate
+                          a route HSTS Policy route annotation, and affect route admission.
+                          \n A candidate route is checked for HSTS Policies if it
+                          has the HSTS Policy route annotation: \"haproxy.router.openshift.io/hsts_header\"
+                          E.g. haproxy.router.openshift.io/hsts_header: max-age=31536000;preload;includeSubDomains
+                          \n - For each candidate route, if it matches a requiredHSTSPolicy
+                          domainPattern and optional namespaceSelector, then the maxAge,
+                          preloadPolicy, and includeSubdomainsPolicy must be valid
+                          to be admitted.  Otherwise, the route is rejected. - The
+                          first match, by domainPattern and optional namespaceSelector,
+                          in the ordering of the RequiredHSTSPolicies determines the
+                          route's admission status. - If the candidate route doesn't
+                          match any requiredHSTSPolicy domainPattern and optional
+                          namespaceSelector, then it may use any HSTS Policy annotation.
+                          \n The HSTS policy configuration may be changed after routes
+                          have already been created. An update to a previously admitted
+                          route may then fail if the updated route does not conform
+                          to the updated HSTS policy configuration. However, changing
+                          the HSTS policy configuration will not cause a route that
+                          is already admitted to stop working. \n Note that if there
+                          are no RequiredHSTSPolicies, any HSTS Policy annotation
+                          on the route is valid."
+                        items:
+                          properties:
+                            domainPatterns:
+                              description: "domainPatterns is a list of domains for
+                                which the desired HSTS annotations are required. If
+                                domainPatterns is specified and a route is created
+                                with a spec.host matching one of the domains, the
+                                route must specify the HSTS Policy components described
+                                in the matching RequiredHSTSPolicy. \n The use of
+                                wildcards is allowed like this: *.foo.com matches
+                                everything under foo.com. foo.com only matches foo.com,
+                                so to cover foo.com and everything under it, you must
+                                specify *both*."
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                            includeSubDomainsPolicy:
+                              description: 'includeSubDomainsPolicy means the HSTS
+                                Policy should apply to any subdomains of the host''s
+                                domain name.  Thus, for the host bar.foo.com, if includeSubDomainsPolicy
+                                was set to RequireIncludeSubDomains: - the host app.bar.foo.com
+                                would inherit the HSTS Policy of bar.foo.com - the
+                                host bar.foo.com would inherit the HSTS Policy of
+                                bar.foo.com - the host foo.com would NOT inherit the
+                                HSTS Policy of bar.foo.com - the host def.foo.com
+                                would NOT inherit the HSTS Policy of bar.foo.com'
+                              enum:
+                              - RequireIncludeSubDomains
+                              - RequireNoIncludeSubDomains
+                              - NoOpinion
+                              type: string
+                            maxAge:
+                              description: maxAge is the delta time range in seconds
+                                during which hosts are regarded as HSTS hosts. If
+                                set to 0, it negates the effect, and hosts are removed
+                                as HSTS hosts. If set to 0 and includeSubdomains is
+                                specified, all subdomains of the host are also removed
+                                as HSTS hosts. maxAge is a time-to-live value, and
+                                if this policy is not refreshed on a client, the HSTS
+                                policy will eventually expire on that client.
+                              properties:
+                                largestMaxAge:
+                                  description: The largest allowed value (in seconds)
+                                    of the RequiredHSTSPolicy max-age This value can
+                                    be left unspecified, in which case no upper limit
+                                    is enforced.
+                                  format: int32
+                                  maximum: 2147483647
+                                  minimum: 0
+                                  type: integer
+                                smallestMaxAge:
+                                  description: The smallest allowed value (in seconds)
+                                    of the RequiredHSTSPolicy max-age Setting max-age=0
+                                    allows the deletion of an existing HSTS header
+                                    from a host.  This is a necessary tool for administrators
+                                    to quickly correct mistakes. This value can be
+                                    left unspecified, in which case no lower limit
+                                    is enforced.
+                                  format: int32
+                                  maximum: 2147483647
+                                  minimum: 0
+                                  type: integer
+                              type: object
+                            namespaceSelector:
+                              description: namespaceSelector specifies a label selector
+                                such that the policy applies only to those routes
+                                that are in namespaces with labels that match the
+                                selector, and are in one of the DomainPatterns. Defaults
+                                to the empty LabelSelector, which matches everything.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            preloadPolicy:
+                              description: preloadPolicy directs the client to include
+                                hosts in its host preload list so that it never needs
+                                to do an initial load to get the HSTS header (note
+                                that this is not defined in RFC 6797 and is therefore
+                                client implementation-dependent).
+                              enum:
+                              - RequirePreload
+                              - RequireNoPreload
+                              - NoOpinion
+                              type: string
+                          required:
+                          - domainPatterns
+                          type: object
+                        type: array
+                    type: object
+                  items:
+                    description: "Items embeds the serialized configuration resources.
+                      \n Deprecated This field is deprecated and will be removed in
+                      a future release"
+                    items:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    type: array
+                    x-kubernetes-preserve-unknown-fields: true
+                  network:
+                    description: 'Network holds cluster-wide information about the
+                      network. It is used to configure the desired network configuration,
+                      such as: IP address pools for services/pod IPs, network plugin,
+                      etc. Please view network.spec for an explanation on what applies
+                      when configuring this resource. TODO (csrwng): Add validation
+                      here to exclude changes that conflict with networking settings
+                      in the HostedCluster.Spec.Networking field.'
+                    properties:
+                      clusterNetwork:
+                        description: IP address pool to use for pod IPs. This field
+                          is immutable after installation.
+                        items:
+                          description: ClusterNetworkEntry is a contiguous block of
+                            IP addresses from which pod IPs are allocated.
+                          properties:
+                            cidr:
+                              description: The complete block for pod IPs.
+                              type: string
+                            hostPrefix:
+                              description: The size (prefix) of block to allocate
+                                to each node. If this field is not used by the plugin,
+                                it can be left unset.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                          type: object
+                        type: array
+                      externalIP:
+                        description: externalIP defines configuration for controllers
+                          that affect Service.ExternalIP. If nil, then ExternalIP
+                          is not allowed to be set.
+                        properties:
+                          autoAssignCIDRs:
+                            description: autoAssignCIDRs is a list of CIDRs from which
+                              to automatically assign Service.ExternalIP. These are
+                              assigned when the service is of type LoadBalancer. In
+                              general, this is only useful for bare-metal clusters.
+                              In Openshift 3.x, this was misleadingly called "IngressIPs".
+                              Automatically assigned External IPs are not affected
+                              by any ExternalIPPolicy rules. Currently, only one entry
+                              may be provided.
+                            items:
+                              type: string
+                            type: array
+                          policy:
+                            description: policy is a set of restrictions applied to
+                              the ExternalIP field. If nil or empty, then ExternalIP
+                              is not allowed to be set.
+                            properties:
+                              allowedCIDRs:
+                                description: allowedCIDRs is the list of allowed CIDRs.
+                                items:
+                                  type: string
+                                type: array
+                              rejectedCIDRs:
+                                description: rejectedCIDRs is the list of disallowed
+                                  CIDRs. These take precedence over allowedCIDRs.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      networkType:
+                        description: 'NetworkType is the plugin that is to be deployed
+                          (e.g. OpenShiftSDN). This should match a value that the
+                          cluster-network-operator understands, or else no networking
+                          will be installed. Currently supported values are: - OpenShiftSDN
+                          This field is immutable after installation.'
+                        type: string
+                      serviceNetwork:
+                        description: IP address pool for services. Currently, we only
+                          support a single entry here. This field is immutable after
+                          installation.
+                        items:
+                          type: string
+                        type: array
+                      serviceNodePortRange:
+                        description: The port range allowed for Services of type NodePort.
+                          If not specified, the default of 30000-32767 will be used.
+                          Such Services without a NodePort specified will have one
+                          automatically allocated from this range. This parameter
+                          can be updated after the cluster is installed.
+                        pattern: ^([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])-([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
+                        type: string
+                    type: object
+                  oauth:
+                    description: OAuth holds cluster-wide information about OAuth.
+                      It is used to configure the integrated OAuth server. This configuration
+                      is only honored when the top level Authentication config has
+                      type set to IntegratedOAuth.
+                    properties:
+                      identityProviders:
+                        description: identityProviders is an ordered list of ways
+                          for a user to identify themselves. When this list is empty,
+                          no identities are provisioned for users.
+                        items:
+                          description: IdentityProvider provides identities for users
+                            authenticating using credentials
+                          properties:
+                            basicAuth:
+                              description: basicAuth contains configuration options
+                                for the BasicAuth IdP
+                              properties:
+                                ca:
+                                  description: ca is an optional reference to a config
+                                    map by name containing the PEM-encoded CA bundle.
+                                    It is used as a trust anchor to validate the TLS
+                                    certificate presented by the remote server. The
+                                    key "ca.crt" is used to locate the data. If specified
+                                    and the config map or expected key is not found,
+                                    the identity provider is not honored. If the specified
+                                    ca data is not valid, the identity provider is
+                                    not honored. If empty, the default system roots
+                                    are used. The namespace for this config map is
+                                    openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced config map
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                tlsClientCert:
+                                  description: tlsClientCert is an optional reference
+                                    to a secret by name that contains the PEM-encoded
+                                    TLS client certificate to present when connecting
+                                    to the server. The key "tls.crt" is used to locate
+                                    the data. If specified and the secret or expected
+                                    key is not found, the identity provider is not
+                                    honored. If the specified certificate data is
+                                    not valid, the identity provider is not honored.
+                                    The namespace for this secret is openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced secret
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                tlsClientKey:
+                                  description: tlsClientKey is an optional reference
+                                    to a secret by name that contains the PEM-encoded
+                                    TLS private key for the client certificate referenced
+                                    in tlsClientCert. The key "tls.key" is used to
+                                    locate the data. If specified and the secret or
+                                    expected key is not found, the identity provider
+                                    is not honored. If the specified certificate data
+                                    is not valid, the identity provider is not honored.
+                                    The namespace for this secret is openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced secret
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                url:
+                                  description: url is the remote URL to connect to
+                                  type: string
+                              type: object
+                            github:
+                              description: github enables user authentication using
+                                GitHub credentials
+                              properties:
+                                ca:
+                                  description: ca is an optional reference to a config
+                                    map by name containing the PEM-encoded CA bundle.
+                                    It is used as a trust anchor to validate the TLS
+                                    certificate presented by the remote server. The
+                                    key "ca.crt" is used to locate the data. If specified
+                                    and the config map or expected key is not found,
+                                    the identity provider is not honored. If the specified
+                                    ca data is not valid, the identity provider is
+                                    not honored. If empty, the default system roots
+                                    are used. This can only be configured when hostname
+                                    is set to a non-empty value. The namespace for
+                                    this config map is openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced config map
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                clientID:
+                                  description: clientID is the oauth client ID
+                                  type: string
+                                clientSecret:
+                                  description: clientSecret is a required reference
+                                    to the secret by name containing the oauth client
+                                    secret. The key "clientSecret" is used to locate
+                                    the data. If the secret or expected key is not
+                                    found, the identity provider is not honored. The
+                                    namespace for this secret is openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced secret
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                hostname:
+                                  description: hostname is the optional domain (e.g.
+                                    "mycompany.com") for use with a hosted instance
+                                    of GitHub Enterprise. It must match the GitHub
+                                    Enterprise settings value configured at /setup/settings#hostname.
+                                  type: string
+                                organizations:
+                                  description: organizations optionally restricts
+                                    which organizations are allowed to log in
+                                  items:
+                                    type: string
+                                  type: array
+                                teams:
+                                  description: teams optionally restricts which teams
+                                    are allowed to log in. Format is <org>/<team>.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            gitlab:
+                              description: gitlab enables user authentication using
+                                GitLab credentials
+                              properties:
+                                ca:
+                                  description: ca is an optional reference to a config
+                                    map by name containing the PEM-encoded CA bundle.
+                                    It is used as a trust anchor to validate the TLS
+                                    certificate presented by the remote server. The
+                                    key "ca.crt" is used to locate the data. If specified
+                                    and the config map or expected key is not found,
+                                    the identity provider is not honored. If the specified
+                                    ca data is not valid, the identity provider is
+                                    not honored. If empty, the default system roots
+                                    are used. The namespace for this config map is
+                                    openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced config map
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                clientID:
+                                  description: clientID is the oauth client ID
+                                  type: string
+                                clientSecret:
+                                  description: clientSecret is a required reference
+                                    to the secret by name containing the oauth client
+                                    secret. The key "clientSecret" is used to locate
+                                    the data. If the secret or expected key is not
+                                    found, the identity provider is not honored. The
+                                    namespace for this secret is openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced secret
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                url:
+                                  description: url is the oauth server base URL
+                                  type: string
+                              type: object
+                            google:
+                              description: google enables user authentication using
+                                Google credentials
+                              properties:
+                                clientID:
+                                  description: clientID is the oauth client ID
+                                  type: string
+                                clientSecret:
+                                  description: clientSecret is a required reference
+                                    to the secret by name containing the oauth client
+                                    secret. The key "clientSecret" is used to locate
+                                    the data. If the secret or expected key is not
+                                    found, the identity provider is not honored. The
+                                    namespace for this secret is openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced secret
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                hostedDomain:
+                                  description: hostedDomain is the optional Google
+                                    App domain (e.g. "mycompany.com") to restrict
+                                    logins to
+                                  type: string
+                              type: object
+                            htpasswd:
+                              description: htpasswd enables user authentication using
+                                an HTPasswd file to validate credentials
+                              properties:
+                                fileData:
+                                  description: fileData is a required reference to
+                                    a secret by name containing the data to use as
+                                    the htpasswd file. The key "htpasswd" is used
+                                    to locate the data. If the secret or expected
+                                    key is not found, the identity provider is not
+                                    honored. If the specified htpasswd data is not
+                                    valid, the identity provider is not honored. The
+                                    namespace for this secret is openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced secret
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                              type: object
+                            keystone:
+                              description: keystone enables user authentication using
+                                keystone password credentials
+                              properties:
+                                ca:
+                                  description: ca is an optional reference to a config
+                                    map by name containing the PEM-encoded CA bundle.
+                                    It is used as a trust anchor to validate the TLS
+                                    certificate presented by the remote server. The
+                                    key "ca.crt" is used to locate the data. If specified
+                                    and the config map or expected key is not found,
+                                    the identity provider is not honored. If the specified
+                                    ca data is not valid, the identity provider is
+                                    not honored. If empty, the default system roots
+                                    are used. The namespace for this config map is
+                                    openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced config map
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                domainName:
+                                  description: domainName is required for keystone
+                                    v3
+                                  type: string
+                                tlsClientCert:
+                                  description: tlsClientCert is an optional reference
+                                    to a secret by name that contains the PEM-encoded
+                                    TLS client certificate to present when connecting
+                                    to the server. The key "tls.crt" is used to locate
+                                    the data. If specified and the secret or expected
+                                    key is not found, the identity provider is not
+                                    honored. If the specified certificate data is
+                                    not valid, the identity provider is not honored.
+                                    The namespace for this secret is openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced secret
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                tlsClientKey:
+                                  description: tlsClientKey is an optional reference
+                                    to a secret by name that contains the PEM-encoded
+                                    TLS private key for the client certificate referenced
+                                    in tlsClientCert. The key "tls.key" is used to
+                                    locate the data. If specified and the secret or
+                                    expected key is not found, the identity provider
+                                    is not honored. If the specified certificate data
+                                    is not valid, the identity provider is not honored.
+                                    The namespace for this secret is openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced secret
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                url:
+                                  description: url is the remote URL to connect to
+                                  type: string
+                              type: object
+                            ldap:
+                              description: ldap enables user authentication using
+                                LDAP credentials
+                              properties:
+                                attributes:
+                                  description: attributes maps LDAP attributes to
+                                    identities
+                                  properties:
+                                    email:
+                                      description: email is the list of attributes
+                                        whose values should be used as the email address.
+                                        Optional. If unspecified, no email is set
+                                        for the identity
+                                      items:
+                                        type: string
+                                      type: array
+                                    id:
+                                      description: id is the list of attributes whose
+                                        values should be used as the user ID. Required.
+                                        First non-empty attribute is used. At least
+                                        one attribute is required. If none of the
+                                        listed attribute have a value, authentication
+                                        fails. LDAP standard identity attribute is
+                                        "dn"
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: name is the list of attributes
+                                        whose values should be used as the display
+                                        name. Optional. If unspecified, no display
+                                        name is set for the identity LDAP standard
+                                        display name attribute is "cn"
+                                      items:
+                                        type: string
+                                      type: array
+                                    preferredUsername:
+                                      description: preferredUsername is the list of
+                                        attributes whose values should be used as
+                                        the preferred username. LDAP standard login
+                                        attribute is "uid"
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                bindDN:
+                                  description: bindDN is an optional DN to bind with
+                                    during the search phase.
+                                  type: string
+                                bindPassword:
+                                  description: bindPassword is an optional reference
+                                    to a secret by name containing a password to bind
+                                    with during the search phase. The key "bindPassword"
+                                    is used to locate the data. If specified and the
+                                    secret or expected key is not found, the identity
+                                    provider is not honored. The namespace for this
+                                    secret is openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced secret
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                ca:
+                                  description: ca is an optional reference to a config
+                                    map by name containing the PEM-encoded CA bundle.
+                                    It is used as a trust anchor to validate the TLS
+                                    certificate presented by the remote server. The
+                                    key "ca.crt" is used to locate the data. If specified
+                                    and the config map or expected key is not found,
+                                    the identity provider is not honored. If the specified
+                                    ca data is not valid, the identity provider is
+                                    not honored. If empty, the default system roots
+                                    are used. The namespace for this config map is
+                                    openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced config map
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                insecure:
+                                  description: 'insecure, if true, indicates the connection
+                                    should not use TLS WARNING: Should not be set
+                                    to `true` with the URL scheme "ldaps://" as "ldaps://"
+                                    URLs always attempt to connect using TLS, even
+                                    when `insecure` is set to `true` When `true`,
+                                    "ldap://" URLS connect insecurely. When `false`,
+                                    "ldap://" URLs are upgraded to a TLS connection
+                                    using StartTLS as specified in https://tools.ietf.org/html/rfc2830.'
+                                  type: boolean
+                                url:
+                                  description: 'url is an RFC 2255 URL which specifies
+                                    the LDAP search parameters to use. The syntax
+                                    of the URL is: ldap://host:port/basedn?attribute?scope?filter'
+                                  type: string
+                              type: object
+                            mappingMethod:
+                              description: mappingMethod determines how identities
+                                from this provider are mapped to users Defaults to
+                                "claim"
+                              type: string
+                            name:
+                              description: 'name is used to qualify the identities
+                                returned by this provider. - It MUST be unique and
+                                not shared by any other identity provider used - It
+                                MUST be a valid path segment: name cannot equal "."
+                                or ".." or contain "/" or "%" or ":" Ref: https://godoc.org/github.com/openshift/origin/pkg/user/apis/user/validation#ValidateIdentityProviderName'
+                              type: string
+                            openID:
+                              description: openID enables user authentication using
+                                OpenID credentials
+                              properties:
+                                ca:
+                                  description: ca is an optional reference to a config
+                                    map by name containing the PEM-encoded CA bundle.
+                                    It is used as a trust anchor to validate the TLS
+                                    certificate presented by the remote server. The
+                                    key "ca.crt" is used to locate the data. If specified
+                                    and the config map or expected key is not found,
+                                    the identity provider is not honored. If the specified
+                                    ca data is not valid, the identity provider is
+                                    not honored. If empty, the default system roots
+                                    are used. The namespace for this config map is
+                                    openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced config map
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                claims:
+                                  description: claims mappings
+                                  properties:
+                                    email:
+                                      description: email is the list of claims whose
+                                        values should be used as the email address.
+                                        Optional. If unspecified, no email is set
+                                        for the identity
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    groups:
+                                      description: groups is the list of claims value
+                                        of which should be used to synchronize groups
+                                        from the OIDC provider to OpenShift for the
+                                        user. If multiple claims are specified, the
+                                        first one with a non-empty value is used.
+                                      items:
+                                        description: OpenIDClaim represents a claim
+                                          retrieved from an OpenID provider's tokens
+                                          or userInfo responses
+                                        minLength: 1
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    name:
+                                      description: name is the list of claims whose
+                                        values should be used as the display name.
+                                        Optional. If unspecified, no display name
+                                        is set for the identity
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    preferredUsername:
+                                      description: preferredUsername is the list of
+                                        claims whose values should be used as the
+                                        preferred username. If unspecified, the preferred
+                                        username is determined from the value of the
+                                        sub claim
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                clientID:
+                                  description: clientID is the oauth client ID
+                                  type: string
+                                clientSecret:
+                                  description: clientSecret is a required reference
+                                    to the secret by name containing the oauth client
+                                    secret. The key "clientSecret" is used to locate
+                                    the data. If the secret or expected key is not
+                                    found, the identity provider is not honored. The
+                                    namespace for this secret is openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced secret
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                extraAuthorizeParameters:
+                                  additionalProperties:
+                                    type: string
+                                  description: extraAuthorizeParameters are any custom
+                                    parameters to add to the authorize request.
+                                  type: object
+                                extraScopes:
+                                  description: extraScopes are any scopes to request
+                                    in addition to the standard "openid" scope.
+                                  items:
+                                    type: string
+                                  type: array
+                                issuer:
+                                  description: issuer is the URL that the OpenID Provider
+                                    asserts as its Issuer Identifier. It must use
+                                    the https scheme with no query or fragment component.
+                                  type: string
+                              type: object
+                            requestHeader:
+                              description: requestHeader enables user authentication
+                                using request header credentials
+                              properties:
+                                ca:
+                                  description: ca is a required reference to a config
+                                    map by name containing the PEM-encoded CA bundle.
+                                    It is used as a trust anchor to validate the TLS
+                                    certificate presented by the remote server. Specifically,
+                                    it allows verification of incoming requests to
+                                    prevent header spoofing. The key "ca.crt" is used
+                                    to locate the data. If the config map or expected
+                                    key is not found, the identity provider is not
+                                    honored. If the specified ca data is not valid,
+                                    the identity provider is not honored. The namespace
+                                    for this config map is openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced config map
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                challengeURL:
+                                  description: challengeURL is a URL to redirect unauthenticated
+                                    /authorize requests to Unauthenticated requests
+                                    from OAuth clients which expect WWW-Authenticate
+                                    challenges will be redirected here. ${url} is
+                                    replaced with the current URL, escaped to be safe
+                                    in a query parameter https://www.example.com/sso-login?then=${url}
+                                    ${query} is replaced with the current query string
+                                    https://www.example.com/auth-proxy/oauth/authorize?${query}
+                                    Required when challenge is set to true.
+                                  type: string
+                                clientCommonNames:
+                                  description: clientCommonNames is an optional list
+                                    of common names to require a match from. If empty,
+                                    any client certificate validated against the clientCA
+                                    bundle is considered authoritative.
+                                  items:
+                                    type: string
+                                  type: array
+                                emailHeaders:
+                                  description: emailHeaders is the set of headers
+                                    to check for the email address
+                                  items:
+                                    type: string
+                                  type: array
+                                headers:
+                                  description: headers is the set of headers to check
+                                    for identity information
+                                  items:
+                                    type: string
+                                  type: array
+                                loginURL:
+                                  description: loginURL is a URL to redirect unauthenticated
+                                    /authorize requests to Unauthenticated requests
+                                    from OAuth clients which expect interactive logins
+                                    will be redirected here ${url} is replaced with
+                                    the current URL, escaped to be safe in a query
+                                    parameter https://www.example.com/sso-login?then=${url}
+                                    ${query} is replaced with the current query string
+                                    https://www.example.com/auth-proxy/oauth/authorize?${query}
+                                    Required when login is set to true.
+                                  type: string
+                                nameHeaders:
+                                  description: nameHeaders is the set of headers to
+                                    check for the display name
+                                  items:
+                                    type: string
+                                  type: array
+                                preferredUsernameHeaders:
+                                  description: preferredUsernameHeaders is the set
+                                    of headers to check for the preferred username
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            type:
+                              description: type identifies the identity provider type
+                                for this entry.
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      templates:
+                        description: templates allow you to customize pages like the
+                          login page.
+                        properties:
+                          error:
+                            description: error is the name of a secret that specifies
+                              a go template to use to render error pages during the
+                              authentication or grant flow. The key "errors.html"
+                              is used to locate the template data. If specified and
+                              the secret or expected key is not found, the default
+                              error page is used. If the specified template is not
+                              valid, the default error page is used. If unspecified,
+                              the default error page is used. The namespace for this
+                              secret is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          login:
+                            description: login is the name of a secret that specifies
+                              a go template to use to render the login page. The key
+                              "login.html" is used to locate the template data. If
+                              specified and the secret or expected key is not found,
+                              the default login page is used. If the specified template
+                              is not valid, the default login page is used. If unspecified,
+                              the default login page is used. The namespace for this
+                              secret is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          providerSelection:
+                            description: providerSelection is the name of a secret
+                              that specifies a go template to use to render the provider
+                              selection page. The key "providers.html" is used to
+                              locate the template data. If specified and the secret
+                              or expected key is not found, the default provider selection
+                              page is used. If the specified template is not valid,
+                              the default provider selection page is used. If unspecified,
+                              the default provider selection page is used. The namespace
+                              for this secret is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        type: object
+                      tokenConfig:
+                        description: tokenConfig contains options for authorization
+                          and access tokens
+                        properties:
+                          accessTokenInactivityTimeout:
+                            description: "accessTokenInactivityTimeout defines the
+                              token inactivity timeout for tokens granted by any client.
+                              The value represents the maximum amount of time that
+                              can occur between consecutive uses of the token. Tokens
+                              become invalid if they are not used within this temporal
+                              window. The user will need to acquire a new token to
+                              regain access once a token times out. Takes valid time
+                              duration string such as \"5m\", \"1.5h\" or \"2h45m\".
+                              The minimum allowed value for duration is 300s (5 minutes).
+                              If the timeout is configured per client, then that value
+                              takes precedence. If the timeout value is not specified
+                              and the client does not override the value, then tokens
+                              are valid until their lifetime. \n WARNING: existing
+                              tokens' timeout will not be affected (lowered) by changing
+                              this value"
+                            type: string
+                          accessTokenInactivityTimeoutSeconds:
+                            description: 'accessTokenInactivityTimeoutSeconds - DEPRECATED:
+                              setting this field has no effect.'
+                            format: int32
+                            type: integer
+                          accessTokenMaxAgeSeconds:
+                            description: accessTokenMaxAgeSeconds defines the maximum
+                              age of access tokens
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                  operatorhub:
+                    description: OperatorHub specifies the configuration for the Operator
+                      Lifecycle Manager in the HostedCluster. This is only configured
+                      at deployment time but the controller are not reconcilling over
+                      it. The OperatorHub configuration will be constantly reconciled
+                      if catalog placement is management, but only on cluster creation
+                      otherwise.
+                    properties:
+                      disableAllDefaultSources:
+                        description: disableAllDefaultSources allows you to disable
+                          all the default hub sources. If this is true, a specific
+                          entry in sources can be used to enable a default source.
+                          If this is false, a specific entry in sources can be used
+                          to disable or enable a default source.
+                        type: boolean
+                      sources:
+                        description: sources is the list of default hub sources and
+                          their configuration. If the list is empty, it implies that
+                          the default hub sources are enabled on the cluster unless
+                          disableAllDefaultSources is true. If disableAllDefaultSources
+                          is true and sources is not empty, the configuration present
+                          in sources will take precedence. The list of default hub
+                          sources and their current state will always be reflected
+                          in the status block.
+                        items:
+                          description: HubSource is used to specify the hub source
+                            and its configuration
+                          properties:
+                            disabled:
+                              description: disabled is used to disable a default hub
+                                source on cluster
+                              type: boolean
+                            name:
+                              description: name is the name of one of the default
+                                hub sources
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  proxy:
+                    description: Proxy holds cluster-wide information on how to configure
+                      default proxies for the cluster.
+                    properties:
+                      httpProxy:
+                        description: httpProxy is the URL of the proxy for HTTP requests.  Empty
+                          means unset and will not result in an env var.
+                        type: string
+                      httpsProxy:
+                        description: httpsProxy is the URL of the proxy for HTTPS
+                          requests.  Empty means unset and will not result in an env
+                          var.
+                        type: string
+                      noProxy:
+                        description: noProxy is a comma-separated list of hostnames
+                          and/or CIDRs and/or IPs for which the proxy should not be
+                          used. Empty means unset and will not result in an env var.
+                        type: string
+                      readinessEndpoints:
+                        description: readinessEndpoints is a list of endpoints used
+                          to verify readiness of the proxy.
+                        items:
+                          type: string
+                        type: array
+                      trustedCA:
+                        description: "trustedCA is a reference to a ConfigMap containing
+                          a CA certificate bundle. The trustedCA field should only
+                          be consumed by a proxy validator. The validator is responsible
+                          for reading the certificate bundle from the required key
+                          \"ca-bundle.crt\", merging it with the system default trust
+                          bundle, and writing the merged trust bundle to a ConfigMap
+                          named \"trusted-ca-bundle\" in the \"openshift-config-managed\"
+                          namespace. Clients that expect to make proxy connections
+                          must use the trusted-ca-bundle for all HTTPS requests to
+                          the proxy, and may use the trusted-ca-bundle for non-proxy
+                          HTTPS requests as well. \n The namespace for the ConfigMap
+                          referenced by trustedCA is \"openshift-config\". Here is
+                          an example ConfigMap (in yaml): \n apiVersion: v1 kind:
+                          ConfigMap metadata: name: user-ca-bundle namespace: openshift-config
+                          data: ca-bundle.crt: | -----BEGIN CERTIFICATE----- Custom
+                          CA certificate bundle. -----END CERTIFICATE-----"
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    type: object
+                  scheduler:
+                    description: Scheduler holds cluster-wide config information to
+                      run the Kubernetes Scheduler and influence its placement decisions.
+                      The canonical name for this config is `cluster`.
+                    properties:
+                      defaultNodeSelector:
+                        description: 'defaultNodeSelector helps set the cluster-wide
+                          default node selector to restrict pod placement to specific
+                          nodes. This is applied to the pods created in all namespaces
+                          and creates an intersection with any existing nodeSelectors
+                          already set on a pod, additionally constraining that pod''s
+                          selector. For example, defaultNodeSelector: "type=user-node,region=east"
+                          would set nodeSelector field in pod spec to "type=user-node,region=east"
+                          to all pods created in all namespaces. Namespaces having
+                          project-wide node selectors won''t be impacted even if this
+                          field is set. This adds an annotation section to the namespace.
+                          For example, if a new namespace is created with node-selector=''type=user-node,region=east'',
+                          the annotation openshift.io/node-selector: type=user-node,region=east
+                          gets added to the project. When the openshift.io/node-selector
+                          annotation is set on the project the value is used in preference
+                          to the value we are setting for defaultNodeSelector field.
+                          For instance, openshift.io/node-selector: "type=user-node,region=west"
+                          means that the default of "type=user-node,region=east" set
+                          in defaultNodeSelector would not be applied.'
+                        type: string
+                      mastersSchedulable:
+                        description: 'MastersSchedulable allows masters nodes to be
+                          schedulable. When this flag is turned on, all the master
+                          nodes in the cluster will be made schedulable, so that workload
+                          pods can run on them. The default value for this field is
+                          false, meaning none of the master nodes are schedulable.
+                          Important Note: Once the workload pods start running on
+                          the master nodes, extreme care must be taken to ensure that
+                          cluster-critical control plane components are not impacted.
+                          Please turn on this field after doing due diligence.'
+                        type: boolean
+                      policy:
+                        description: 'DEPRECATED: the scheduler Policy API has been
+                          deprecated and will be removed in a future release. policy
+                          is a reference to a ConfigMap containing scheduler policy
+                          which has user specified predicates and priorities. If this
+                          ConfigMap is not available scheduler will default to use
+                          DefaultAlgorithmProvider. The namespace for this configmap
+                          is openshift-config.'
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      profile:
+                        description: "profile sets which scheduling profile should
+                          be set in order to configure scheduling decisions for new
+                          pods. \n Valid values are \"LowNodeUtilization\", \"HighNodeUtilization\",
+                          \"NoScoring\" Defaults to \"LowNodeUtilization\""
+                        enum:
+                        - ""
+                        - LowNodeUtilization
+                        - HighNodeUtilization
+                        - NoScoring
+                        type: string
+                    type: object
+                  secretRefs:
+                    description: "SecretRefs holds references to any secrets referenced
+                      by configuration entries. Entries can reference the secrets
+                      using local object references. \n Deprecated This field is deprecated
+                      and will be removed in a future release"
+                    items:
+                      description: LocalObjectReference contains enough information
+                        to let you locate the referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                type: object
+              controlPlaneRelease:
+                description: ControlPlaneRelease specifies the desired OCP release
+                  payload for control plane components running on the management cluster.
+                  Updating this field will trigger a rollout of the control plane.
+                  The behavior of the rollout will be driven by the ControllerAvailabilityPolicy
+                  and InfrastructureAvailabilityPolicy. If not defined, Release is
+                  used
+                properties:
+                  image:
+                    description: Image is the image pullspec of an OCP release payload
+                      image.
+                    pattern: ^(\w+\S+)$
+                    type: string
+                required:
+                - image
+                type: object
+              controllerAvailabilityPolicy:
+                default: SingleReplica
+                description: ControllerAvailabilityPolicy specifies the availability
+                  policy applied to critical control plane components. The default
+                  value is SingleReplica.
+                type: string
+              dns:
+                description: DNS specifies DNS configuration for the cluster.
+                properties:
+                  baseDomain:
+                    description: BaseDomain is the base domain of the cluster.
+                    type: string
+                  baseDomainPrefix:
+                    description: BaseDomainPrefix is the base domain prefix of the
+                      cluster. defaults to clusterName if not set
+                    type: string
+                  privateZoneID:
+                    description: PrivateZoneID is the Hosted Zone ID where all the
+                      DNS records that are only available internally to the cluster
+                      exist.
+                    type: string
+                  publicZoneID:
+                    description: PublicZoneID is the Hosted Zone ID where all the
+                      DNS records that are publicly accessible to the internet exist.
+                    type: string
+                required:
+                - baseDomain
+                type: object
+              etcd:
+                default:
+                  managed:
+                    storage:
+                      persistentVolume:
+                        size: 4Gi
+                      type: PersistentVolume
+                  managementType: Managed
+                description: Etcd specifies configuration for the control plane etcd
+                  cluster. The default ManagementType is Managed. Once set, the ManagementType
+                  cannot be changed.
+                properties:
+                  managed:
+                    description: Managed specifies the behavior of an etcd cluster
+                      managed by HyperShift.
+                    properties:
+                      storage:
+                        description: Storage specifies how etcd data is persisted.
+                        properties:
+                          persistentVolume:
+                            description: PersistentVolume is the configuration for
+                              PersistentVolume etcd storage. With this implementation,
+                              a PersistentVolume will be allocated for every etcd
+                              member (either 1 or 3 depending on the HostedCluster
+                              control plane availability configuration).
+                            properties:
+                              size:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                default: 8Gi
+                                description: Size is the minimum size of the data
+                                  volume for each etcd member.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                                x-kubernetes-validations:
+                                - message: Etcd PV storage size is immutable
+                                  rule: self == oldSelf
+                              storageClassName:
+                                description: "StorageClassName is the StorageClass
+                                  of the data volume for each etcd member. \n See
+                                  https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1."
+                                type: string
+                            type: object
+                          restoreSnapshotURL:
+                            description: RestoreSnapshotURL allows an optional URL
+                              to be provided where an etcd snapshot can be downloaded,
+                              for example a pre-signed URL referencing a storage service.
+                              This snapshot will be restored on initial startup, only
+                              when the etcd PV is empty.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-validations:
+                            - message: RestoreSnapshotURL shouldn't contain more than
+                                1 entry
+                              rule: self.size() <= 1
+                          type:
+                            description: Type is the kind of persistent storage implementation
+                              to use for etcd.
+                            enum:
+                            - PersistentVolume
+                            type: string
+                        required:
+                        - type
+                        type: object
+                    required:
+                    - storage
+                    type: object
+                  managementType:
+                    description: ManagementType defines how the etcd cluster is managed.
+                    enum:
+                    - Managed
+                    - Unmanaged
+                    type: string
+                  unmanaged:
+                    description: Unmanaged specifies configuration which enables the
+                      control plane to integrate with an eternally managed etcd cluster.
+                    properties:
+                      endpoint:
+                        description: "Endpoint is the full etcd cluster client endpoint
+                          URL. For example: \n https://etcd-client:2379 \n If the
+                          URL uses an HTTPS scheme, the TLS field is required."
+                        pattern: ^https://
+                        type: string
+                      tls:
+                        description: TLS specifies TLS configuration for HTTPS etcd
+                          client endpoints.
+                        properties:
+                          clientSecret:
+                            description: "ClientSecret refers to a secret for client
+                              mTLS authentication with the etcd cluster. It may have
+                              the following key/value pairs: \n etcd-client-ca.crt:
+                              Certificate Authority value etcd-client.crt: Client
+                              certificate value etcd-client.key: Client certificate
+                              key value"
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        required:
+                        - clientSecret
+                        type: object
+                    required:
+                    - endpoint
+                    - tls
+                    type: object
+                required:
+                - managementType
+                type: object
+              fips:
+                description: FIPS indicates whether this cluster's nodes will be running
+                  in FIPS mode. If set to true, the control plane's ignition server
+                  will be configured to expect that nodes joining the cluster will
+                  be FIPS-enabled.
+                type: boolean
+              imageContentSources:
+                description: ImageContentSources specifies image mirrors that can
+                  be used by cluster nodes to pull content.
+                items:
+                  description: ImageContentSource specifies image mirrors that can
+                    be used by cluster nodes to pull content. For cluster workloads,
+                    if a container image registry host of the pullspec matches Source
+                    then one of the Mirrors are substituted as hosts in the pullspec
+                    and tried in order to fetch the image.
+                  properties:
+                    mirrors:
+                      description: Mirrors are one or more repositories that may also
+                        contain the same images.
+                      items:
+                        type: string
+                      type: array
+                    source:
+                      description: Source is the repository that users refer to, e.g.
+                        in image pull specifications.
+                      type: string
+                  required:
+                  - source
+                  type: object
+                type: array
+              infraID:
+                description: InfraID is a globally unique identifier for the cluster.
+                  This identifier will be used to associate various cloud resources
+                  with the HostedCluster and its associated NodePools.
+                type: string
+              infrastructureAvailabilityPolicy:
+                default: SingleReplica
+                description: InfrastructureAvailabilityPolicy specifies the availability
+                  policy applied to infrastructure services which run on cluster nodes.
+                  The default value is SingleReplica.
+                type: string
+              issuerURL:
+                default: https://kubernetes.default.svc
+                description: IssuerURL is an OIDC issuer URL which is used as the
+                  issuer in all ServiceAccount tokens generated by the control plane
+                  API server. The default value is kubernetes.default.svc, which only
+                  works for in-cluster validation.
+                format: uri
+                type: string
+              networking:
+                default:
+                  clusterNetwork:
+                  - cidr: 10.132.0.0/14
+                  networkType: OVNKubernetes
+                  serviceNetwork:
+                  - cidr: 172.31.0.0/16
+                description: Networking specifies network configuration for the cluster.
+                properties:
+                  apiServer:
+                    description: APIServer contains advanced network settings for
+                      the API server that affect how the APIServer is exposed inside
+                      a cluster node.
+                    properties:
+                      advertiseAddress:
+                        description: AdvertiseAddress is the address that nodes will
+                          use to talk to the API server. This is an address associated
+                          with the loopback adapter of each node. If not specified,
+                          172.20.0.1 is used.
+                        type: string
+                      allowedCIDRBlocks:
+                        description: AllowedCIDRBlocks is an allow list of CIDR blocks
+                          that can access the APIServer If not specified, traffic
+                          is allowed from all addresses. This depends on underlying
+                          support by the cloud provider for Service LoadBalancerSourceRanges
+                        items:
+                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          type: string
+                        type: array
+                      port:
+                        description: Port is the port at which the APIServer is exposed
+                          inside a node. Other pods using host networking cannot listen
+                          on this port. If not specified, 6443 is used.
+                        format: int32
+                        type: integer
+                    type: object
+                  clusterNetwork:
+                    default:
+                    - cidr: 10.132.0.0/14
+                    description: 'ClusterNetwork is the list of IP address pools for
+                      pods. TODO: make this required in the next version of the API'
+                    items:
+                      description: ClusterNetworkEntry is a single IP address block
+                        for pod IP blocks. IP blocks are allocated with size 2^HostSubnetLength.
+                      properties:
+                        cidr:
+                          description: CIDR is the IP block address pool.
+                          type: string
+                        hostPrefix:
+                          description: HostPrefix is the prefix size to allocate to
+                            each node from the CIDR. For example, 24 would allocate
+                            2^8=256 adresses to each node. If this field is not used
+                            by the plugin, it can be left unset.
+                          format: int32
+                          type: integer
+                      required:
+                      - cidr
+                      type: object
+                    type: array
+                  machineCIDR:
+                    description: Deprecated This field will be removed in the next
+                      API release. Use MachineNetwork instead
+                    format: cidr
+                    type: string
+                  machineNetwork:
+                    description: 'MachineNetwork is the list of IP address pools for
+                      machines. TODO: make this required in the next version of the
+                      API'
+                    items:
+                      description: MachineNetworkEntry is a single IP address block
+                        for node IP blocks.
+                      properties:
+                        cidr:
+                          description: CIDR is the IP block address pool for machines
+                            within the cluster.
+                          type: string
+                      required:
+                      - cidr
+                      type: object
+                    type: array
+                  networkType:
+                    default: OVNKubernetes
+                    description: NetworkType specifies the SDN provider used for cluster
+                      networking.
+                    enum:
+                    - OpenShiftSDN
+                    - Calico
+                    - OVNKubernetes
+                    - Other
+                    type: string
+                  podCIDR:
+                    description: Deprecated This field will be removed in the next
+                      API release. Use ClusterNetwork instead
+                    format: cidr
+                    type: string
+                  serviceCIDR:
+                    description: Deprecated This field will be removed in the next
+                      API release. Use ServiceNetwork instead
+                    format: cidr
+                    type: string
+                  serviceNetwork:
+                    default:
+                    - cidr: 172.31.0.0/16
+                    description: 'ServiceNetwork is the list of IP address pools for
+                      services. NOTE: currently only one entry is supported. TODO:
+                      make this required in the next version of the API'
+                    items:
+                      description: ServiceNetworkEntry is a single IP address block
+                        for the service network.
+                      properties:
+                        cidr:
+                          description: CIDR is the IP block address pool for services
+                            within the cluster.
+                          type: string
+                      required:
+                      - cidr
+                      type: object
+                    type: array
+                required:
+                - networkType
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector when specified, must be true for the pods
+                  managed by the HostedCluster to be scheduled.
+                type: object
+              olmCatalogPlacement:
+                default: management
+                description: OLMCatalogPlacement specifies the placement of OLM catalog
+                  components. By default, this is set to management and OLM catalog
+                  components are deployed onto the management cluster. If set to guest,
+                  the OLM catalog components will be deployed onto the guest cluster.
+                enum:
+                - management
+                - guest
+                type: string
+              pausedUntil:
+                description: 'PausedUntil is a field that can be used to pause reconciliation
+                  on a resource. Either a date can be provided in RFC3339 format or
+                  a boolean. If a date is provided: reconciliation is paused on the
+                  resource until that date. If the boolean true is provided: reconciliation
+                  is paused on the resource until the field is removed.'
+                type: string
+              platform:
+                description: Platform specifies the underlying infrastructure provider
+                  for the cluster and is used to configure platform specific behavior.
+                properties:
+                  agent:
+                    description: Agent specifies configuration for agent-based installations.
+                    properties:
+                      agentNamespace:
+                        description: AgentNamespace is the namespace where to search
+                          for Agents for this cluster
+                        type: string
+                    required:
+                    - agentNamespace
+                    type: object
+                  aws:
+                    description: AWS specifies configuration for clusters running
+                      on Amazon Web Services.
+                    properties:
+                      additionalAllowedPrincipals:
+                        description: AdditionalAllowedPrincipals specifies a list
+                          of additional allowed principal ARNs to be added to the
+                          hosted control plane's VPC Endpoint Service to enable additional
+                          VPC Endpoint connection requests to be automatically accepted.
+                          See https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html
+                          for more details around VPC Endpoint Service allowed principals.
+                        items:
+                          type: string
+                        type: array
+                      cloudProviderConfig:
+                        description: 'CloudProviderConfig specifies AWS networking
+                          configuration for the control plane. This is mainly used
+                          for cloud provider controller config: https://github.com/kubernetes/kubernetes/blob/f5be5052e3d0808abb904aebd3218fe4a5c2dd82/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go#L1347-L1364
+                          TODO(dan): should this be named AWSNetworkConfig?'
+                        properties:
+                          subnet:
+                            description: Subnet is the subnet to use for control plane
+                              cloud resources.
+                            properties:
+                              filters:
+                                description: 'Filters is a set of key/value pairs
+                                  used to identify a resource They are applied according
+                                  to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                                items:
+                                  description: Filter is a filter used to identify
+                                    an AWS resource
+                                  properties:
+                                    name:
+                                      description: Name of the filter. Filter names
+                                        are case-sensitive.
+                                      type: string
+                                    values:
+                                      description: Values includes one or more filter
+                                        values. Filter values are case-sensitive.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - name
+                                  - values
+                                  type: object
+                                type: array
+                              id:
+                                description: ID of resource
+                                type: string
+                            type: object
+                          vpc:
+                            description: VPC is the VPC to use for control plane cloud
+                              resources.
+                            type: string
+                          zone:
+                            description: Zone is the availability zone where control
+                              plane cloud resources are created.
+                            type: string
+                        required:
+                        - vpc
+                        type: object
+                      controlPlaneOperatorCreds:
+                        description: Deprecated This field will be removed in the
+                          next API release. Use RolesRef instead.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      endpointAccess:
+                        default: Public
+                        description: EndpointAccess specifies the publishing scope
+                          of cluster endpoints. The default is Public.
+                        enum:
+                        - Public
+                        - PublicAndPrivate
+                        - Private
+                        type: string
+                      kubeCloudControllerCreds:
+                        description: Deprecated This field will be removed in the
+                          next API release. Use RolesRef instead.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodePoolManagementCreds:
+                        description: Deprecated This field will be removed in the
+                          next API release. Use RolesRef instead.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      region:
+                        description: Region is the AWS region in which the cluster
+                          resides. This configures the OCP control plane cloud integrations,
+                          and is used by NodePool to resolve the correct boot AMI
+                          for a given release.
+                        type: string
+                      resourceTags:
+                        description: ResourceTags is a list of additional tags to
+                          apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html
+                          for information on tagging AWS resources. AWS supports a
+                          maximum of 50 tags per resource. OpenShift reserves 25 tags
+                          for its use, leaving 25 tags available for the user.
+                        items:
+                          description: AWSResourceTag is a tag to apply to AWS resources
+                            created for the cluster.
+                          properties:
+                            key:
+                              description: Key is the key of the tag.
+                              maxLength: 128
+                              minLength: 1
+                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                              type: string
+                            value:
+                              description: "Value is the value of the tag. \n Some
+                                AWS service do not support empty values. Since tags
+                                are added to resources in many services, the length
+                                of the tag value must meet the requirements of all
+                                services."
+                              maxLength: 256
+                              minLength: 1
+                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                              type: string
+                          required:
+                          - key
+                          - value
+                          type: object
+                        maxItems: 25
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
+                      roles:
+                        description: Deprecated This field will be removed in the
+                          next API release. Use RolesRef instead.
+                        items:
+                          properties:
+                            arn:
+                              type: string
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          required:
+                          - arn
+                          - name
+                          - namespace
+                          type: object
+                        type: array
+                      rolesRef:
+                        description: RolesRef contains references to various AWS IAM
+                          roles required to enable integrations such as OIDC.
+                        properties:
+                          controlPlaneOperatorARN:
+                            description: "ControlPlaneOperatorARN  is an ARN value
+                              referencing a role appropriate for the Control Plane
+                              Operator. \n The following is an example of a valid
+                              policy document: \n { \"Version\": \"2012-10-17\", \"Statement\":
+                              [ { \"Effect\": \"Allow\", \"Action\": [ \"ec2:CreateVpcEndpoint\",
+                              \"ec2:DescribeVpcEndpoints\", \"ec2:ModifyVpcEndpoint\",
+                              \"ec2:DeleteVpcEndpoints\", \"ec2:CreateTags\", \"route53:ListHostedZones\"
+                              ], \"Resource\": \"*\" }, { \"Effect\": \"Allow\", \"Action\":
+                              [ \"route53:ChangeResourceRecordSets\", \"route53:ListResourceRecordSets\"
+                              ], \"Resource\": \"arn:aws:route53:::%s\" } ] }"
+                            type: string
+                          imageRegistryARN:
+                            description: "ImageRegistryARN is an ARN value referencing
+                              a role appropriate for the Image Registry Operator.
+                              \n The following is an example of a valid policy document:
+                              \n { \"Version\": \"2012-10-17\", \"Statement\": [ {
+                              \"Effect\": \"Allow\", \"Action\": [ \"s3:CreateBucket\",
+                              \"s3:DeleteBucket\", \"s3:PutBucketTagging\", \"s3:GetBucketTagging\",
+                              \"s3:PutBucketPublicAccessBlock\", \"s3:GetBucketPublicAccessBlock\",
+                              \"s3:PutEncryptionConfiguration\", \"s3:GetEncryptionConfiguration\",
+                              \"s3:PutLifecycleConfiguration\", \"s3:GetLifecycleConfiguration\",
+                              \"s3:GetBucketLocation\", \"s3:ListBucket\", \"s3:GetObject\",
+                              \"s3:PutObject\", \"s3:DeleteObject\", \"s3:ListBucketMultipartUploads\",
+                              \"s3:AbortMultipartUpload\", \"s3:ListMultipartUploadParts\"
+                              ], \"Resource\": \"*\" } ] }"
+                            type: string
+                          ingressARN:
+                            description: "The referenced role must have a trust relationship
+                              that allows it to be assumed via web identity. https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html.
+                              Example: { \"Version\": \"2012-10-17\", \"Statement\":
+                              [ { \"Effect\": \"Allow\", \"Principal\": { \"Federated\":
+                              \"{{ .ProviderARN }}\" }, \"Action\": \"sts:AssumeRoleWithWebIdentity\",
+                              \"Condition\": { \"StringEquals\": { \"{{ .ProviderName
+                              }}:sub\": {{ .ServiceAccounts }} } } } ] } \n IngressARN
+                              is an ARN value referencing a role appropriate for the
+                              Ingress Operator. \n The following is an example of
+                              a valid policy document: \n { \"Version\": \"2012-10-17\",
+                              \"Statement\": [ { \"Effect\": \"Allow\", \"Action\":
+                              [ \"elasticloadbalancing:DescribeLoadBalancers\", \"tag:GetResources\",
+                              \"route53:ListHostedZones\" ], \"Resource\": \"*\" },
+                              { \"Effect\": \"Allow\", \"Action\": [ \"route53:ChangeResourceRecordSets\"
+                              ], \"Resource\": [ \"arn:aws:route53:::PUBLIC_ZONE_ID\",
+                              \"arn:aws:route53:::PRIVATE_ZONE_ID\" ] } ] }"
+                            type: string
+                          kubeCloudControllerARN:
+                            description: "KubeCloudControllerARN is an ARN value referencing
+                              a role appropriate for the KCM/KCC. \n The following
+                              is an example of a valid policy document: \n { \"Version\":
+                              \"2012-10-17\", \"Statement\": [ { \"Action\": [ \"ec2:DescribeInstances\",
+                              \"ec2:DescribeImages\", \"ec2:DescribeRegions\", \"ec2:DescribeRouteTables\",
+                              \"ec2:DescribeSecurityGroups\", \"ec2:DescribeSubnets\",
+                              \"ec2:DescribeVolumes\", \"ec2:CreateSecurityGroup\",
+                              \"ec2:CreateTags\", \"ec2:CreateVolume\", \"ec2:ModifyInstanceAttribute\",
+                              \"ec2:ModifyVolume\", \"ec2:AttachVolume\", \"ec2:AuthorizeSecurityGroupIngress\",
+                              \"ec2:CreateRoute\", \"ec2:DeleteRoute\", \"ec2:DeleteSecurityGroup\",
+                              \"ec2:DeleteVolume\", \"ec2:DetachVolume\", \"ec2:RevokeSecurityGroupIngress\",
+                              \"ec2:DescribeVpcs\", \"elasticloadbalancing:AddTags\",
+                              \"elasticloadbalancing:AttachLoadBalancerToSubnets\",
+                              \"elasticloadbalancing:ApplySecurityGroupsToLoadBalancer\",
+                              \"elasticloadbalancing:CreateLoadBalancer\", \"elasticloadbalancing:CreateLoadBalancerPolicy\",
+                              \"elasticloadbalancing:CreateLoadBalancerListeners\",
+                              \"elasticloadbalancing:ConfigureHealthCheck\", \"elasticloadbalancing:DeleteLoadBalancer\",
+                              \"elasticloadbalancing:DeleteLoadBalancerListeners\",
+                              \"elasticloadbalancing:DescribeLoadBalancers\", \"elasticloadbalancing:DescribeLoadBalancerAttributes\",
+                              \"elasticloadbalancing:DetachLoadBalancerFromSubnets\",
+                              \"elasticloadbalancing:DeregisterInstancesFromLoadBalancer\",
+                              \"elasticloadbalancing:ModifyLoadBalancerAttributes\",
+                              \"elasticloadbalancing:RegisterInstancesWithLoadBalancer\",
+                              \"elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer\",
+                              \"elasticloadbalancing:AddTags\", \"elasticloadbalancing:CreateListener\",
+                              \"elasticloadbalancing:CreateTargetGroup\", \"elasticloadbalancing:DeleteListener\",
+                              \"elasticloadbalancing:DeleteTargetGroup\", \"elasticloadbalancing:DescribeListeners\",
+                              \"elasticloadbalancing:DescribeLoadBalancerPolicies\",
+                              \"elasticloadbalancing:DescribeTargetGroups\", \"elasticloadbalancing:DescribeTargetHealth\",
+                              \"elasticloadbalancing:ModifyListener\", \"elasticloadbalancing:ModifyTargetGroup\",
+                              \"elasticloadbalancing:RegisterTargets\", \"elasticloadbalancing:SetLoadBalancerPoliciesOfListener\",
+                              \"iam:CreateServiceLinkedRole\", \"kms:DescribeKey\"
+                              ], \"Resource\": [ \"*\" ], \"Effect\": \"Allow\" }
+                              ] }"
+                            type: string
+                          networkARN:
+                            description: "NetworkARN is an ARN value referencing a
+                              role appropriate for the Network Operator. \n The following
+                              is an example of a valid policy document: \n { \"Version\":
+                              \"2012-10-17\", \"Statement\": [ { \"Effect\": \"Allow\",
+                              \"Action\": [ \"ec2:DescribeInstances\", \"ec2:DescribeInstanceStatus\",
+                              \"ec2:DescribeInstanceTypes\", \"ec2:UnassignPrivateIpAddresses\",
+                              \"ec2:AssignPrivateIpAddresses\", \"ec2:UnassignIpv6Addresses\",
+                              \"ec2:AssignIpv6Addresses\", \"ec2:DescribeSubnets\",
+                              \"ec2:DescribeNetworkInterfaces\" ], \"Resource\": \"*\"
+                              } ] }"
+                            type: string
+                          nodePoolManagementARN:
+                            description: "NodePoolManagementARN is an ARN value referencing
+                              a role appropriate for the CAPI Controller. \n The following
+                              is an example of a valid policy document: \n { \"Version\":
+                              \"2012-10-17\", \"Statement\": [ { \"Action\": [ \"ec2:AllocateAddress\",
+                              \"ec2:AssociateRouteTable\", \"ec2:AttachInternetGateway\",
+                              \"ec2:AuthorizeSecurityGroupIngress\", \"ec2:CreateInternetGateway\",
+                              \"ec2:CreateNatGateway\", \"ec2:CreateRoute\", \"ec2:CreateRouteTable\",
+                              \"ec2:CreateSecurityGroup\", \"ec2:CreateSubnet\", \"ec2:CreateTags\",
+                              \"ec2:DeleteInternetGateway\", \"ec2:DeleteNatGateway\",
+                              \"ec2:DeleteRouteTable\", \"ec2:DeleteSecurityGroup\",
+                              \"ec2:DeleteSubnet\", \"ec2:DeleteTags\", \"ec2:DescribeAccountAttributes\",
+                              \"ec2:DescribeAddresses\", \"ec2:DescribeAvailabilityZones\",
+                              \"ec2:DescribeImages\", \"ec2:DescribeInstances\", \"ec2:DescribeInternetGateways\",
+                              \"ec2:DescribeNatGateways\", \"ec2:DescribeNetworkInterfaces\",
+                              \"ec2:DescribeNetworkInterfaceAttribute\", \"ec2:DescribeRouteTables\",
+                              \"ec2:DescribeSecurityGroups\", \"ec2:DescribeSubnets\",
+                              \"ec2:DescribeVpcs\", \"ec2:DescribeVpcAttribute\",
+                              \"ec2:DescribeVolumes\", \"ec2:DetachInternetGateway\",
+                              \"ec2:DisassociateRouteTable\", \"ec2:DisassociateAddress\",
+                              \"ec2:ModifyInstanceAttribute\", \"ec2:ModifyNetworkInterfaceAttribute\",
+                              \"ec2:ModifySubnetAttribute\", \"ec2:ReleaseAddress\",
+                              \"ec2:RevokeSecurityGroupIngress\", \"ec2:RunInstances\",
+                              \"ec2:TerminateInstances\", \"tag:GetResources\", \"ec2:CreateLaunchTemplate\",
+                              \"ec2:CreateLaunchTemplateVersion\", \"ec2:DescribeLaunchTemplates\",
+                              \"ec2:DescribeLaunchTemplateVersions\", \"ec2:DeleteLaunchTemplate\",
+                              \"ec2:DeleteLaunchTemplateVersions\" ], \"Resource\":
+                              [ \"*\" ], \"Effect\": \"Allow\" }, { \"Condition\":
+                              { \"StringLike\": { \"iam:AWSServiceName\": \"elasticloadbalancing.amazonaws.com\"
+                              } }, \"Action\": [ \"iam:CreateServiceLinkedRole\" ],
+                              \"Resource\": [ \"arn:*:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing\"
+                              ], \"Effect\": \"Allow\" }, { \"Action\": [ \"iam:PassRole\"
+                              ], \"Resource\": [ \"arn:*:iam::*:role/*-worker-role\"
+                              ], \"Effect\": \"Allow\" }, { \"Effect\": \"Allow\",
+                              \"Action\": [ \"kms:Decrypt\", \"kms:Encrypt\", \"kms:GenerateDataKey\",
+                              \"kms:GenerateDataKeyWithoutPlainText\", \"kms:DescribeKey\"
+                              ], \"Resource\": \"*\" }, { \"Effect\": \"Allow\", \"Action\":
+                              [ \"kms:RevokeGrant\", \"kms:CreateGrant\", \"kms:ListGrants\"
+                              ], \"Resource\": \"*\", \"Condition\": { \"Bool\": {
+                              \"kms:GrantIsForAWSResource\": true } } } ] }"
+                            type: string
+                          storageARN:
+                            description: "StorageARN is an ARN value referencing a
+                              role appropriate for the Storage Operator. \n The following
+                              is an example of a valid policy document: \n { \"Version\":
+                              \"2012-10-17\", \"Statement\": [ { \"Effect\": \"Allow\",
+                              \"Action\": [ \"ec2:AttachVolume\", \"ec2:CreateSnapshot\",
+                              \"ec2:CreateTags\", \"ec2:CreateVolume\", \"ec2:DeleteSnapshot\",
+                              \"ec2:DeleteTags\", \"ec2:DeleteVolume\", \"ec2:DescribeInstances\",
+                              \"ec2:DescribeSnapshots\", \"ec2:DescribeTags\", \"ec2:DescribeVolumes\",
+                              \"ec2:DescribeVolumesModifications\", \"ec2:DetachVolume\",
+                              \"ec2:ModifyVolume\" ], \"Resource\": \"*\" } ] }"
+                            type: string
+                        required:
+                        - controlPlaneOperatorARN
+                        - imageRegistryARN
+                        - ingressARN
+                        - kubeCloudControllerARN
+                        - networkARN
+                        - nodePoolManagementARN
+                        - storageARN
+                        type: object
+                      serviceEndpoints:
+                        description: "ServiceEndpoints specifies optional custom endpoints
+                          which will override the default service endpoint of specific
+                          AWS Services. \n There must be only one ServiceEndpoint
+                          for a given service name."
+                        items:
+                          description: AWSServiceEndpoint stores the configuration
+                            for services to override existing defaults of AWS Services.
+                          properties:
+                            name:
+                              description: Name is the name of the AWS service. This
+                                must be provided and cannot be empty.
+                              type: string
+                            url:
+                              description: URL is fully qualified URI with scheme
+                                https, that overrides the default generated endpoint
+                                for a client. This must be provided and cannot be
+                                empty.
+                              pattern: ^https://
+                              type: string
+                          required:
+                          - name
+                          - url
+                          type: object
+                        type: array
+                    required:
+                    - controlPlaneOperatorCreds
+                    - kubeCloudControllerCreds
+                    - nodePoolManagementCreds
+                    - region
+                    - rolesRef
+                    type: object
+                  azure:
+                    description: Azure defines azure specific settings
+                    properties:
+                      credentials:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      location:
+                        type: string
+                      machineIdentityID:
+                        type: string
+                      resourceGroup:
+                        type: string
+                      securityGroupName:
+                        type: string
+                      subnetName:
+                        type: string
+                      subscriptionID:
+                        type: string
+                      vnetID:
+                        type: string
+                      vnetName:
+                        type: string
+                    required:
+                    - credentials
+                    - location
+                    - machineIdentityID
+                    - resourceGroup
+                    - securityGroupName
+                    - subnetName
+                    - subscriptionID
+                    - vnetID
+                    - vnetName
+                    type: object
+                  ibmcloud:
+                    description: IBMCloud defines IBMCloud specific settings for components
+                    properties:
+                      providerType:
+                        description: ProviderType is a specific supported infrastructure
+                          provider within IBM Cloud.
+                        type: string
+                    type: object
+                  kubevirt:
+                    description: KubeVirt defines KubeVirt specific settings for cluster
+                      components.
+                    properties:
+                      baseDomainPassthrough:
+                        description: "BaseDomainPassthrough toggles whether or not
+                          an automatically generated base domain for the guest cluster
+                          should be used that is a subdomain of the management cluster's
+                          *.apps DNS. \n For the KubeVirt platform, the basedomain
+                          can be autogenerated using the *.apps domain of the management/infra
+                          hosting cluster This makes the guest cluster's base domain
+                          a subdomain of the hypershift infra/mgmt cluster's base
+                          domain. \n Example: Infra/Mgmt cluster's DNS Base: example.com
+                          Cluster: mgmt-cluster.example.com Apps:    *.apps.mgmt-cluster.example.com
+                          KubeVirt Guest cluster's DNS Base: apps.mgmt-cluster.example.com
+                          Cluster: guest.apps.mgmt-cluster.example.com Apps: *.apps.guest.apps.mgmt-cluster.example.com
+                          \n This is possible using OCP wildcard routes"
+                        type: boolean
+                        x-kubernetes-validations:
+                        - message: baseDomainPassthrough is immutable
+                          rule: self == oldSelf
+                      credentials:
+                        description: "Credentials defines the client credentials used
+                          when creating KubeVirt virtual machines. Defining credentials
+                          is only necessary when the KubeVirt virtual machines are
+                          being placed on a cluster separate from the one hosting
+                          the Hosted Control Plane components. \n The default behavior
+                          when Credentials is not defined is for the KubeVirt VMs
+                          to be placed on the same cluster and namespace as the Hosted
+                          Control Plane."
+                        properties:
+                          infraKubeConfigSecret:
+                            description: InfraKubeConfigSecret is a reference to a
+                              secret that contains the kubeconfig for the external
+                              infra cluster that will be used to host the KubeVirt
+                              virtual machines for this cluster.
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                            x-kubernetes-validations:
+                            - message: infraKubeConfigSecret is immutable
+                              rule: self == oldSelf
+                          infraNamespace:
+                            description: InfraNamespace defines the namespace on the
+                              external infra cluster that is used to host the KubeVirt
+                              virtual machines. This namespace must already exist
+                              before creating the HostedCluster and the kubeconfig
+                              referenced in the InfraKubeConfigSecret must have access
+                              to manage the required resources within this namespace.
+                            type: string
+                            x-kubernetes-validations:
+                            - message: infraNamespace is immutable
+                              rule: self == oldSelf
+                        required:
+                        - infraNamespace
+                        type: object
+                      generateID:
+                        description: GenerateID is used to uniquely apply a name suffix
+                          to resources associated with kubevirt infrastructure resources
+                        maxLength: 11
+                        type: string
+                        x-kubernetes-validations:
+                        - message: Kubevirt GenerateID is immutable once set
+                          rule: self == oldSelf
+                      storageDriver:
+                        description: StorageDriver defines how the KubeVirt CSI driver
+                          exposes StorageClasses on the infra cluster (hosting the
+                          VMs) to the guest cluster.
+                        properties:
+                          manual:
+                            description: Manual is used to explicilty define how the
+                              infra storageclasses are mapped to guest storageclasses
+                            properties:
+                              storageClassMapping:
+                                description: "StorageClassMapping maps StorageClasses
+                                  on the infra cluster hosting the KubeVirt VMs to
+                                  StorageClasses that are made available within the
+                                  Guest Cluster. \n NOTE: It is possible that not
+                                  all capablities of an infra cluster's storageclass
+                                  will be present for the corresponding guest clusters
+                                  storageclass."
+                                items:
+                                  properties:
+                                    guestStorageClassName:
+                                      description: GuestStorageClassName is the name
+                                        that the corresponding storageclass will be
+                                        called within the guest cluster
+                                      type: string
+                                    infraStorageClassName:
+                                      description: InfraStorageClassName is the name
+                                        of the infra cluster storage class that will
+                                        be exposed into the guest.
+                                      type: string
+                                  required:
+                                  - guestStorageClassName
+                                  - infraStorageClassName
+                                  type: object
+                                type: array
+                                x-kubernetes-validations:
+                                - message: storageClassMapping is immutable
+                                  rule: self == oldSelf
+                            type: object
+                            x-kubernetes-validations:
+                            - message: storageDriver.Manual is immutable
+                              rule: self == oldSelf
+                          type:
+                            default: Default
+                            description: Type represents the type of kubevirt csi
+                              driver configuration to use
+                            enum:
+                            - None
+                            - Default
+                            - Manual
+                            type: string
+                            x-kubernetes-validations:
+                            - message: storageDriver.Type is immutable
+                              rule: self == oldSelf
+                        type: object
+                        x-kubernetes-validations:
+                        - message: storageDriver is immutable
+                          rule: self == oldSelf
+                    type: object
+                    x-kubernetes-validations:
+                    - message: Kubevirt GenerateID is required once set
+                      rule: '!has(oldSelf.generateID) || has(self.generateID)'
+                  powervs:
+                    description: PowerVS specifies configuration for clusters running
+                      on IBMCloud Power VS Service. This field is immutable. Once
+                      set, It can't be changed.
+                    properties:
+                      accountID:
+                        description: AccountID is the IBMCloud account id. This field
+                          is immutable. Once set, It can't be changed.
+                        type: string
+                      cisInstanceCRN:
+                        description: CISInstanceCRN is the IBMCloud CIS Service Instance's
+                          Cloud Resource Name This field is immutable. Once set, It
+                          can't be changed.
+                        pattern: '^crn:'
+                        type: string
+                      imageRegistryOperatorCloudCreds:
+                        description: ImageRegistryOperatorCloudCreds is a reference
+                          to a secret containing ibm cloud credentials for image registry
+                          operator to get authenticated with ibm cloud.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      ingressOperatorCloudCreds:
+                        description: IngressOperatorCloudCreds is a reference to a
+                          secret containing ibm cloud credentials for ingress operator
+                          to get authenticated with ibm cloud.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      kubeCloudControllerCreds:
+                        description: "KubeCloudControllerCreds is a reference to a
+                          secret containing cloud credentials with permissions matching
+                          the cloud controller policy. This field is immutable. Once
+                          set, It can't be changed. \n TODO(dan): document the \"cloud
+                          controller policy\""
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodePoolManagementCreds:
+                        description: "NodePoolManagementCreds is a reference to a
+                          secret containing cloud credentials with permissions matching
+                          the node pool management policy. This field is immutable.
+                          Once set, It can't be changed. \n TODO(dan): document the
+                          \"node pool management policy\""
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      region:
+                        description: Region is the IBMCloud region in which the cluster
+                          resides. This configures the OCP control plane cloud integrations,
+                          and is used by NodePool to resolve the correct boot image
+                          for a given release. This field is immutable. Once set,
+                          It can't be changed.
+                        type: string
+                      resourceGroup:
+                        description: ResourceGroup is the IBMCloud Resource Group
+                          in which the cluster resides. This field is immutable. Once
+                          set, It can't be changed.
+                        type: string
+                      serviceInstanceID:
+                        description: "ServiceInstance is the reference to the Power
+                          VS service on which the server instance(VM) will be created.
+                          Power VS service is a container for all Power VS instances
+                          at a specific geographic region. serviceInstance can be
+                          created via IBM Cloud catalog or CLI. ServiceInstanceID
+                          is the unique identifier that can be obtained from IBM Cloud
+                          UI or IBM Cloud cli. \n More detail about Power VS service
+                          instance. https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-creating-power-virtual-server
+                          \n This field is immutable. Once set, It can't be changed."
+                        type: string
+                      storageOperatorCloudCreds:
+                        description: StorageOperatorCloudCreds is a reference to a
+                          secret containing ibm cloud credentials for storage operator
+                          to get authenticated with ibm cloud.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      subnet:
+                        description: Subnet is the subnet to use for control plane
+                          cloud resources. This field is immutable. Once set, It can't
+                          be changed.
+                        properties:
+                          id:
+                            description: ID of resource
+                            type: string
+                          name:
+                            description: Name of resource
+                            type: string
+                        type: object
+                      vpc:
+                        description: VPC specifies IBM Cloud PowerVS Load Balancing
+                          configuration for the control plane. This field is immutable.
+                          Once set, It can't be changed.
+                        properties:
+                          name:
+                            description: Name for VPC to used for all the service
+                              load balancer. This field is immutable. Once set, It
+                              can't be changed.
+                            type: string
+                          region:
+                            description: Region is the IBMCloud region in which VPC
+                              gets created, this VPC used for all the ingress traffic
+                              into the OCP cluster. This field is immutable. Once
+                              set, It can't be changed.
+                            type: string
+                          subnet:
+                            description: Subnet is the subnet to use for load balancer.
+                              This field is immutable. Once set, It can't be changed.
+                            type: string
+                          zone:
+                            description: Zone is the availability zone where load
+                              balancer cloud resources are created. This field is
+                              immutable. Once set, It can't be changed.
+                            type: string
+                        required:
+                        - name
+                        - region
+                        type: object
+                      zone:
+                        description: Zone is the availability zone where control plane
+                          cloud resources are created. This field is immutable. Once
+                          set, It can't be changed.
+                        type: string
+                    required:
+                    - accountID
+                    - cisInstanceCRN
+                    - imageRegistryOperatorCloudCreds
+                    - ingressOperatorCloudCreds
+                    - kubeCloudControllerCreds
+                    - nodePoolManagementCreds
+                    - region
+                    - resourceGroup
+                    - serviceInstanceID
+                    - storageOperatorCloudCreds
+                    - subnet
+                    - vpc
+                    - zone
+                    type: object
+                  type:
+                    description: Type is the type of infrastructure provider for the
+                      cluster.
+                    enum:
+                    - AWS
+                    - None
+                    - IBMCloud
+                    - Agent
+                    - KubeVirt
+                    - Azure
+                    - PowerVS
+                    type: string
+                required:
+                - type
+                type: object
+              pullSecret:
+                description: PullSecret references a pull secret to be injected into
+                  the container runtime of all cluster nodes. The secret must have
+                  a key named ".dockerconfigjson" whose value is the pull secret JSON.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              release:
+                description: "Release specifies the desired OCP release payload for
+                  the hosted cluster. \n Updating this field will trigger a rollout
+                  of the control plane. The behavior of the rollout will be driven
+                  by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy."
+                properties:
+                  image:
+                    description: Image is the image pullspec of an OCP release payload
+                      image.
+                    pattern: ^(\w+\S+)$
+                    type: string
+                required:
+                - image
+                type: object
+              secretEncryption:
+                description: SecretEncryption specifies a Kubernetes secret encryption
+                  strategy for the control plane.
+                properties:
+                  aescbc:
+                    description: AESCBC defines metadata about the AESCBC secret encryption
+                      strategy
+                    properties:
+                      activeKey:
+                        description: ActiveKey defines the active key used to encrypt
+                          new secrets
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      backupKey:
+                        description: BackupKey defines the old key during the rotation
+                          process so previously created secrets can continue to be
+                          decrypted until they are all re-encrypted with the active
+                          key.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - activeKey
+                    type: object
+                  kms:
+                    description: KMS defines metadata about the kms secret encryption
+                      strategy
+                    properties:
+                      aws:
+                        description: AWS defines metadata about the configuration
+                          of the AWS KMS Secret Encryption provider
+                        properties:
+                          activeKey:
+                            description: ActiveKey defines the active key used to
+                              encrypt new secrets
+                            properties:
+                              arn:
+                                description: ARN is the Amazon Resource Name for the
+                                  encryption key
+                                pattern: '^arn:'
+                                type: string
+                            required:
+                            - arn
+                            type: object
+                          auth:
+                            description: Auth defines metadata about the management
+                              of credentials used to interact with AWS KMS
+                            properties:
+                              awsKms:
+                                description: "The referenced role must have a trust
+                                  relationship that allows it to be assumed via web
+                                  identity. https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html.
+                                  Example: { \"Version\": \"2012-10-17\", \"Statement\":
+                                  [ { \"Effect\": \"Allow\", \"Principal\": { \"Federated\":
+                                  \"{{ .ProviderARN }}\" }, \"Action\": \"sts:AssumeRoleWithWebIdentity\",
+                                  \"Condition\": { \"StringEquals\": { \"{{ .ProviderName
+                                  }}:sub\": {{ .ServiceAccounts }} } } } ] } \n AWSKMSARN
+                                  is an ARN value referencing a role appropriate for
+                                  managing the auth via the AWS KMS key. \n The following
+                                  is an example of a valid policy document: \n { \"Version\":
+                                  \"2012-10-17\", \"Statement\": [ { \"Effect\": \"Allow\",
+                                  \"Action\": [ \"kms:Encrypt\", \"kms:Decrypt\",
+                                  \"kms:ReEncrypt*\", \"kms:GenerateDataKey*\", \"kms:DescribeKey\"
+                                  ], \"Resource\": %q } ] }"
+                                type: string
+                              credentials:
+                                description: Deprecated This field is deprecated and
+                                  will be removed in a future release. Use AWSKMSRoleARN
+                                  instead. Credentials contains the name of the secret
+                                  that holds the aws credentials that can be used
+                                  to make the necessary KMS calls. It should at key
+                                  AWSCredentialsFileSecretKey contain the aws credentials
+                                  file that can be used to configure AWS SDKs
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                            - awsKms
+                            - credentials
+                            type: object
+                          backupKey:
+                            description: BackupKey defines the old key during the
+                              rotation process so previously created secrets can continue
+                              to be decrypted until they are all re-encrypted with
+                              the active key.
+                            properties:
+                              arn:
+                                description: ARN is the Amazon Resource Name for the
+                                  encryption key
+                                pattern: '^arn:'
+                                type: string
+                            required:
+                            - arn
+                            type: object
+                          region:
+                            description: Region contains the AWS region
+                            type: string
+                        required:
+                        - activeKey
+                        - auth
+                        - region
+                        type: object
+                      azure:
+                        description: Azure defines metadata about the configuration
+                          of the Azure KMS Secret Encryption provider using Azure
+                          key vault
+                        properties:
+                          keyName:
+                            description: KeyName is the name of the keyvault key used
+                              for encrypt/decrypt
+                            type: string
+                          keyVaultName:
+                            description: 'KeyVaultName is the name of the keyvault.
+                              Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the
+                              cluster must be authorized to access this keyvault,
+                              e.g using the AzureCLI: `az keyvault set-policy -n $KEYVAULT_NAME
+                              --key-permissions decrypt encrypt --spn <YOUR APPLICATION
+                              CLIENT ID>`'
+                            type: string
+                          keyVersion:
+                            description: KeyVersion contains the version of the key
+                              to use
+                            type: string
+                          location:
+                            description: Location contains the Azure region
+                            type: string
+                        required:
+                        - keyName
+                        - keyVaultName
+                        - keyVersion
+                        type: object
+                      ibmcloud:
+                        description: IBMCloud defines metadata for the IBM Cloud KMS
+                          encryption strategy
+                        properties:
+                          auth:
+                            description: Auth defines metadata for how authentication
+                              is done with IBM Cloud KMS
+                            properties:
+                              managed:
+                                description: Managed defines metadata around the service
+                                  to service authentication strategy for the IBM Cloud
+                                  KMS system (all provider managed).
+                                type: object
+                              type:
+                                description: Type defines the IBM Cloud KMS authentication
+                                  strategy
+                                enum:
+                                - Managed
+                                - Unmanaged
+                                type: string
+                              unmanaged:
+                                description: Unmanaged defines the auth metadata the
+                                  customer provides to interact with IBM Cloud KMS
+                                properties:
+                                  credentials:
+                                    description: Credentials should reference a secret
+                                      with a key field of IBMCloudIAMAPIKeySecretKey
+                                      that contains a apikey to call IBM Cloud KMS
+                                      APIs
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                required:
+                                - credentials
+                                type: object
+                            required:
+                            - type
+                            type: object
+                          keyList:
+                            description: KeyList defines the list of keys used for
+                              data encryption
+                            items:
+                              description: IBMCloudKMSKeyEntry defines metadata for
+                                an IBM Cloud KMS encryption key
+                              properties:
+                                correlationID:
+                                  description: CorrelationID is an identifier used
+                                    to track all api call usage from hypershift
+                                  type: string
+                                crkID:
+                                  description: CRKID is the customer rook key id
+                                  type: string
+                                instanceID:
+                                  description: InstanceID is the id for the key protect
+                                    instance
+                                  type: string
+                                keyVersion:
+                                  description: KeyVersion is a unique number associated
+                                    with the key. The number increments whenever a
+                                    new key is enabled for data encryption.
+                                  type: integer
+                                url:
+                                  description: URL is the url to call key protect
+                                    apis over
+                                  pattern: ^https://
+                                  type: string
+                              required:
+                              - correlationID
+                              - crkID
+                              - instanceID
+                              - keyVersion
+                              - url
+                              type: object
+                            type: array
+                          region:
+                            description: Region is the IBM Cloud region
+                            type: string
+                        required:
+                        - auth
+                        - keyList
+                        - region
+                        type: object
+                      provider:
+                        description: Provider defines the KMS provider
+                        enum:
+                        - IBMCloud
+                        - AWS
+                        - Azure
+                        type: string
+                    required:
+                    - provider
+                    type: object
+                  type:
+                    description: Type defines the type of kube secret encryption being
+                      used
+                    enum:
+                    - kms
+                    - aescbc
+                    type: string
+                required:
+                - type
+                type: object
+              serviceAccountSigningKey:
+                description: ServiceAccountSigningKey is a reference to a secret containing
+                  the private key used by the service account token issuer. The secret
+                  is expected to contain a single key named "key". If not specified,
+                  a service account signing key will be generated automatically for
+                  the cluster. When specifying a service account signing key, a IssuerURL
+                  must also be specified.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              services:
+                description: "Services specifies how individual control plane services
+                  are published from the hosting cluster of the control plane. \n
+                  If a given service is not present in this list, it will be exposed
+                  publicly by default."
+                items:
+                  description: ServicePublishingStrategyMapping specifies how individual
+                    control plane services are published from the hosting cluster
+                    of a control plane.
+                  properties:
+                    service:
+                      description: Service identifies the type of service being published.
+                      enum:
+                      - APIServer
+                      - OAuthServer
+                      - OIDC
+                      - Konnectivity
+                      - Ignition
+                      - OVNSbDb
+                      type: string
+                    servicePublishingStrategy:
+                      description: ServicePublishingStrategy specifies how to publish
+                        Service.
+                      properties:
+                        loadBalancer:
+                          description: LoadBalancer configures exposing a service
+                            using a LoadBalancer.
+                          properties:
+                            hostname:
+                              description: Hostname is the name of the DNS record
+                                that will be created pointing to the LoadBalancer.
+                              type: string
+                          type: object
+                        nodePort:
+                          description: NodePort configures exposing a service using
+                            a NodePort.
+                          properties:
+                            address:
+                              description: Address is the host/ip that the NodePort
+                                service is exposed over.
+                              type: string
+                            port:
+                              description: Port is the port of the NodePort service.
+                                If <=0, the port is dynamically assigned when the
+                                service is created.
+                              format: int32
+                              type: integer
+                          required:
+                          - address
+                          type: object
+                        route:
+                          description: Route configures exposing a service using a
+                            Route.
+                          properties:
+                            hostname:
+                              description: Hostname is the name of the DNS record
+                                that will be created pointing to the Route.
+                              type: string
+                          type: object
+                        type:
+                          description: Type is the publishing strategy used for the
+                            service.
+                          enum:
+                          - LoadBalancer
+                          - NodePort
+                          - Route
+                          - None
+                          - S3
+                          type: string
+                      required:
+                      - type
+                      type: object
+                  required:
+                  - service
+                  - servicePublishingStrategy
+                  type: object
+                type: array
+              sshKey:
+                description: SSHKey references an SSH key to be injected into all
+                  cluster node sshd servers. The secret must have a single key "id_rsa.pub"
+                  whose value is the public part of an SSH key.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - networking
+            - platform
+            - pullSecret
+            - release
+            - services
+            - sshKey
+            type: object
+          status:
+            description: Status is the latest observed status of the HostedCluster.
+            properties:
+              conditions:
+                description: Conditions represents the latest available observations
+                  of a control plane's current state.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint contains the endpoint information
+                  by which external clients can access the control plane. This is
+                  populated after the infrastructure is ready.
+                properties:
+                  host:
+                    description: Host is the hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: Port is the port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              ignitionEndpoint:
+                description: IgnitionEndpoint is the endpoint injected in the ign
+                  config userdata. It exposes the config for instances to become kubernetes
+                  nodes.
+                type: string
+              kubeadminPassword:
+                description: KubeadminPassword is a reference to the secret that contains
+                  the initial kubeadmin user password for the guest cluster.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              kubeconfig:
+                description: KubeConfig is a reference to the secret containing the
+                  default kubeconfig for the cluster.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              oauthCallbackURLTemplate:
+                description: OAuthCallbackURLTemplate contains a template for the
+                  URL to use as a callback for identity providers. The [identity-provider-name]
+                  placeholder must be replaced with the name of an identity provider
+                  defined on the HostedCluster. This is populated after the infrastructure
+                  is ready.
+                type: string
+              platform:
+                description: Platform contains platform-specific status of the HostedCluster
+                properties:
+                  aws:
+                    description: AWSPlatformStatus contains status specific to the
+                      AWS platform
+                    properties:
+                      defaultWorkerSecurityGroupID:
+                        description: DefaultWorkerSecurityGroupID is the ID of a security
+                          group created by the control plane operator. It is used
+                          for NodePools that don't specify a security group.
+                        type: string
+                    type: object
+                type: object
+              version:
+                description: Version is the status of the release version applied
+                  to the HostedCluster.
+                properties:
+                  availableUpdates:
+                    description: availableUpdates contains updates recommended for
+                      this cluster. Updates which appear in conditionalUpdates but
+                      not in availableUpdates may expose this cluster to known issues.
+                      This list may be empty if no updates are recommended, if the
+                      update service is unavailable, or if an invalid channel has
+                      been specified.
+                    items:
+                      description: Release represents an OpenShift release image and
+                        associated metadata.
+                      properties:
+                        channels:
+                          description: channels is the set of Cincinnati channels
+                            to which the release currently belongs.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        image:
+                          description: image is a container image location that contains
+                            the update. When this field is part of spec, image is
+                            optional if version is specified and the availableUpdates
+                            field contains a matching version.
+                          type: string
+                        url:
+                          description: url contains information about this release.
+                            This URL is set by the 'url' metadata property on a release
+                            or the metadata returned by the update API and should
+                            be displayed as a link in user interfaces. The URL field
+                            may not be set for test or nightly releases.
+                          type: string
+                        version:
+                          description: version is a semantic version identifying the
+                            update version. When this field is part of spec, version
+                            is optional if image is specified.
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  conditionalUpdates:
+                    description: conditionalUpdates contains the list of updates that
+                      may be recommended for this cluster if it meets specific required
+                      conditions. Consumers interested in the set of updates that
+                      are actually recommended for this cluster should use availableUpdates.
+                      This list may be empty if no updates are recommended, if the
+                      update service is unavailable, or if an empty or invalid channel
+                      has been specified.
+                    items:
+                      description: ConditionalUpdate represents an update which is
+                        recommended to some clusters on the version the current cluster
+                        is reconciling, but which may not be recommended for the current
+                        cluster.
+                      properties:
+                        conditions:
+                          description: 'conditions represents the observations of
+                            the conditional update''s current status. Known types
+                            are: * Evaluating, for whether the cluster-version operator
+                            will attempt to evaluate any risks[].matchingRules. *
+                            Recommended, for whether the update is recommended for
+                            the current cluster.'
+                          items:
+                            description: "Condition contains details for one aspect
+                              of the current state of this API Resource. --- This
+                              struct is intended for direct use as an array at the
+                              field path .status.conditions.  For example, \n type
+                              FooStatus struct{ // Represents the observations of
+                              a foo's current state. // Known .status.conditions.type
+                              are: \"Available\", \"Progressing\", and \"Degraded\"
+                              // +patchMergeKey=type // +patchStrategy=merge // +listType=map
+                              // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                              patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                              \n // other fields }"
+                            properties:
+                              lastTransitionTime:
+                                description: lastTransitionTime is the last time the
+                                  condition transitioned from one status to another.
+                                  This should be when the underlying condition changed.  If
+                                  that is not known, then using the time when the
+                                  API field changed is acceptable.
+                                format: date-time
+                                type: string
+                              message:
+                                description: message is a human readable message indicating
+                                  details about the transition. This may be an empty
+                                  string.
+                                maxLength: 32768
+                                type: string
+                              observedGeneration:
+                                description: observedGeneration represents the .metadata.generation
+                                  that the condition was set based upon. For instance,
+                                  if .metadata.generation is currently 12, but the
+                                  .status.conditions[x].observedGeneration is 9, the
+                                  condition is out of date with respect to the current
+                                  state of the instance.
+                                format: int64
+                                minimum: 0
+                                type: integer
+                              reason:
+                                description: reason contains a programmatic identifier
+                                  indicating the reason for the condition's last transition.
+                                  Producers of specific condition types may define
+                                  expected values and meanings for this field, and
+                                  whether the values are considered a guaranteed API.
+                                  The value should be a CamelCase string. This field
+                                  may not be empty.
+                                maxLength: 1024
+                                minLength: 1
+                                pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                type: string
+                              status:
+                                description: status of the condition, one of True,
+                                  False, Unknown.
+                                enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                                type: string
+                              type:
+                                description: type of condition in CamelCase or in
+                                  foo.example.com/CamelCase. --- Many .condition.type
+                                  values are consistent across resources like Available,
+                                  but because arbitrary conditions can be useful (see
+                                  .node.status.conditions), the ability to deconflict
+                                  is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                type: string
+                            required:
+                            - lastTransitionTime
+                            - message
+                            - reason
+                            - status
+                            - type
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - type
+                          x-kubernetes-list-type: map
+                        release:
+                          description: release is the target of the update.
+                          properties:
+                            channels:
+                              description: channels is the set of Cincinnati channels
+                                to which the release currently belongs.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            image:
+                              description: image is a container image location that
+                                contains the update. When this field is part of spec,
+                                image is optional if version is specified and the
+                                availableUpdates field contains a matching version.
+                              type: string
+                            url:
+                              description: url contains information about this release.
+                                This URL is set by the 'url' metadata property on
+                                a release or the metadata returned by the update API
+                                and should be displayed as a link in user interfaces.
+                                The URL field may not be set for test or nightly releases.
+                              type: string
+                            version:
+                              description: version is a semantic version identifying
+                                the update version. When this field is part of spec,
+                                version is optional if image is specified.
+                              type: string
+                          type: object
+                        risks:
+                          description: risks represents the range of issues associated
+                            with updating to the target release. The cluster-version
+                            operator will evaluate all entries, and only recommend
+                            the update if there is at least one entry and all entries
+                            recommend the update.
+                          items:
+                            description: ConditionalUpdateRisk represents a reason
+                              and cluster-state for not recommending a conditional
+                              update.
+                            properties:
+                              matchingRules:
+                                description: matchingRules is a slice of conditions
+                                  for deciding which clusters match the risk and which
+                                  do not. The slice is ordered by decreasing precedence.
+                                  The cluster-version operator will walk the slice
+                                  in order, and stop after the first it can successfully
+                                  evaluate. If no condition can be successfully evaluated,
+                                  the update will not be recommended.
+                                items:
+                                  description: ClusterCondition is a union of typed
+                                    cluster conditions.  The 'type' property determines
+                                    which of the type-specific properties are relevant.
+                                    When evaluated on a cluster, the condition may
+                                    match, not match, or fail to evaluate.
+                                  properties:
+                                    promql:
+                                      description: promQL represents a cluster condition
+                                        based on PromQL.
+                                      properties:
+                                        promql:
+                                          description: PromQL is a PromQL query classifying
+                                            clusters. This query query should return
+                                            a 1 in the match case and a 0 in the does-not-match
+                                            case. Queries which return no time series,
+                                            or which return values besides 0 or 1,
+                                            are evaluation failures.
+                                          type: string
+                                      required:
+                                      - promql
+                                      type: object
+                                    type:
+                                      description: type represents the cluster-condition
+                                        type. This defines the members and semantics
+                                        of any additional properties.
+                                      enum:
+                                      - Always
+                                      - PromQL
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                minItems: 1
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              message:
+                                description: message provides additional information
+                                  about the risk of updating, in the event that matchingRules
+                                  match the cluster state. This is only to be consumed
+                                  by humans. It may contain Line Feed characters (U+000A),
+                                  which should be rendered as new lines.
+                                minLength: 1
+                                type: string
+                              name:
+                                description: name is the CamelCase reason for not
+                                  recommending a conditional update, in the event
+                                  that matchingRules match the cluster state.
+                                minLength: 1
+                                type: string
+                              url:
+                                description: url contains information about this risk.
+                                format: uri
+                                minLength: 1
+                                type: string
+                            required:
+                            - matchingRules
+                            - message
+                            - name
+                            - url
+                            type: object
+                          minItems: 1
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                      required:
+                      - release
+                      - risks
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  desired:
+                    description: desired is the version that the cluster is reconciling
+                      towards. If the cluster is not yet fully initialized desired
+                      will be set with the information available, which may be an
+                      image or a tag.
+                    properties:
+                      channels:
+                        description: channels is the set of Cincinnati channels to
+                          which the release currently belongs.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      image:
+                        description: image is a container image location that contains
+                          the update. When this field is part of spec, image is optional
+                          if version is specified and the availableUpdates field contains
+                          a matching version.
+                        type: string
+                      url:
+                        description: url contains information about this release.
+                          This URL is set by the 'url' metadata property on a release
+                          or the metadata returned by the update API and should be
+                          displayed as a link in user interfaces. The URL field may
+                          not be set for test or nightly releases.
+                        type: string
+                      version:
+                        description: version is a semantic version identifying the
+                          update version. When this field is part of spec, version
+                          is optional if image is specified.
+                        type: string
+                    type: object
+                  history:
+                    description: history contains a list of the most recent versions
+                      applied to the cluster. This value may be empty during cluster
+                      startup, and then will be updated when a new update is being
+                      applied. The newest update is first in the list and it is ordered
+                      by recency. Updates in the history have state Completed if the
+                      rollout completed - if an update was failing or halfway applied
+                      the state will be Partial. Only a limited amount of update history
+                      is preserved.
+                    items:
+                      description: UpdateHistory is a single attempted update to the
+                        cluster.
+                      properties:
+                        acceptedRisks:
+                          description: acceptedRisks records risks which were accepted
+                            to initiate the update. For example, it may menition an
+                            Upgradeable=False or missing signature that was overriden
+                            via desiredUpdate.force, or an update that was initiated
+                            despite not being in the availableUpdates set of recommended
+                            update targets.
+                          type: string
+                        completionTime:
+                          description: completionTime, if set, is when the update
+                            was fully applied. The update that is currently being
+                            applied will have a null completion time. Completion time
+                            will always be set for entries that are not the current
+                            update (usually to the started time of the next update).
+                          format: date-time
+                          nullable: true
+                          type: string
+                        image:
+                          description: image is a container image location that contains
+                            the update. This value is always populated.
+                          type: string
+                        startedTime:
+                          description: startedTime is the time at which the update
+                            was started.
+                          format: date-time
+                          type: string
+                        state:
+                          description: state reflects whether the update was fully
+                            applied. The Partial state indicates the update is not
+                            fully applied, while the Completed state indicates the
+                            update was successfully rolled out at least once (all
+                            parts of the update successfully applied).
+                          type: string
+                        verified:
+                          description: verified indicates whether the provided update
+                            was properly verified before it was installed. If this
+                            is false the cluster may not be trusted. Verified does
+                            not cover upgradeable checks that depend on the cluster
+                            state at the time when the update target was accepted.
+                          type: boolean
+                        version:
+                          description: version is a semantic version identifying the
+                            update version. If the requested image does not define
+                            a version, or if a failure occurs retrieving the image,
+                            this value may be empty.
+                          type: string
+                      required:
+                      - completionTime
+                      - image
+                      - startedTime
+                      - state
+                      - verified
+                      type: object
+                    type: array
+                  observedGeneration:
+                    description: observedGeneration reports which version of the spec
+                      is being synced. If this value is not equal to metadata.generation,
+                      then the desired and conditions fields may represent a previous
+                      version.
+                    format: int64
+                    type: integer
+                required:
+                - availableUpdates
+                - desired
+                - observedGeneration
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Version
+      jsonPath: .status.version.history[?(@.state=="Completed")].version
+      name: Version
+      type: string
+    - description: KubeConfig Secret
+      jsonPath: .status.kubeconfig.name
+      name: KubeConfig
+      type: string
+    - description: Progress
+      jsonPath: .status.version.history[?(@.state!="")].state
+      name: Progress
+      type: string
+    - description: Available
+      jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - description: Progressing
+      jsonPath: .status.conditions[?(@.type=="Progressing")].status
+      name: Progressing
+      type: string
+    - description: Message
+      jsonPath: .status.conditions[?(@.type=="Available")].message
+      name: Message
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: HostedCluster is the primary representation of a HyperShift cluster
+          and encapsulates the control plane and common data plane configuration.
+          Creating a HostedCluster results in a fully functional OpenShift control
+          plane with no attached nodes. To support workloads (e.g. pods), a HostedCluster
+          may have one or more associated NodePool resources.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec is the desired behavior of the HostedCluster.
+            properties:
+              additionalTrustBundle:
+                description: AdditionalTrustBundle is a reference to a ConfigMap containing
+                  a PEM-encoded X.509 certificate bundle that will be added to the
+                  hosted controlplane and nodes
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              auditWebhook:
+                description: AuditWebhook contains metadata for configuring an audit
+                  webhook endpoint for a cluster to process cluster audit events.
+                  It references a secret that contains the webhook information for
+                  the audit webhook endpoint. It is a secret because if the endpoint
+                  has mTLS the kubeconfig will contain client keys. The kubeconfig
+                  needs to be stored in the secret with a secret key name that corresponds
+                  to the constant AuditWebhookKubeconfigKey.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              autoscaling:
+                description: Autoscaling specifies auto-scaling behavior that applies
+                  to all NodePools associated with the control plane.
+                properties:
+                  maxNodeProvisionTime:
+                    description: MaxNodeProvisionTime is the maximum time to wait
+                      for node provisioning before considering the provisioning to
+                      be unsuccessful, expressed as a Go duration string. The default
+                      is 15 minutes.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                    type: string
+                  maxNodesTotal:
+                    description: MaxNodesTotal is the maximum allowable number of
+                      nodes across all NodePools for a HostedCluster. The autoscaler
+                      will not grow the cluster beyond this number.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  maxPodGracePeriod:
+                    description: MaxPodGracePeriod is the maximum seconds to wait
+                      for graceful pod termination before scaling down a NodePool.
+                      The default is 600 seconds.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  podPriorityThreshold:
+                    description: "PodPriorityThreshold enables users to schedule \"best-effort\"
+                      pods, which shouldn't trigger autoscaler actions, but only run
+                      when there are spare resources available. The default is -10.
+                      \n See the following for more details: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption"
+                    format: int32
+                    type: integer
+                type: object
+              channel:
+                description: channel is an identifier for explicitly requesting that
+                  a non-default set of updates be applied to this cluster. The default
+                  channel will be contain stable updates that are appropriate for
+                  production clusters.
+                type: string
+              clusterID:
+                description: ClusterID uniquely identifies this cluster. This is expected
+                  to be an RFC4122 UUID value (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+                  in hexadecimal values). As with a Kubernetes metadata.uid, this
+                  ID uniquely identifies this cluster in space and time. This value
+                  identifies the cluster in metrics pushed to telemetry and metrics
+                  produced by the control plane operators. If a value is not specified,
+                  an ID is generated. After initial creation, the value is immutable.
+                pattern: '[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}'
+                type: string
+              configuration:
+                description: Configuration specifies configuration for individual
+                  OCP components in the cluster, represented as embedded resources
+                  that correspond to the openshift configuration API.
+                properties:
+                  apiServer:
+                    description: APIServer holds configuration (like serving certificates,
+                      client CA and CORS domains) shared by all API servers in the
+                      system, among them especially kube-apiserver and openshift-apiserver.
+                    properties:
+                      additionalCORSAllowedOrigins:
+                        description: additionalCORSAllowedOrigins lists additional,
+                          user-defined regular expressions describing hosts for which
+                          the API server allows access using the CORS headers. This
+                          may be needed to access the API and the integrated OAuth
+                          server from JavaScript applications. The values are regular
+                          expressions that correspond to the Golang regular expression
+                          language.
+                        items:
+                          type: string
+                        type: array
+                      audit:
+                        default:
+                          profile: Default
+                        description: audit specifies the settings for audit configuration
+                          to be applied to all OpenShift-provided API servers in the
+                          cluster.
+                        properties:
+                          customRules:
+                            description: customRules specify profiles per group. These
+                              profile take precedence over the top-level profile field
+                              if they apply. They are evaluation from top to bottom
+                              and the first one that matches, applies.
+                            items:
+                              description: AuditCustomRule describes a custom rule
+                                for an audit profile that takes precedence over the
+                                top-level profile.
+                              properties:
+                                group:
+                                  description: group is a name of group a request
+                                    user must be member of in order to this profile
+                                    to apply.
+                                  minLength: 1
+                                  type: string
+                                profile:
+                                  description: "profile specifies the name of the
+                                    desired audit policy configuration to be deployed
+                                    to all OpenShift-provided API servers in the cluster.
+                                    \n The following profiles are provided: - Default:
+                                    the existing default policy. - WriteRequestBodies:
+                                    like 'Default', but logs request and response
+                                    HTTP payloads for write requests (create, update,
+                                    patch). - AllRequestBodies: like 'WriteRequestBodies',
+                                    but also logs request and response HTTP payloads
+                                    for read requests (get, list). - None: no requests
+                                    are logged at all, not even oauthaccesstokens
+                                    and oauthauthorizetokens. \n If unset, the 'Default'
+                                    profile is used as the default."
+                                  enum:
+                                  - Default
+                                  - WriteRequestBodies
+                                  - AllRequestBodies
+                                  - None
+                                  type: string
+                              required:
+                              - group
+                              - profile
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - group
+                            x-kubernetes-list-type: map
+                          profile:
+                            default: Default
+                            description: "profile specifies the name of the desired
+                              top-level audit profile to be applied to all requests
+                              sent to any of the OpenShift-provided API servers in
+                              the cluster (kube-apiserver, openshift-apiserver and
+                              oauth-apiserver), with the exception of those requests
+                              that match one or more of the customRules. \n The following
+                              profiles are provided: - Default: default policy which
+                              means MetaData level logging with the exception of events
+                              (not logged at all), oauthaccesstokens and oauthauthorizetokens
+                              (both logged at RequestBody level). - WriteRequestBodies:
+                              like 'Default', but logs request and response HTTP payloads
+                              for write requests (create, update, patch). - AllRequestBodies:
+                              like 'WriteRequestBodies', but also logs request and
+                              response HTTP payloads for read requests (get, list).
+                              - None: no requests are logged at all, not even oauthaccesstokens
+                              and oauthauthorizetokens. \n Warning: It is not recommended
+                              to disable audit logging by using the `None` profile
+                              unless you are fully aware of the risks of not logging
+                              data that can be beneficial when troubleshooting issues.
+                              If you disable audit logging and a support situation
+                              arises, you might need to enable audit logging and reproduce
+                              the issue in order to troubleshoot properly. \n If unset,
+                              the 'Default' profile is used as the default."
+                            enum:
+                            - Default
+                            - WriteRequestBodies
+                            - AllRequestBodies
+                            - None
+                            type: string
+                        type: object
+                      clientCA:
+                        description: 'clientCA references a ConfigMap containing a
+                          certificate bundle for the signers that will be recognized
+                          for incoming client certificates in addition to the operator
+                          managed signers. If this is empty, then only operator managed
+                          signers are valid. You usually only have to set this if
+                          you have your own PKI you wish to honor client certificates
+                          from. The ConfigMap must exist in the openshift-config namespace
+                          and contain the following required fields: - ConfigMap.Data["ca-bundle.crt"]
+                          - CA bundle.'
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      encryption:
+                        description: encryption allows the configuration of encryption
+                          of resources at the datastore layer.
+                        properties:
+                          type:
+                            description: "type defines what encryption type should
+                              be used to encrypt resources at the datastore layer.
+                              When this field is unset (i.e. when it is set to the
+                              empty string), identity is implied. The behavior of
+                              unset can and will change over time.  Even if encryption
+                              is enabled by default, the meaning of unset may change
+                              to a different encryption type based on changes in best
+                              practices. \n When encryption is enabled, all sensitive
+                              resources shipped with the platform are encrypted. This
+                              list of sensitive resources can and will change over
+                              time.  The current authoritative list is: \n 1. secrets
+                              2. configmaps 3. routes.route.openshift.io 4. oauthaccesstokens.oauth.openshift.io
+                              5. oauthauthorizetokens.oauth.openshift.io"
+                            enum:
+                            - ""
+                            - identity
+                            - aescbc
+                            - aesgcm
+                            type: string
+                        type: object
+                      servingCerts:
+                        description: servingCert is the TLS cert info for serving
+                          secure traffic. If not specified, operator managed certificates
+                          will be used for serving secure traffic.
+                        properties:
+                          namedCertificates:
+                            description: namedCertificates references secrets containing
+                              the TLS cert info for serving secure traffic to specific
+                              hostnames. If no named certificates are provided, or
+                              no named certificates match the server name as understood
+                              by a client, the defaultServingCertificate will be used.
+                            items:
+                              description: APIServerNamedServingCert maps a server
+                                DNS name, as understood by a client, to a certificate.
+                              properties:
+                                names:
+                                  description: names is a optional list of explicit
+                                    DNS names (leading wildcards allowed) that should
+                                    use this certificate to serve secure traffic.
+                                    If no names are provided, the implicit names will
+                                    be extracted from the certificates. Exact names
+                                    trump over wildcard names. Explicit names defined
+                                    here trump over extracted implicit names.
+                                  items:
+                                    type: string
+                                  type: array
+                                servingCertificate:
+                                  description: 'servingCertificate references a kubernetes.io/tls
+                                    type secret containing the TLS cert info for serving
+                                    secure traffic. The secret must exist in the openshift-config
+                                    namespace and contain the following required fields:
+                                    - Secret.Data["tls.key"] - TLS private key. -
+                                    Secret.Data["tls.crt"] - TLS certificate.'
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced secret
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                      tlsSecurityProfile:
+                        description: "tlsSecurityProfile specifies settings for TLS
+                          connections for externally exposed servers. \n If unset,
+                          a default (which may change between releases) is chosen.
+                          Note that only Old, Intermediate and Custom profiles are
+                          currently supported, and the maximum available minTLSVersion
+                          is VersionTLS12."
+                        properties:
+                          custom:
+                            description: "custom is a user-defined TLS security profile.
+                              Be extremely careful using a custom profile as invalid
+                              configurations can be catastrophic. An example custom
+                              profile looks like this: \n ciphers: - ECDHE-ECDSA-CHACHA20-POLY1305
+                              - ECDHE-RSA-CHACHA20-POLY1305 - ECDHE-RSA-AES128-GCM-SHA256
+                              - ECDHE-ECDSA-AES128-GCM-SHA256 minTLSVersion: VersionTLS11"
+                            nullable: true
+                            properties:
+                              ciphers:
+                                description: "ciphers is used to specify the cipher
+                                  algorithms that are negotiated during the TLS handshake.
+                                  \ Operators may remove entries their operands do
+                                  not support.  For example, to use DES-CBC3-SHA  (yaml):
+                                  \n ciphers: - DES-CBC3-SHA"
+                                items:
+                                  type: string
+                                type: array
+                              minTLSVersion:
+                                description: "minTLSVersion is used to specify the
+                                  minimal version of the TLS protocol that is negotiated
+                                  during the TLS handshake. For example, to use TLS
+                                  versions 1.1, 1.2 and 1.3 (yaml): \n minTLSVersion:
+                                  VersionTLS11 \n NOTE: currently the highest minTLSVersion
+                                  allowed is VersionTLS12"
+                                enum:
+                                - VersionTLS10
+                                - VersionTLS11
+                                - VersionTLS12
+                                - VersionTLS13
+                                type: string
+                            type: object
+                          intermediate:
+                            description: "intermediate is a TLS security profile based
+                              on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
+                              \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256
+                              - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256
+                              - ECDHE-ECDSA-AES128-GCM-SHA256 - ECDHE-RSA-AES128-GCM-SHA256
+                              - ECDHE-ECDSA-AES256-GCM-SHA384 - ECDHE-RSA-AES256-GCM-SHA384
+                              - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305
+                              - DHE-RSA-AES128-GCM-SHA256 - DHE-RSA-AES256-GCM-SHA384
+                              minTLSVersion: VersionTLS12"
+                            nullable: true
+                            type: object
+                          modern:
+                            description: "modern is a TLS security profile based on:
+                              \n https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
+                              \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256
+                              - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256
+                              minTLSVersion: VersionTLS13 \n NOTE: Currently unsupported."
+                            nullable: true
+                            type: object
+                          old:
+                            description: "old is a TLS security profile based on:
+                              \n https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
+                              \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256
+                              - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256
+                              - ECDHE-ECDSA-AES128-GCM-SHA256 - ECDHE-RSA-AES128-GCM-SHA256
+                              - ECDHE-ECDSA-AES256-GCM-SHA384 - ECDHE-RSA-AES256-GCM-SHA384
+                              - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305
+                              - DHE-RSA-AES128-GCM-SHA256 - DHE-RSA-AES256-GCM-SHA384
+                              - DHE-RSA-CHACHA20-POLY1305 - ECDHE-ECDSA-AES128-SHA256
+                              - ECDHE-RSA-AES128-SHA256 - ECDHE-ECDSA-AES128-SHA -
+                              ECDHE-RSA-AES128-SHA - ECDHE-ECDSA-AES256-SHA384 - ECDHE-RSA-AES256-SHA384
+                              - ECDHE-ECDSA-AES256-SHA - ECDHE-RSA-AES256-SHA - DHE-RSA-AES128-SHA256
+                              - DHE-RSA-AES256-SHA256 - AES128-GCM-SHA256 - AES256-GCM-SHA384
+                              - AES128-SHA256 - AES256-SHA256 - AES128-SHA - AES256-SHA
+                              - DES-CBC3-SHA minTLSVersion: VersionTLS10"
+                            nullable: true
+                            type: object
+                          type:
+                            description: "type is one of Old, Intermediate, Modern
+                              or Custom. Custom provides the ability to specify individual
+                              TLS security profile parameters. Old, Intermediate and
+                              Modern are TLS security profiles based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations
+                              \n The profiles are intent based, so they may change
+                              over time as new ciphers are developed and existing
+                              ciphers are found to be insecure.  Depending on precisely
+                              which ciphers are available to a process, the list may
+                              be reduced. \n Note that the Modern profile is currently
+                              not supported because it is not yet well adopted by
+                              common software libraries."
+                            enum:
+                            - Old
+                            - Intermediate
+                            - Modern
+                            - Custom
+                            type: string
+                        type: object
+                    type: object
+                  authentication:
+                    description: Authentication specifies cluster-wide settings for
+                      authentication (like OAuth and webhook token authenticators).
+                    properties:
+                      oauthMetadata:
+                        description: 'oauthMetadata contains the discovery endpoint
+                          data for OAuth 2.0 Authorization Server Metadata for an
+                          external OAuth server. This discovery document can be viewed
+                          from its served location: oc get --raw ''/.well-known/oauth-authorization-server''
+                          For further details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2
+                          If oauthMetadata.name is non-empty, this value has precedence
+                          over any metadata reference stored in status. The key "oauthMetadata"
+                          is used to locate the data. If specified and the config
+                          map or expected key is not found, no metadata is served.
+                          If the specified metadata is not valid, no metadata is served.
+                          The namespace for this config map is openshift-config.'
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      oidcProviders:
+                        description: "OIDCProviders are OIDC identity providers that
+                          can issue tokens for this cluster Can only be set if \"Type\"
+                          is set to \"OIDC\". \n At most one provider can be configured."
+                        items:
+                          properties:
+                            claimMappings:
+                              description: ClaimMappings describes rules on how to
+                                transform information from an ID token into a cluster
+                                identity
+                              properties:
+                                groups:
+                                  description: Groups is a name of the claim that
+                                    should be used to construct groups for the cluster
+                                    identity. The referenced claim must use array
+                                    of strings values.
+                                  properties:
+                                    claim:
+                                      description: Claim is a JWT token claim to be
+                                        used in the mapping
+                                      type: string
+                                    prefix:
+                                      description: "Prefix is a string to prefix the
+                                        value from the token in the result of the
+                                        claim mapping. \n By default, no prefixing
+                                        occurs. \n Example: if `prefix` is set to
+                                        \"myoidc:\"\" and the `claim` in JWT contains
+                                        an array of strings \"a\", \"b\" and  \"c\",
+                                        the mapping will result in an array of string
+                                        \"myoidc:a\", \"myoidc:b\" and \"myoidc:c\"."
+                                      type: string
+                                  required:
+                                  - claim
+                                  type: object
+                                username:
+                                  description: "Username is a name of the claim that
+                                    should be used to construct usernames for the
+                                    cluster identity. \n Default value: \"sub\""
+                                  properties:
+                                    claim:
+                                      description: Claim is a JWT token claim to be
+                                        used in the mapping
+                                      type: string
+                                    prefix:
+                                      properties:
+                                        prefixString:
+                                          minLength: 1
+                                          type: string
+                                      required:
+                                      - prefixString
+                                      type: object
+                                    prefixPolicy:
+                                      description: "PrefixPolicy specifies how a prefix
+                                        should apply. \n By default, claims other
+                                        than `email` will be prefixed with the issuer
+                                        URL to prevent naming clashes with other plugins.
+                                        \n Set to \"NoPrefix\" to disable prefixing.
+                                        \n Example: (1) `prefix` is set to \"myoidc:\"
+                                        and `claim` is set to \"username\". If the
+                                        JWT claim `username` contains value `userA`,
+                                        the resulting mapped value will be \"myoidc:userA\".
+                                        (2) `prefix` is set to \"myoidc:\" and `claim`
+                                        is set to \"email\". If the JWT `email` claim
+                                        contains value \"userA@myoidc.tld\", the resulting
+                                        mapped value will be \"myoidc:userA@myoidc.tld\".
+                                        (3) `prefix` is unset, `issuerURL` is set
+                                        to `https://myoidc.tld`, the JWT claims include
+                                        \"username\":\"userA\" and \"email\":\"userA@myoidc.tld\",
+                                        and `claim` is set to: (a) \"username\": the
+                                        mapped value will be \"https://myoidc.tld#userA\"
+                                        (b) \"email\": the mapped value will be \"userA@myoidc.tld\""
+                                      enum:
+                                      - ""
+                                      - NoPrefix
+                                      - Prefix
+                                      type: string
+                                  required:
+                                  - claim
+                                  type: object
+                                  x-kubernetes-validations:
+                                  - message: prefix must be set if prefixPolicy is
+                                      'Prefix', but must remain unset otherwise
+                                    rule: 'has(self.prefixPolicy) && self.prefixPolicy
+                                      == ''Prefix'' ? (has(self.prefix) && size(self.prefix.prefixString)
+                                      > 0) : !has(self.prefix)'
+                              type: object
+                            claimValidationRules:
+                              description: ClaimValidationRules are rules that are
+                                applied to validate token claims to authenticate users.
+                              items:
+                                properties:
+                                  requiredClaim:
+                                    description: RequiredClaim allows configuring
+                                      a required claim name and its expected value
+                                    properties:
+                                      claim:
+                                        description: Claim is a name of a required
+                                          claim. Only claims with string values are
+                                          supported.
+                                        minLength: 1
+                                        type: string
+                                      requiredValue:
+                                        description: RequiredValue is the required
+                                          value for the claim.
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - claim
+                                    - requiredValue
+                                    type: object
+                                  type:
+                                    default: RequiredClaim
+                                    description: Type sets the type of the validation
+                                      rule
+                                    enum:
+                                    - RequiredClaim
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            issuer:
+                              description: Issuer describes atributes of the OIDC
+                                token issuer
+                              properties:
+                                audiences:
+                                  description: Audiences is an array of audiences
+                                    that the token was issued for. Valid tokens must
+                                    include at least one of these values in their
+                                    "aud" claim. Must be set to exactly one value.
+                                  items:
+                                    minLength: 1
+                                    type: string
+                                  maxItems: 10
+                                  minItems: 1
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                issuerCertificateAuthority:
+                                  description: CertificateAuthority is a reference
+                                    to a config map in the configuration namespace.
+                                    The .data of the configMap must contain the "ca-bundle.crt"
+                                    key. If unset, system trust is used instead.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced config map
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                issuerURL:
+                                  description: URL is the serving URL of the token
+                                    issuer. Must use the https:// scheme.
+                                  pattern: ^https:\/\/[^\s]
+                                  type: string
+                              required:
+                              - audiences
+                              - issuerURL
+                              type: object
+                            name:
+                              description: Name of the OIDC provider
+                              minLength: 1
+                              type: string
+                            oidcClients:
+                              description: OIDCClients contains configuration for
+                                the platform's clients that need to request tokens
+                                from the issuer
+                              items:
+                                properties:
+                                  clientID:
+                                    description: ClientID is the identifier of the
+                                      OIDC client from the OIDC provider
+                                    minLength: 1
+                                    type: string
+                                  clientSecret:
+                                    description: ClientSecret refers to a secret in
+                                      the `openshift-config` namespace that contains
+                                      the client secret in the `clientSecret` key
+                                      of the `.data` field
+                                    properties:
+                                      name:
+                                        description: name is the metadata.name of
+                                          the referenced secret
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  componentName:
+                                    description: ComponentName is the name of the
+                                      component that is supposed to consume this client
+                                      configuration
+                                    maxLength: 256
+                                    minLength: 1
+                                    type: string
+                                  componentNamespace:
+                                    description: ComponentNamespace is the namespace
+                                      of the component that is supposed to consume
+                                      this client configuration
+                                    maxLength: 63
+                                    minLength: 1
+                                    type: string
+                                  extraScopes:
+                                    description: ExtraScopes is an optional set of
+                                      scopes to request tokens with.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - clientID
+                                - componentName
+                                - componentNamespace
+                                type: object
+                              maxItems: 20
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - componentNamespace
+                              - componentName
+                              x-kubernetes-list-type: map
+                          required:
+                          - issuer
+                          - name
+                          type: object
+                        maxItems: 1
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      serviceAccountIssuer:
+                        description: 'serviceAccountIssuer is the identifier of the
+                          bound service account token issuer. The default is https://kubernetes.default.svc
+                          WARNING: Updating this field will not result in immediate
+                          invalidation of all bound tokens with the previous issuer
+                          value. Instead, the tokens issued by previous service account
+                          issuer will continue to be trusted for a time period chosen
+                          by the platform (currently set to 24h). This time period
+                          is subject to change over time. This allows internal components
+                          to transition to use new service account issuer without
+                          service distruption.'
+                        type: string
+                      type:
+                        description: type identifies the cluster managed, user facing
+                          authentication mode in use. Specifically, it manages the
+                          component that responds to login attempts. The default is
+                          IntegratedOAuth.
+                        type: string
+                      webhookTokenAuthenticator:
+                        description: "webhookTokenAuthenticator configures a remote
+                          token reviewer. These remote authentication webhooks can
+                          be used to verify bearer tokens via the tokenreviews.authentication.k8s.io
+                          REST API. This is required to honor bearer tokens that are
+                          provisioned by an external authentication service. \n Can
+                          only be set if \"Type\" is set to \"None\"."
+                        properties:
+                          kubeConfig:
+                            description: "kubeConfig references a secret that contains
+                              kube config file data which describes how to access
+                              the remote webhook service. The namespace for the referenced
+                              secret is openshift-config. \n For further details,
+                              see: \n https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication
+                              \n The key \"kubeConfig\" is used to locate the data.
+                              If the secret or expected key is not found, the webhook
+                              is not honored. If the specified kube config data is
+                              not valid, the webhook is not honored."
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        required:
+                        - kubeConfig
+                        type: object
+                      webhookTokenAuthenticators:
+                        description: webhookTokenAuthenticators is DEPRECATED, setting
+                          it has no effect.
+                        items:
+                          description: deprecatedWebhookTokenAuthenticator holds the
+                            necessary configuration options for a remote token authenticator.
+                            It's the same as WebhookTokenAuthenticator but it's missing
+                            the 'required' validation on KubeConfig field.
+                          properties:
+                            kubeConfig:
+                              description: 'kubeConfig contains kube config file data
+                                which describes how to access the remote webhook service.
+                                For further details, see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication
+                                The key "kubeConfig" is used to locate the data. If
+                                the secret or expected key is not found, the webhook
+                                is not honored. If the specified kube config data
+                                is not valid, the webhook is not honored. The namespace
+                                for this secret is determined by the point of use.'
+                              properties:
+                                name:
+                                  description: name is the metadata.name of the referenced
+                                    secret
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  featureGate:
+                    description: FeatureGate holds cluster-wide information about
+                      feature gates.
+                    properties:
+                      customNoUpgrade:
+                        description: customNoUpgrade allows the enabling or disabling
+                          of any feature. Turning this feature set on IS NOT SUPPORTED,
+                          CANNOT BE UNDONE, and PREVENTS UPGRADES. Because of its
+                          nature, this setting cannot be validated.  If you have any
+                          typos or accidentally apply invalid combinations your cluster
+                          may fail in an unrecoverable way.  featureSet must equal
+                          "CustomNoUpgrade" must be set to use this field.
+                        nullable: true
+                        properties:
+                          disabled:
+                            description: disabled is a list of all feature gates that
+                              you want to force off
+                            items:
+                              description: FeatureGateName is a string to enforce
+                                patterns on the name of a FeatureGate
+                              pattern: ^([A-Za-z0-9-]+\.)*[A-Za-z0-9-]+\.?$
+                              type: string
+                            type: array
+                          enabled:
+                            description: enabled is a list of all feature gates that
+                              you want to force on
+                            items:
+                              description: FeatureGateName is a string to enforce
+                                patterns on the name of a FeatureGate
+                              pattern: ^([A-Za-z0-9-]+\.)*[A-Za-z0-9-]+\.?$
+                              type: string
+                            type: array
+                        type: object
+                      featureSet:
+                        description: featureSet changes the list of features in the
+                          cluster.  The default is empty.  Be very careful adjusting
+                          this setting. Turning on or off features may cause irreversible
+                          changes in your cluster which cannot be undone.
+                        type: string
+                    type: object
+                  image:
+                    description: Image governs policies related to imagestream imports
+                      and runtime configuration for external registries. It allows
+                      cluster admins to configure which registries OpenShift is allowed
+                      to import images from, extra CA trust bundles for external registries,
+                      and policies to block or allow registry hostnames. When exposing
+                      OpenShift's image registry to the public, this also lets cluster
+                      admins specify the external hostname.
+                    properties:
+                      additionalTrustedCA:
+                        description: additionalTrustedCA is a reference to a ConfigMap
+                          containing additional CAs that should be trusted during
+                          imagestream import, pod image pull, build image pull, and
+                          imageregistry pullthrough. The namespace for this config
+                          map is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      allowedRegistriesForImport:
+                        description: allowedRegistriesForImport limits the container
+                          image registries that normal users may import images from.
+                          Set this list to the registries that you trust to contain
+                          valid Docker images and that you want applications to be
+                          able to import from. Users with permission to create Images
+                          or ImageStreamMappings via the API are not affected by this
+                          policy - typically only administrators or system integrations
+                          will have those permissions.
+                        items:
+                          description: RegistryLocation contains a location of the
+                            registry specified by the registry domain name. The domain
+                            name might include wildcards, like '*' or '??'.
+                          properties:
+                            domainName:
+                              description: domainName specifies a domain name for
+                                the registry In case the registry use non-standard
+                                (80 or 443) port, the port should be included in the
+                                domain name as well.
+                              type: string
+                            insecure:
+                              description: insecure indicates whether the registry
+                                is secure (https) or insecure (http) By default (if
+                                not specified) the registry is assumed as secure.
+                              type: boolean
+                          type: object
+                        type: array
+                      externalRegistryHostnames:
+                        description: externalRegistryHostnames provides the hostnames
+                          for the default external image registry. The external hostname
+                          should be set only when the image registry is exposed externally.
+                          The first value is used in 'publicDockerImageRepository'
+                          field in ImageStreams. The value must be in "hostname[:port]"
+                          format.
+                        items:
+                          type: string
+                        type: array
+                      registrySources:
+                        description: registrySources contains configuration that determines
+                          how the container runtime should treat individual registries
+                          when accessing images for builds+pods. (e.g. whether or
+                          not to allow insecure access).  It does not contain configuration
+                          for the internal cluster registry.
+                        properties:
+                          allowedRegistries:
+                            description: "allowedRegistries are the only registries
+                              permitted for image pull and push actions. All other
+                              registries are denied. \n Only one of BlockedRegistries
+                              or AllowedRegistries may be set."
+                            items:
+                              type: string
+                            type: array
+                          blockedRegistries:
+                            description: "blockedRegistries cannot be used for image
+                              pull and push actions. All other registries are permitted.
+                              \n Only one of BlockedRegistries or AllowedRegistries
+                              may be set."
+                            items:
+                              type: string
+                            type: array
+                          containerRuntimeSearchRegistries:
+                            description: 'containerRuntimeSearchRegistries are registries
+                              that will be searched when pulling images that do not
+                              have fully qualified domains in their pull specs. Registries
+                              will be searched in the order provided in the list.
+                              Note: this search list only works with the container
+                              runtime, i.e CRI-O. Will NOT work with builds or imagestream
+                              imports.'
+                            format: hostname
+                            items:
+                              type: string
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
+                          insecureRegistries:
+                            description: insecureRegistries are registries which do
+                              not have a valid TLS certificates or only support HTTP
+                              connections.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                    type: object
+                  ingress:
+                    description: Ingress holds cluster-wide information about ingress,
+                      including the default ingress domain used for routes.
+                    properties:
+                      appsDomain:
+                        description: appsDomain is an optional domain to use instead
+                          of the one specified in the domain field when a Route is
+                          created without specifying an explicit host. If appsDomain
+                          is nonempty, this value is used to generate default host
+                          values for Route. Unlike domain, appsDomain may be modified
+                          after installation. This assumes a new ingresscontroller
+                          has been setup with a wildcard certificate.
+                        type: string
+                      componentRoutes:
+                        description: "componentRoutes is an optional list of routes
+                          that are managed by OpenShift components that a cluster-admin
+                          is able to configure the hostname and serving certificate
+                          for. The namespace and name of each route in this list should
+                          match an existing entry in the status.componentRoutes list.
+                          \n To determine the set of configurable Routes, look at
+                          namespace and name of entries in the .status.componentRoutes
+                          list, where participating operators write the status of
+                          configurable routes."
+                        items:
+                          description: ComponentRouteSpec allows for configuration
+                            of a route's hostname and serving certificate.
+                          properties:
+                            hostname:
+                              description: hostname is the hostname that should be
+                                used by the route.
+                              pattern: ^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
+                              type: string
+                            name:
+                              description: "name is the logical name of the route
+                                to customize. \n The namespace and name of this componentRoute
+                                must match a corresponding entry in the list of status.componentRoutes
+                                if the route is to be customized."
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                            namespace:
+                              description: "namespace is the namespace of the route
+                                to customize. \n The namespace and name of this componentRoute
+                                must match a corresponding entry in the list of status.componentRoutes
+                                if the route is to be customized."
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            servingCertKeyPairSecret:
+                              description: servingCertKeyPairSecret is a reference
+                                to a secret of type `kubernetes.io/tls` in the openshift-config
+                                namespace. The serving cert/key pair must match and
+                                will be used by the operator to fulfill the intent
+                                of serving with this name. If the custom hostname
+                                uses the default routing suffix of the cluster, the
+                                Secret specification for a serving certificate will
+                                not be needed.
+                              properties:
+                                name:
+                                  description: name is the metadata.name of the referenced
+                                    secret
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                          required:
+                          - hostname
+                          - name
+                          - namespace
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - namespace
+                        - name
+                        x-kubernetes-list-type: map
+                      domain:
+                        description: "domain is used to generate a default host name
+                          for a route when the route's host name is empty. The generated
+                          host name will follow this pattern: \"<route-name>.<route-namespace>.<domain>\".
+                          \n It is also used as the default wildcard domain suffix
+                          for ingress. The default ingresscontroller domain will follow
+                          this pattern: \"*.<domain>\". \n Once set, changing domain
+                          is not currently supported."
+                        type: string
+                      loadBalancer:
+                        description: loadBalancer contains the load balancer details
+                          in general which are not only specific to the underlying
+                          infrastructure provider of the current cluster and are required
+                          for Ingress Controller to work on OpenShift.
+                        properties:
+                          platform:
+                            description: platform holds configuration specific to
+                              the underlying infrastructure provider for the ingress
+                              load balancers. When omitted, this means the user has
+                              no opinion and the platform is left to choose reasonable
+                              defaults. These defaults are subject to change over
+                              time.
+                            properties:
+                              aws:
+                                description: aws contains settings specific to the
+                                  Amazon Web Services infrastructure provider.
+                                properties:
+                                  type:
+                                    description: "type allows user to set a load balancer
+                                      type. When this field is set the default ingresscontroller
+                                      will get created using the specified LBType.
+                                      If this field is not set then the default ingress
+                                      controller of LBType Classic will be created.
+                                      Valid values are: \n * \"Classic\": A Classic
+                                      Load Balancer that makes routing decisions at
+                                      either the transport layer (TCP/SSL) or the
+                                      application layer (HTTP/HTTPS). See the following
+                                      for additional details: \n https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#clb
+                                      \n * \"NLB\": A Network Load Balancer that makes
+                                      routing decisions at the transport layer (TCP/SSL).
+                                      See the following for additional details: \n
+                                      https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#nlb"
+                                    enum:
+                                    - NLB
+                                    - Classic
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              type:
+                                description: type is the underlying infrastructure
+                                  provider for the cluster. Allowed values are "AWS",
+                                  "Azure", "BareMetal", "GCP", "Libvirt", "OpenStack",
+                                  "VSphere", "oVirt", "KubeVirt", "EquinixMetal",
+                                  "PowerVS", "AlibabaCloud", "Nutanix" and "None".
+                                  Individual components may not support all platforms,
+                                  and must handle unrecognized platforms as None if
+                                  they do not support that platform.
+                                enum:
+                                - ""
+                                - AWS
+                                - Azure
+                                - BareMetal
+                                - GCP
+                                - Libvirt
+                                - OpenStack
+                                - None
+                                - VSphere
+                                - oVirt
+                                - IBMCloud
+                                - KubeVirt
+                                - EquinixMetal
+                                - PowerVS
+                                - AlibabaCloud
+                                - Nutanix
+                                - External
+                                type: string
+                            type: object
+                        type: object
+                      requiredHSTSPolicies:
+                        description: "requiredHSTSPolicies specifies HSTS policies
+                          that are required to be set on newly created  or updated
+                          routes matching the domainPattern/s and namespaceSelector/s
+                          that are specified in the policy. Each requiredHSTSPolicy
+                          must have at least a domainPattern and a maxAge to validate
+                          a route HSTS Policy route annotation, and affect route admission.
+                          \n A candidate route is checked for HSTS Policies if it
+                          has the HSTS Policy route annotation: \"haproxy.router.openshift.io/hsts_header\"
+                          E.g. haproxy.router.openshift.io/hsts_header: max-age=31536000;preload;includeSubDomains
+                          \n - For each candidate route, if it matches a requiredHSTSPolicy
+                          domainPattern and optional namespaceSelector, then the maxAge,
+                          preloadPolicy, and includeSubdomainsPolicy must be valid
+                          to be admitted.  Otherwise, the route is rejected. - The
+                          first match, by domainPattern and optional namespaceSelector,
+                          in the ordering of the RequiredHSTSPolicies determines the
+                          route's admission status. - If the candidate route doesn't
+                          match any requiredHSTSPolicy domainPattern and optional
+                          namespaceSelector, then it may use any HSTS Policy annotation.
+                          \n The HSTS policy configuration may be changed after routes
+                          have already been created. An update to a previously admitted
+                          route may then fail if the updated route does not conform
+                          to the updated HSTS policy configuration. However, changing
+                          the HSTS policy configuration will not cause a route that
+                          is already admitted to stop working. \n Note that if there
+                          are no RequiredHSTSPolicies, any HSTS Policy annotation
+                          on the route is valid."
+                        items:
+                          properties:
+                            domainPatterns:
+                              description: "domainPatterns is a list of domains for
+                                which the desired HSTS annotations are required. If
+                                domainPatterns is specified and a route is created
+                                with a spec.host matching one of the domains, the
+                                route must specify the HSTS Policy components described
+                                in the matching RequiredHSTSPolicy. \n The use of
+                                wildcards is allowed like this: *.foo.com matches
+                                everything under foo.com. foo.com only matches foo.com,
+                                so to cover foo.com and everything under it, you must
+                                specify *both*."
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                            includeSubDomainsPolicy:
+                              description: 'includeSubDomainsPolicy means the HSTS
+                                Policy should apply to any subdomains of the host''s
+                                domain name.  Thus, for the host bar.foo.com, if includeSubDomainsPolicy
+                                was set to RequireIncludeSubDomains: - the host app.bar.foo.com
+                                would inherit the HSTS Policy of bar.foo.com - the
+                                host bar.foo.com would inherit the HSTS Policy of
+                                bar.foo.com - the host foo.com would NOT inherit the
+                                HSTS Policy of bar.foo.com - the host def.foo.com
+                                would NOT inherit the HSTS Policy of bar.foo.com'
+                              enum:
+                              - RequireIncludeSubDomains
+                              - RequireNoIncludeSubDomains
+                              - NoOpinion
+                              type: string
+                            maxAge:
+                              description: maxAge is the delta time range in seconds
+                                during which hosts are regarded as HSTS hosts. If
+                                set to 0, it negates the effect, and hosts are removed
+                                as HSTS hosts. If set to 0 and includeSubdomains is
+                                specified, all subdomains of the host are also removed
+                                as HSTS hosts. maxAge is a time-to-live value, and
+                                if this policy is not refreshed on a client, the HSTS
+                                policy will eventually expire on that client.
+                              properties:
+                                largestMaxAge:
+                                  description: The largest allowed value (in seconds)
+                                    of the RequiredHSTSPolicy max-age This value can
+                                    be left unspecified, in which case no upper limit
+                                    is enforced.
+                                  format: int32
+                                  maximum: 2147483647
+                                  minimum: 0
+                                  type: integer
+                                smallestMaxAge:
+                                  description: The smallest allowed value (in seconds)
+                                    of the RequiredHSTSPolicy max-age Setting max-age=0
+                                    allows the deletion of an existing HSTS header
+                                    from a host.  This is a necessary tool for administrators
+                                    to quickly correct mistakes. This value can be
+                                    left unspecified, in which case no lower limit
+                                    is enforced.
+                                  format: int32
+                                  maximum: 2147483647
+                                  minimum: 0
+                                  type: integer
+                              type: object
+                            namespaceSelector:
+                              description: namespaceSelector specifies a label selector
+                                such that the policy applies only to those routes
+                                that are in namespaces with labels that match the
+                                selector, and are in one of the DomainPatterns. Defaults
+                                to the empty LabelSelector, which matches everything.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            preloadPolicy:
+                              description: preloadPolicy directs the client to include
+                                hosts in its host preload list so that it never needs
+                                to do an initial load to get the HSTS header (note
+                                that this is not defined in RFC 6797 and is therefore
+                                client implementation-dependent).
+                              enum:
+                              - RequirePreload
+                              - RequireNoPreload
+                              - NoOpinion
+                              type: string
+                          required:
+                          - domainPatterns
+                          type: object
+                        type: array
+                    type: object
+                  network:
+                    description: 'Network holds cluster-wide information about the
+                      network. It is used to configure the desired network configuration,
+                      such as: IP address pools for services/pod IPs, network plugin,
+                      etc. Please view network.spec for an explanation on what applies
+                      when configuring this resource. TODO (csrwng): Add validation
+                      here to exclude changes that conflict with networking settings
+                      in the HostedCluster.Spec.Networking field.'
+                    properties:
+                      clusterNetwork:
+                        description: IP address pool to use for pod IPs. This field
+                          is immutable after installation.
+                        items:
+                          description: ClusterNetworkEntry is a contiguous block of
+                            IP addresses from which pod IPs are allocated.
+                          properties:
+                            cidr:
+                              description: The complete block for pod IPs.
+                              type: string
+                            hostPrefix:
+                              description: The size (prefix) of block to allocate
+                                to each node. If this field is not used by the plugin,
+                                it can be left unset.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                          type: object
+                        type: array
+                      externalIP:
+                        description: externalIP defines configuration for controllers
+                          that affect Service.ExternalIP. If nil, then ExternalIP
+                          is not allowed to be set.
+                        properties:
+                          autoAssignCIDRs:
+                            description: autoAssignCIDRs is a list of CIDRs from which
+                              to automatically assign Service.ExternalIP. These are
+                              assigned when the service is of type LoadBalancer. In
+                              general, this is only useful for bare-metal clusters.
+                              In Openshift 3.x, this was misleadingly called "IngressIPs".
+                              Automatically assigned External IPs are not affected
+                              by any ExternalIPPolicy rules. Currently, only one entry
+                              may be provided.
+                            items:
+                              type: string
+                            type: array
+                          policy:
+                            description: policy is a set of restrictions applied to
+                              the ExternalIP field. If nil or empty, then ExternalIP
+                              is not allowed to be set.
+                            properties:
+                              allowedCIDRs:
+                                description: allowedCIDRs is the list of allowed CIDRs.
+                                items:
+                                  type: string
+                                type: array
+                              rejectedCIDRs:
+                                description: rejectedCIDRs is the list of disallowed
+                                  CIDRs. These take precedence over allowedCIDRs.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      networkType:
+                        description: 'NetworkType is the plugin that is to be deployed
+                          (e.g. OpenShiftSDN). This should match a value that the
+                          cluster-network-operator understands, or else no networking
+                          will be installed. Currently supported values are: - OpenShiftSDN
+                          This field is immutable after installation.'
+                        type: string
+                      serviceNetwork:
+                        description: IP address pool for services. Currently, we only
+                          support a single entry here. This field is immutable after
+                          installation.
+                        items:
+                          type: string
+                        type: array
+                      serviceNodePortRange:
+                        description: The port range allowed for Services of type NodePort.
+                          If not specified, the default of 30000-32767 will be used.
+                          Such Services without a NodePort specified will have one
+                          automatically allocated from this range. This parameter
+                          can be updated after the cluster is installed.
+                        pattern: ^([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])-([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
+                        type: string
+                    type: object
+                  oauth:
+                    description: OAuth holds cluster-wide information about OAuth.
+                      It is used to configure the integrated OAuth server. This configuration
+                      is only honored when the top level Authentication config has
+                      type set to IntegratedOAuth.
+                    properties:
+                      identityProviders:
+                        description: identityProviders is an ordered list of ways
+                          for a user to identify themselves. When this list is empty,
+                          no identities are provisioned for users.
+                        items:
+                          description: IdentityProvider provides identities for users
+                            authenticating using credentials
+                          properties:
+                            basicAuth:
+                              description: basicAuth contains configuration options
+                                for the BasicAuth IdP
+                              properties:
+                                ca:
+                                  description: ca is an optional reference to a config
+                                    map by name containing the PEM-encoded CA bundle.
+                                    It is used as a trust anchor to validate the TLS
+                                    certificate presented by the remote server. The
+                                    key "ca.crt" is used to locate the data. If specified
+                                    and the config map or expected key is not found,
+                                    the identity provider is not honored. If the specified
+                                    ca data is not valid, the identity provider is
+                                    not honored. If empty, the default system roots
+                                    are used. The namespace for this config map is
+                                    openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced config map
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                tlsClientCert:
+                                  description: tlsClientCert is an optional reference
+                                    to a secret by name that contains the PEM-encoded
+                                    TLS client certificate to present when connecting
+                                    to the server. The key "tls.crt" is used to locate
+                                    the data. If specified and the secret or expected
+                                    key is not found, the identity provider is not
+                                    honored. If the specified certificate data is
+                                    not valid, the identity provider is not honored.
+                                    The namespace for this secret is openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced secret
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                tlsClientKey:
+                                  description: tlsClientKey is an optional reference
+                                    to a secret by name that contains the PEM-encoded
+                                    TLS private key for the client certificate referenced
+                                    in tlsClientCert. The key "tls.key" is used to
+                                    locate the data. If specified and the secret or
+                                    expected key is not found, the identity provider
+                                    is not honored. If the specified certificate data
+                                    is not valid, the identity provider is not honored.
+                                    The namespace for this secret is openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced secret
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                url:
+                                  description: url is the remote URL to connect to
+                                  type: string
+                              type: object
+                            github:
+                              description: github enables user authentication using
+                                GitHub credentials
+                              properties:
+                                ca:
+                                  description: ca is an optional reference to a config
+                                    map by name containing the PEM-encoded CA bundle.
+                                    It is used as a trust anchor to validate the TLS
+                                    certificate presented by the remote server. The
+                                    key "ca.crt" is used to locate the data. If specified
+                                    and the config map or expected key is not found,
+                                    the identity provider is not honored. If the specified
+                                    ca data is not valid, the identity provider is
+                                    not honored. If empty, the default system roots
+                                    are used. This can only be configured when hostname
+                                    is set to a non-empty value. The namespace for
+                                    this config map is openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced config map
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                clientID:
+                                  description: clientID is the oauth client ID
+                                  type: string
+                                clientSecret:
+                                  description: clientSecret is a required reference
+                                    to the secret by name containing the oauth client
+                                    secret. The key "clientSecret" is used to locate
+                                    the data. If the secret or expected key is not
+                                    found, the identity provider is not honored. The
+                                    namespace for this secret is openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced secret
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                hostname:
+                                  description: hostname is the optional domain (e.g.
+                                    "mycompany.com") for use with a hosted instance
+                                    of GitHub Enterprise. It must match the GitHub
+                                    Enterprise settings value configured at /setup/settings#hostname.
+                                  type: string
+                                organizations:
+                                  description: organizations optionally restricts
+                                    which organizations are allowed to log in
+                                  items:
+                                    type: string
+                                  type: array
+                                teams:
+                                  description: teams optionally restricts which teams
+                                    are allowed to log in. Format is <org>/<team>.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            gitlab:
+                              description: gitlab enables user authentication using
+                                GitLab credentials
+                              properties:
+                                ca:
+                                  description: ca is an optional reference to a config
+                                    map by name containing the PEM-encoded CA bundle.
+                                    It is used as a trust anchor to validate the TLS
+                                    certificate presented by the remote server. The
+                                    key "ca.crt" is used to locate the data. If specified
+                                    and the config map or expected key is not found,
+                                    the identity provider is not honored. If the specified
+                                    ca data is not valid, the identity provider is
+                                    not honored. If empty, the default system roots
+                                    are used. The namespace for this config map is
+                                    openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced config map
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                clientID:
+                                  description: clientID is the oauth client ID
+                                  type: string
+                                clientSecret:
+                                  description: clientSecret is a required reference
+                                    to the secret by name containing the oauth client
+                                    secret. The key "clientSecret" is used to locate
+                                    the data. If the secret or expected key is not
+                                    found, the identity provider is not honored. The
+                                    namespace for this secret is openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced secret
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                url:
+                                  description: url is the oauth server base URL
+                                  type: string
+                              type: object
+                            google:
+                              description: google enables user authentication using
+                                Google credentials
+                              properties:
+                                clientID:
+                                  description: clientID is the oauth client ID
+                                  type: string
+                                clientSecret:
+                                  description: clientSecret is a required reference
+                                    to the secret by name containing the oauth client
+                                    secret. The key "clientSecret" is used to locate
+                                    the data. If the secret or expected key is not
+                                    found, the identity provider is not honored. The
+                                    namespace for this secret is openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced secret
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                hostedDomain:
+                                  description: hostedDomain is the optional Google
+                                    App domain (e.g. "mycompany.com") to restrict
+                                    logins to
+                                  type: string
+                              type: object
+                            htpasswd:
+                              description: htpasswd enables user authentication using
+                                an HTPasswd file to validate credentials
+                              properties:
+                                fileData:
+                                  description: fileData is a required reference to
+                                    a secret by name containing the data to use as
+                                    the htpasswd file. The key "htpasswd" is used
+                                    to locate the data. If the secret or expected
+                                    key is not found, the identity provider is not
+                                    honored. If the specified htpasswd data is not
+                                    valid, the identity provider is not honored. The
+                                    namespace for this secret is openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced secret
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                              type: object
+                            keystone:
+                              description: keystone enables user authentication using
+                                keystone password credentials
+                              properties:
+                                ca:
+                                  description: ca is an optional reference to a config
+                                    map by name containing the PEM-encoded CA bundle.
+                                    It is used as a trust anchor to validate the TLS
+                                    certificate presented by the remote server. The
+                                    key "ca.crt" is used to locate the data. If specified
+                                    and the config map or expected key is not found,
+                                    the identity provider is not honored. If the specified
+                                    ca data is not valid, the identity provider is
+                                    not honored. If empty, the default system roots
+                                    are used. The namespace for this config map is
+                                    openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced config map
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                domainName:
+                                  description: domainName is required for keystone
+                                    v3
+                                  type: string
+                                tlsClientCert:
+                                  description: tlsClientCert is an optional reference
+                                    to a secret by name that contains the PEM-encoded
+                                    TLS client certificate to present when connecting
+                                    to the server. The key "tls.crt" is used to locate
+                                    the data. If specified and the secret or expected
+                                    key is not found, the identity provider is not
+                                    honored. If the specified certificate data is
+                                    not valid, the identity provider is not honored.
+                                    The namespace for this secret is openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced secret
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                tlsClientKey:
+                                  description: tlsClientKey is an optional reference
+                                    to a secret by name that contains the PEM-encoded
+                                    TLS private key for the client certificate referenced
+                                    in tlsClientCert. The key "tls.key" is used to
+                                    locate the data. If specified and the secret or
+                                    expected key is not found, the identity provider
+                                    is not honored. If the specified certificate data
+                                    is not valid, the identity provider is not honored.
+                                    The namespace for this secret is openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced secret
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                url:
+                                  description: url is the remote URL to connect to
+                                  type: string
+                              type: object
+                            ldap:
+                              description: ldap enables user authentication using
+                                LDAP credentials
+                              properties:
+                                attributes:
+                                  description: attributes maps LDAP attributes to
+                                    identities
+                                  properties:
+                                    email:
+                                      description: email is the list of attributes
+                                        whose values should be used as the email address.
+                                        Optional. If unspecified, no email is set
+                                        for the identity
+                                      items:
+                                        type: string
+                                      type: array
+                                    id:
+                                      description: id is the list of attributes whose
+                                        values should be used as the user ID. Required.
+                                        First non-empty attribute is used. At least
+                                        one attribute is required. If none of the
+                                        listed attribute have a value, authentication
+                                        fails. LDAP standard identity attribute is
+                                        "dn"
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: name is the list of attributes
+                                        whose values should be used as the display
+                                        name. Optional. If unspecified, no display
+                                        name is set for the identity LDAP standard
+                                        display name attribute is "cn"
+                                      items:
+                                        type: string
+                                      type: array
+                                    preferredUsername:
+                                      description: preferredUsername is the list of
+                                        attributes whose values should be used as
+                                        the preferred username. LDAP standard login
+                                        attribute is "uid"
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                bindDN:
+                                  description: bindDN is an optional DN to bind with
+                                    during the search phase.
+                                  type: string
+                                bindPassword:
+                                  description: bindPassword is an optional reference
+                                    to a secret by name containing a password to bind
+                                    with during the search phase. The key "bindPassword"
+                                    is used to locate the data. If specified and the
+                                    secret or expected key is not found, the identity
+                                    provider is not honored. The namespace for this
+                                    secret is openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced secret
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                ca:
+                                  description: ca is an optional reference to a config
+                                    map by name containing the PEM-encoded CA bundle.
+                                    It is used as a trust anchor to validate the TLS
+                                    certificate presented by the remote server. The
+                                    key "ca.crt" is used to locate the data. If specified
+                                    and the config map or expected key is not found,
+                                    the identity provider is not honored. If the specified
+                                    ca data is not valid, the identity provider is
+                                    not honored. If empty, the default system roots
+                                    are used. The namespace for this config map is
+                                    openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced config map
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                insecure:
+                                  description: 'insecure, if true, indicates the connection
+                                    should not use TLS WARNING: Should not be set
+                                    to `true` with the URL scheme "ldaps://" as "ldaps://"
+                                    URLs always attempt to connect using TLS, even
+                                    when `insecure` is set to `true` When `true`,
+                                    "ldap://" URLS connect insecurely. When `false`,
+                                    "ldap://" URLs are upgraded to a TLS connection
+                                    using StartTLS as specified in https://tools.ietf.org/html/rfc2830.'
+                                  type: boolean
+                                url:
+                                  description: 'url is an RFC 2255 URL which specifies
+                                    the LDAP search parameters to use. The syntax
+                                    of the URL is: ldap://host:port/basedn?attribute?scope?filter'
+                                  type: string
+                              type: object
+                            mappingMethod:
+                              description: mappingMethod determines how identities
+                                from this provider are mapped to users Defaults to
+                                "claim"
+                              type: string
+                            name:
+                              description: 'name is used to qualify the identities
+                                returned by this provider. - It MUST be unique and
+                                not shared by any other identity provider used - It
+                                MUST be a valid path segment: name cannot equal "."
+                                or ".." or contain "/" or "%" or ":" Ref: https://godoc.org/github.com/openshift/origin/pkg/user/apis/user/validation#ValidateIdentityProviderName'
+                              type: string
+                            openID:
+                              description: openID enables user authentication using
+                                OpenID credentials
+                              properties:
+                                ca:
+                                  description: ca is an optional reference to a config
+                                    map by name containing the PEM-encoded CA bundle.
+                                    It is used as a trust anchor to validate the TLS
+                                    certificate presented by the remote server. The
+                                    key "ca.crt" is used to locate the data. If specified
+                                    and the config map or expected key is not found,
+                                    the identity provider is not honored. If the specified
+                                    ca data is not valid, the identity provider is
+                                    not honored. If empty, the default system roots
+                                    are used. The namespace for this config map is
+                                    openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced config map
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                claims:
+                                  description: claims mappings
+                                  properties:
+                                    email:
+                                      description: email is the list of claims whose
+                                        values should be used as the email address.
+                                        Optional. If unspecified, no email is set
+                                        for the identity
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    groups:
+                                      description: groups is the list of claims value
+                                        of which should be used to synchronize groups
+                                        from the OIDC provider to OpenShift for the
+                                        user. If multiple claims are specified, the
+                                        first one with a non-empty value is used.
+                                      items:
+                                        description: OpenIDClaim represents a claim
+                                          retrieved from an OpenID provider's tokens
+                                          or userInfo responses
+                                        minLength: 1
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    name:
+                                      description: name is the list of claims whose
+                                        values should be used as the display name.
+                                        Optional. If unspecified, no display name
+                                        is set for the identity
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    preferredUsername:
+                                      description: preferredUsername is the list of
+                                        claims whose values should be used as the
+                                        preferred username. If unspecified, the preferred
+                                        username is determined from the value of the
+                                        sub claim
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                clientID:
+                                  description: clientID is the oauth client ID
+                                  type: string
+                                clientSecret:
+                                  description: clientSecret is a required reference
+                                    to the secret by name containing the oauth client
+                                    secret. The key "clientSecret" is used to locate
+                                    the data. If the secret or expected key is not
+                                    found, the identity provider is not honored. The
+                                    namespace for this secret is openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced secret
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                extraAuthorizeParameters:
+                                  additionalProperties:
+                                    type: string
+                                  description: extraAuthorizeParameters are any custom
+                                    parameters to add to the authorize request.
+                                  type: object
+                                extraScopes:
+                                  description: extraScopes are any scopes to request
+                                    in addition to the standard "openid" scope.
+                                  items:
+                                    type: string
+                                  type: array
+                                issuer:
+                                  description: issuer is the URL that the OpenID Provider
+                                    asserts as its Issuer Identifier. It must use
+                                    the https scheme with no query or fragment component.
+                                  type: string
+                              type: object
+                            requestHeader:
+                              description: requestHeader enables user authentication
+                                using request header credentials
+                              properties:
+                                ca:
+                                  description: ca is a required reference to a config
+                                    map by name containing the PEM-encoded CA bundle.
+                                    It is used as a trust anchor to validate the TLS
+                                    certificate presented by the remote server. Specifically,
+                                    it allows verification of incoming requests to
+                                    prevent header spoofing. The key "ca.crt" is used
+                                    to locate the data. If the config map or expected
+                                    key is not found, the identity provider is not
+                                    honored. If the specified ca data is not valid,
+                                    the identity provider is not honored. The namespace
+                                    for this config map is openshift-config.
+                                  properties:
+                                    name:
+                                      description: name is the metadata.name of the
+                                        referenced config map
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                challengeURL:
+                                  description: challengeURL is a URL to redirect unauthenticated
+                                    /authorize requests to Unauthenticated requests
+                                    from OAuth clients which expect WWW-Authenticate
+                                    challenges will be redirected here. ${url} is
+                                    replaced with the current URL, escaped to be safe
+                                    in a query parameter https://www.example.com/sso-login?then=${url}
+                                    ${query} is replaced with the current query string
+                                    https://www.example.com/auth-proxy/oauth/authorize?${query}
+                                    Required when challenge is set to true.
+                                  type: string
+                                clientCommonNames:
+                                  description: clientCommonNames is an optional list
+                                    of common names to require a match from. If empty,
+                                    any client certificate validated against the clientCA
+                                    bundle is considered authoritative.
+                                  items:
+                                    type: string
+                                  type: array
+                                emailHeaders:
+                                  description: emailHeaders is the set of headers
+                                    to check for the email address
+                                  items:
+                                    type: string
+                                  type: array
+                                headers:
+                                  description: headers is the set of headers to check
+                                    for identity information
+                                  items:
+                                    type: string
+                                  type: array
+                                loginURL:
+                                  description: loginURL is a URL to redirect unauthenticated
+                                    /authorize requests to Unauthenticated requests
+                                    from OAuth clients which expect interactive logins
+                                    will be redirected here ${url} is replaced with
+                                    the current URL, escaped to be safe in a query
+                                    parameter https://www.example.com/sso-login?then=${url}
+                                    ${query} is replaced with the current query string
+                                    https://www.example.com/auth-proxy/oauth/authorize?${query}
+                                    Required when login is set to true.
+                                  type: string
+                                nameHeaders:
+                                  description: nameHeaders is the set of headers to
+                                    check for the display name
+                                  items:
+                                    type: string
+                                  type: array
+                                preferredUsernameHeaders:
+                                  description: preferredUsernameHeaders is the set
+                                    of headers to check for the preferred username
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            type:
+                              description: type identifies the identity provider type
+                                for this entry.
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      templates:
+                        description: templates allow you to customize pages like the
+                          login page.
+                        properties:
+                          error:
+                            description: error is the name of a secret that specifies
+                              a go template to use to render error pages during the
+                              authentication or grant flow. The key "errors.html"
+                              is used to locate the template data. If specified and
+                              the secret or expected key is not found, the default
+                              error page is used. If the specified template is not
+                              valid, the default error page is used. If unspecified,
+                              the default error page is used. The namespace for this
+                              secret is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          login:
+                            description: login is the name of a secret that specifies
+                              a go template to use to render the login page. The key
+                              "login.html" is used to locate the template data. If
+                              specified and the secret or expected key is not found,
+                              the default login page is used. If the specified template
+                              is not valid, the default login page is used. If unspecified,
+                              the default login page is used. The namespace for this
+                              secret is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          providerSelection:
+                            description: providerSelection is the name of a secret
+                              that specifies a go template to use to render the provider
+                              selection page. The key "providers.html" is used to
+                              locate the template data. If specified and the secret
+                              or expected key is not found, the default provider selection
+                              page is used. If the specified template is not valid,
+                              the default provider selection page is used. If unspecified,
+                              the default provider selection page is used. The namespace
+                              for this secret is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        type: object
+                      tokenConfig:
+                        description: tokenConfig contains options for authorization
+                          and access tokens
+                        properties:
+                          accessTokenInactivityTimeout:
+                            description: "accessTokenInactivityTimeout defines the
+                              token inactivity timeout for tokens granted by any client.
+                              The value represents the maximum amount of time that
+                              can occur between consecutive uses of the token. Tokens
+                              become invalid if they are not used within this temporal
+                              window. The user will need to acquire a new token to
+                              regain access once a token times out. Takes valid time
+                              duration string such as \"5m\", \"1.5h\" or \"2h45m\".
+                              The minimum allowed value for duration is 300s (5 minutes).
+                              If the timeout is configured per client, then that value
+                              takes precedence. If the timeout value is not specified
+                              and the client does not override the value, then tokens
+                              are valid until their lifetime. \n WARNING: existing
+                              tokens' timeout will not be affected (lowered) by changing
+                              this value"
+                            type: string
+                          accessTokenInactivityTimeoutSeconds:
+                            description: 'accessTokenInactivityTimeoutSeconds - DEPRECATED:
+                              setting this field has no effect.'
+                            format: int32
+                            type: integer
+                          accessTokenMaxAgeSeconds:
+                            description: accessTokenMaxAgeSeconds defines the maximum
+                              age of access tokens
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                    x-kubernetes-validations:
+                    - message: spec.configuration.oauth.tokenConfig.accessTokenInactivityTimeout
+                        minimum acceptable token timeout value is 300 seconds
+                      rule: '!has(self.tokenConfig) || !has(self.tokenConfig.accessTokenInactivityTimeout)
+                        || duration(self.tokenConfig.accessTokenInactivityTimeout).getSeconds()
+                        >= 300'
+                  operatorhub:
+                    description: OperatorHub specifies the configuration for the Operator
+                      Lifecycle Manager in the HostedCluster. This is only configured
+                      at deployment time but the controller are not reconcilling over
+                      it. The OperatorHub configuration will be constantly reconciled
+                      if catalog placement is management, but only on cluster creation
+                      otherwise.
+                    properties:
+                      disableAllDefaultSources:
+                        description: disableAllDefaultSources allows you to disable
+                          all the default hub sources. If this is true, a specific
+                          entry in sources can be used to enable a default source.
+                          If this is false, a specific entry in sources can be used
+                          to disable or enable a default source.
+                        type: boolean
+                      sources:
+                        description: sources is the list of default hub sources and
+                          their configuration. If the list is empty, it implies that
+                          the default hub sources are enabled on the cluster unless
+                          disableAllDefaultSources is true. If disableAllDefaultSources
+                          is true and sources is not empty, the configuration present
+                          in sources will take precedence. The list of default hub
+                          sources and their current state will always be reflected
+                          in the status block.
+                        items:
+                          description: HubSource is used to specify the hub source
+                            and its configuration
+                          properties:
+                            disabled:
+                              description: disabled is used to disable a default hub
+                                source on cluster
+                              type: boolean
+                            name:
+                              description: name is the name of one of the default
+                                hub sources
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  proxy:
+                    description: Proxy holds cluster-wide information on how to configure
+                      default proxies for the cluster.
+                    properties:
+                      httpProxy:
+                        description: httpProxy is the URL of the proxy for HTTP requests.  Empty
+                          means unset and will not result in an env var.
+                        type: string
+                      httpsProxy:
+                        description: httpsProxy is the URL of the proxy for HTTPS
+                          requests.  Empty means unset and will not result in an env
+                          var.
+                        type: string
+                      noProxy:
+                        description: noProxy is a comma-separated list of hostnames
+                          and/or CIDRs and/or IPs for which the proxy should not be
+                          used. Empty means unset and will not result in an env var.
+                        type: string
+                      readinessEndpoints:
+                        description: readinessEndpoints is a list of endpoints used
+                          to verify readiness of the proxy.
+                        items:
+                          type: string
+                        type: array
+                      trustedCA:
+                        description: "trustedCA is a reference to a ConfigMap containing
+                          a CA certificate bundle. The trustedCA field should only
+                          be consumed by a proxy validator. The validator is responsible
+                          for reading the certificate bundle from the required key
+                          \"ca-bundle.crt\", merging it with the system default trust
+                          bundle, and writing the merged trust bundle to a ConfigMap
+                          named \"trusted-ca-bundle\" in the \"openshift-config-managed\"
+                          namespace. Clients that expect to make proxy connections
+                          must use the trusted-ca-bundle for all HTTPS requests to
+                          the proxy, and may use the trusted-ca-bundle for non-proxy
+                          HTTPS requests as well. \n The namespace for the ConfigMap
+                          referenced by trustedCA is \"openshift-config\". Here is
+                          an example ConfigMap (in yaml): \n apiVersion: v1 kind:
+                          ConfigMap metadata: name: user-ca-bundle namespace: openshift-config
+                          data: ca-bundle.crt: | -----BEGIN CERTIFICATE----- Custom
+                          CA certificate bundle. -----END CERTIFICATE-----"
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    type: object
+                  scheduler:
+                    description: Scheduler holds cluster-wide config information to
+                      run the Kubernetes Scheduler and influence its placement decisions.
+                      The canonical name for this config is `cluster`.
+                    properties:
+                      defaultNodeSelector:
+                        description: 'defaultNodeSelector helps set the cluster-wide
+                          default node selector to restrict pod placement to specific
+                          nodes. This is applied to the pods created in all namespaces
+                          and creates an intersection with any existing nodeSelectors
+                          already set on a pod, additionally constraining that pod''s
+                          selector. For example, defaultNodeSelector: "type=user-node,region=east"
+                          would set nodeSelector field in pod spec to "type=user-node,region=east"
+                          to all pods created in all namespaces. Namespaces having
+                          project-wide node selectors won''t be impacted even if this
+                          field is set. This adds an annotation section to the namespace.
+                          For example, if a new namespace is created with node-selector=''type=user-node,region=east'',
+                          the annotation openshift.io/node-selector: type=user-node,region=east
+                          gets added to the project. When the openshift.io/node-selector
+                          annotation is set on the project the value is used in preference
+                          to the value we are setting for defaultNodeSelector field.
+                          For instance, openshift.io/node-selector: "type=user-node,region=west"
+                          means that the default of "type=user-node,region=east" set
+                          in defaultNodeSelector would not be applied.'
+                        type: string
+                      mastersSchedulable:
+                        description: 'MastersSchedulable allows masters nodes to be
+                          schedulable. When this flag is turned on, all the master
+                          nodes in the cluster will be made schedulable, so that workload
+                          pods can run on them. The default value for this field is
+                          false, meaning none of the master nodes are schedulable.
+                          Important Note: Once the workload pods start running on
+                          the master nodes, extreme care must be taken to ensure that
+                          cluster-critical control plane components are not impacted.
+                          Please turn on this field after doing due diligence.'
+                        type: boolean
+                      policy:
+                        description: 'DEPRECATED: the scheduler Policy API has been
+                          deprecated and will be removed in a future release. policy
+                          is a reference to a ConfigMap containing scheduler policy
+                          which has user specified predicates and priorities. If this
+                          ConfigMap is not available scheduler will default to use
+                          DefaultAlgorithmProvider. The namespace for this configmap
+                          is openshift-config.'
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      profile:
+                        description: "profile sets which scheduling profile should
+                          be set in order to configure scheduling decisions for new
+                          pods. \n Valid values are \"LowNodeUtilization\", \"HighNodeUtilization\",
+                          \"NoScoring\" Defaults to \"LowNodeUtilization\""
+                        enum:
+                        - ""
+                        - LowNodeUtilization
+                        - HighNodeUtilization
+                        - NoScoring
+                        type: string
+                    type: object
+                type: object
+              controlPlaneRelease:
+                description: ControlPlaneRelease specifies the desired OCP release
+                  payload for control plane components running on the management cluster.
+                  Updating this field will trigger a rollout of the control plane.
+                  The behavior of the rollout will be driven by the ControllerAvailabilityPolicy
+                  and InfrastructureAvailabilityPolicy. If not defined, Release is
+                  used
+                properties:
+                  image:
+                    description: Image is the image pullspec of an OCP release payload
+                      image.
+                    pattern: ^(\w+\S+)$
+                    type: string
+                required:
+                - image
+                type: object
+              controllerAvailabilityPolicy:
+                default: SingleReplica
+                description: ControllerAvailabilityPolicy specifies the availability
+                  policy applied to critical control plane components. The default
+                  value is SingleReplica.
+                type: string
+              dns:
+                description: DNS specifies DNS configuration for the cluster.
+                properties:
+                  baseDomain:
+                    description: BaseDomain is the base domain of the cluster.
+                    type: string
+                  baseDomainPrefix:
+                    description: BaseDomainPrefix is the base domain prefix of the
+                      cluster. defaults to clusterName if not set. Set it to "" if
+                      you don't want a prefix to be prepended to BaseDomain.
+                    type: string
+                  privateZoneID:
+                    description: PrivateZoneID is the Hosted Zone ID where all the
+                      DNS records that are only available internally to the cluster
+                      exist.
+                    type: string
+                  publicZoneID:
+                    description: PublicZoneID is the Hosted Zone ID where all the
+                      DNS records that are publicly accessible to the internet exist.
+                    type: string
+                required:
+                - baseDomain
+                type: object
+              etcd:
+                default:
+                  managed:
+                    storage:
+                      persistentVolume:
+                        size: 8Gi
+                      type: PersistentVolume
+                  managementType: Managed
+                description: Etcd specifies configuration for the control plane etcd
+                  cluster. The default ManagementType is Managed. Once set, the ManagementType
+                  cannot be changed.
+                properties:
+                  managed:
+                    description: Managed specifies the behavior of an etcd cluster
+                      managed by HyperShift.
+                    properties:
+                      storage:
+                        description: Storage specifies how etcd data is persisted.
+                        properties:
+                          persistentVolume:
+                            description: PersistentVolume is the configuration for
+                              PersistentVolume etcd storage. With this implementation,
+                              a PersistentVolume will be allocated for every etcd
+                              member (either 1 or 3 depending on the HostedCluster
+                              control plane availability configuration).
+                            properties:
+                              size:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                default: 8Gi
+                                description: Size is the minimum size of the data
+                                  volume for each etcd member.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                                x-kubernetes-validations:
+                                - message: Etcd PV storage size is immutable
+                                  rule: self == oldSelf
+                              storageClassName:
+                                description: "StorageClassName is the StorageClass
+                                  of the data volume for each etcd member. \n See
+                                  https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1."
+                                type: string
+                            type: object
+                          restoreSnapshotURL:
+                            description: RestoreSnapshotURL allows an optional URL
+                              to be provided where an etcd snapshot can be downloaded,
+                              for example a pre-signed URL referencing a storage service.
+                              This snapshot will be restored on initial startup, only
+                              when the etcd PV is empty.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-validations:
+                            - message: RestoreSnapshotURL shouldn't contain more than
+                                1 entry
+                              rule: self.size() <= 1
+                          type:
+                            description: Type is the kind of persistent storage implementation
+                              to use for etcd.
+                            enum:
+                            - PersistentVolume
+                            type: string
+                        required:
+                        - type
+                        type: object
+                    required:
+                    - storage
+                    type: object
+                  managementType:
+                    description: ManagementType defines how the etcd cluster is managed.
+                    enum:
+                    - Managed
+                    - Unmanaged
+                    type: string
+                  unmanaged:
+                    description: Unmanaged specifies configuration which enables the
+                      control plane to integrate with an eternally managed etcd cluster.
+                    properties:
+                      endpoint:
+                        description: "Endpoint is the full etcd cluster client endpoint
+                          URL. For example: \n https://etcd-client:2379 \n If the
+                          URL uses an HTTPS scheme, the TLS field is required."
+                        pattern: ^https://
+                        type: string
+                      tls:
+                        description: TLS specifies TLS configuration for HTTPS etcd
+                          client endpoints.
+                        properties:
+                          clientSecret:
+                            description: "ClientSecret refers to a secret for client
+                              mTLS authentication with the etcd cluster. It may have
+                              the following key/value pairs: \n etcd-client-ca.crt:
+                              Certificate Authority value etcd-client.crt: Client
+                              certificate value etcd-client.key: Client certificate
+                              key value"
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        required:
+                        - clientSecret
+                        type: object
+                    required:
+                    - endpoint
+                    - tls
+                    type: object
+                required:
+                - managementType
+                type: object
+              fips:
+                description: FIPS indicates whether this cluster's nodes will be running
+                  in FIPS mode. If set to true, the control plane's ignition server
+                  will be configured to expect that nodes joining the cluster will
+                  be FIPS-enabled.
+                type: boolean
+              imageContentSources:
+                description: ImageContentSources specifies image mirrors that can
+                  be used by cluster nodes to pull content.
+                items:
+                  description: ImageContentSource specifies image mirrors that can
+                    be used by cluster nodes to pull content. For cluster workloads,
+                    if a container image registry host of the pullspec matches Source
+                    then one of the Mirrors are substituted as hosts in the pullspec
+                    and tried in order to fetch the image.
+                  properties:
+                    mirrors:
+                      description: Mirrors are one or more repositories that may also
+                        contain the same images.
+                      items:
+                        type: string
+                      type: array
+                    source:
+                      description: Source is the repository that users refer to, e.g.
+                        in image pull specifications.
+                      type: string
+                  required:
+                  - source
+                  type: object
+                type: array
+              infraID:
+                description: InfraID is a globally unique identifier for the cluster.
+                  This identifier will be used to associate various cloud resources
+                  with the HostedCluster and its associated NodePools.
+                type: string
+              infrastructureAvailabilityPolicy:
+                default: SingleReplica
+                description: InfrastructureAvailabilityPolicy specifies the availability
+                  policy applied to infrastructure services which run on cluster nodes.
+                  The default value is SingleReplica.
+                type: string
+              issuerURL:
+                default: https://kubernetes.default.svc
+                description: IssuerURL is an OIDC issuer URL which is used as the
+                  issuer in all ServiceAccount tokens generated by the control plane
+                  API server. The default value is kubernetes.default.svc, which only
+                  works for in-cluster validation.
+                format: uri
+                type: string
+              networking:
+                default:
+                  clusterNetwork:
+                  - cidr: 10.132.0.0/14
+                  networkType: OVNKubernetes
+                  serviceNetwork:
+                  - cidr: 172.31.0.0/16
+                description: Networking specifies network configuration for the cluster.
+                properties:
+                  apiServer:
+                    description: APIServer contains advanced network settings for
+                      the API server that affect how the APIServer is exposed inside
+                      a cluster node.
+                    properties:
+                      advertiseAddress:
+                        description: AdvertiseAddress is the address that nodes will
+                          use to talk to the API server. This is an address associated
+                          with the loopback adapter of each node. If not specified,
+                          the controller will take default values. The default values
+                          will be set as 172.20.0.1 or fd00::1.
+                        type: string
+                      allowedCIDRBlocks:
+                        description: AllowedCIDRBlocks is an allow list of CIDR blocks
+                          that can access the APIServer If not specified, traffic
+                          is allowed from all addresses. This depends on underlying
+                          support by the cloud provider for Service LoadBalancerSourceRanges
+                        items:
+                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          type: string
+                        type: array
+                      port:
+                        description: Port is the port at which the APIServer is exposed
+                          inside a node. Other pods using host networking cannot listen
+                          on this port. If unset 6443 is used. This is useful to choose
+                          a port other than the default one which might interfere
+                          with customer environments e.g. https://github.com/openshift/hypershift/pull/356.
+                          Setting this to 443 is possible only for backward compatibility
+                          reasons and it's discouraged. Doing so, it would result
+                          in the controller overriding the KAS endpoint in the guest
+                          cluster having a discrepancy with the KAS Pod and potentially
+                          causing temporarily network failures.
+                        format: int32
+                        type: integer
+                    type: object
+                  clusterNetwork:
+                    default:
+                    - cidr: 10.132.0.0/14
+                    description: ClusterNetwork is the list of IP address pools for
+                      pods.
+                    items:
+                      description: ClusterNetworkEntry is a single IP address block
+                        for pod IP blocks. IP blocks are allocated with size 2^HostSubnetLength.
+                      properties:
+                        cidr:
+                          description: CIDR is the IP block address pool.
+                          type: string
+                        hostPrefix:
+                          description: HostPrefix is the prefix size to allocate to
+                            each node from the CIDR. For example, 24 would allocate
+                            2^8=256 adresses to each node. If this field is not used
+                            by the plugin, it can be left unset.
+                          format: int32
+                          type: integer
+                      required:
+                      - cidr
+                      type: object
+                    type: array
+                  machineNetwork:
+                    description: MachineNetwork is the list of IP address pools for
+                      machines.
+                    items:
+                      description: MachineNetworkEntry is a single IP address block
+                        for node IP blocks.
+                      properties:
+                        cidr:
+                          description: CIDR is the IP block address pool for machines
+                            within the cluster.
+                          type: string
+                      required:
+                      - cidr
+                      type: object
+                    type: array
+                  networkType:
+                    default: OVNKubernetes
+                    description: NetworkType specifies the SDN provider used for cluster
+                      networking.
+                    enum:
+                    - OpenShiftSDN
+                    - Calico
+                    - OVNKubernetes
+                    - Other
+                    type: string
+                  serviceNetwork:
+                    default:
+                    - cidr: 172.31.0.0/16
+                    description: 'ServiceNetwork is the list of IP address pools for
+                      services. NOTE: currently only one entry is supported.'
+                    items:
+                      description: ServiceNetworkEntry is a single IP address block
+                        for the service network.
+                      properties:
+                        cidr:
+                          description: CIDR is the IP block address pool for services
+                            within the cluster.
+                          type: string
+                      required:
+                      - cidr
+                      type: object
+                    type: array
+                required:
+                - clusterNetwork
+                - networkType
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector when specified, must be true for the pods
+                  managed by the HostedCluster to be scheduled.
+                type: object
+              olmCatalogPlacement:
+                default: management
+                description: OLMCatalogPlacement specifies the placement of OLM catalog
+                  components. By default, this is set to management and OLM catalog
+                  components are deployed onto the management cluster. If set to guest,
+                  the OLM catalog components will be deployed onto the guest cluster.
+                enum:
+                - management
+                - guest
+                type: string
+                x-kubernetes-validations:
+                - message: OLMCatalogPlacement is immutable
+                  rule: self == oldSelf
+              pausedUntil:
+                description: 'PausedUntil is a field that can be used to pause reconciliation
+                  on a resource. Either a date can be provided in RFC3339 format or
+                  a boolean. If a date is provided: reconciliation is paused on the
+                  resource until that date. If the boolean true is provided: reconciliation
+                  is paused on the resource until the field is removed.'
+                type: string
+              platform:
+                description: Platform specifies the underlying infrastructure provider
+                  for the cluster and is used to configure platform specific behavior.
+                properties:
+                  agent:
+                    description: Agent specifies configuration for agent-based installations.
+                    properties:
+                      agentNamespace:
+                        description: AgentNamespace is the namespace where to search
+                          for Agents for this cluster
+                        type: string
+                    required:
+                    - agentNamespace
+                    type: object
+                  aws:
+                    description: AWS specifies configuration for clusters running
+                      on Amazon Web Services.
+                    properties:
+                      additionalAllowedPrincipals:
+                        description: AdditionalAllowedPrincipals specifies a list
+                          of additional allowed principal ARNs to be added to the
+                          hosted control plane's VPC Endpoint Service to enable additional
+                          VPC Endpoint connection requests to be automatically accepted.
+                          See https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html
+                          for more details around VPC Endpoint Service allowed principals.
+                        items:
+                          type: string
+                        type: array
+                      cloudProviderConfig:
+                        description: 'CloudProviderConfig specifies AWS networking
+                          configuration for the control plane. This is mainly used
+                          for cloud provider controller config: https://github.com/kubernetes/kubernetes/blob/f5be5052e3d0808abb904aebd3218fe4a5c2dd82/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go#L1347-L1364
+                          TODO(dan): should this be named AWSNetworkConfig?'
+                        properties:
+                          subnet:
+                            description: Subnet is the subnet to use for control plane
+                              cloud resources.
+                            properties:
+                              filters:
+                                description: 'Filters is a set of key/value pairs
+                                  used to identify a resource They are applied according
+                                  to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                                items:
+                                  description: Filter is a filter used to identify
+                                    an AWS resource
+                                  properties:
+                                    name:
+                                      description: Name of the filter. Filter names
+                                        are case-sensitive.
+                                      type: string
+                                    values:
+                                      description: Values includes one or more filter
+                                        values. Filter values are case-sensitive.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - name
+                                  - values
+                                  type: object
+                                type: array
+                              id:
+                                description: ID of resource
+                                type: string
+                            type: object
+                          vpc:
+                            description: VPC is the VPC to use for control plane cloud
+                              resources.
+                            type: string
+                          zone:
+                            description: Zone is the availability zone where control
+                              plane cloud resources are created.
+                            type: string
+                        required:
+                        - vpc
+                        type: object
+                      endpointAccess:
+                        default: Public
+                        description: EndpointAccess specifies the publishing scope
+                          of cluster endpoints. The default is Public.
+                        enum:
+                        - Public
+                        - PublicAndPrivate
+                        - Private
+                        type: string
+                      region:
+                        description: Region is the AWS region in which the cluster
+                          resides. This configures the OCP control plane cloud integrations,
+                          and is used by NodePool to resolve the correct boot AMI
+                          for a given release.
+                        type: string
+                      resourceTags:
+                        description: ResourceTags is a list of additional tags to
+                          apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html
+                          for information on tagging AWS resources. AWS supports a
+                          maximum of 50 tags per resource. OpenShift reserves 25 tags
+                          for its use, leaving 25 tags available for the user.
+                        items:
+                          description: AWSResourceTag is a tag to apply to AWS resources
+                            created for the cluster.
+                          properties:
+                            key:
+                              description: Key is the key of the tag.
+                              maxLength: 128
+                              minLength: 1
+                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                              type: string
+                            value:
+                              description: "Value is the value of the tag. \n Some
+                                AWS service do not support empty values. Since tags
+                                are added to resources in many services, the length
+                                of the tag value must meet the requirements of all
+                                services."
+                              maxLength: 256
+                              minLength: 1
+                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                              type: string
+                          required:
+                          - key
+                          - value
+                          type: object
+                        maxItems: 25
+                        type: array
+                      rolesRef:
+                        description: RolesRef contains references to various AWS IAM
+                          roles required to enable integrations such as OIDC.
+                        properties:
+                          controlPlaneOperatorARN:
+                            description: "ControlPlaneOperatorARN  is an ARN value
+                              referencing a role appropriate for the Control Plane
+                              Operator. \n The following is an example of a valid
+                              policy document: \n { \"Version\": \"2012-10-17\", \"Statement\":
+                              [ { \"Effect\": \"Allow\", \"Action\": [ \"ec2:CreateVpcEndpoint\",
+                              \"ec2:DescribeVpcEndpoints\", \"ec2:ModifyVpcEndpoint\",
+                              \"ec2:DeleteVpcEndpoints\", \"ec2:CreateTags\", \"route53:ListHostedZones\",
+                              \"ec2:CreateSecurityGroup\", \"ec2:AuthorizeSecurityGroupIngress\",
+                              \"ec2:AuthorizeSecurityGroupEgress\", \"ec2:DeleteSecurityGroup\",
+                              \"ec2:RevokeSecurityGroupIngress\", \"ec2:RevokeSecurityGroupEgress\",
+                              \"ec2:DescribeSecurityGroups\", \"ec2:DescribeVpcs\",
+                              ], \"Resource\": \"*\" }, { \"Effect\": \"Allow\", \"Action\":
+                              [ \"route53:ChangeResourceRecordSets\", \"route53:ListResourceRecordSets\"
+                              ], \"Resource\": \"arn:aws:route53:::%s\" } ] }"
+                            type: string
+                          imageRegistryARN:
+                            description: "ImageRegistryARN is an ARN value referencing
+                              a role appropriate for the Image Registry Operator.
+                              \n The following is an example of a valid policy document:
+                              \n { \"Version\": \"2012-10-17\", \"Statement\": [ {
+                              \"Effect\": \"Allow\", \"Action\": [ \"s3:CreateBucket\",
+                              \"s3:DeleteBucket\", \"s3:PutBucketTagging\", \"s3:GetBucketTagging\",
+                              \"s3:PutBucketPublicAccessBlock\", \"s3:GetBucketPublicAccessBlock\",
+                              \"s3:PutEncryptionConfiguration\", \"s3:GetEncryptionConfiguration\",
+                              \"s3:PutLifecycleConfiguration\", \"s3:GetLifecycleConfiguration\",
+                              \"s3:GetBucketLocation\", \"s3:ListBucket\", \"s3:GetObject\",
+                              \"s3:PutObject\", \"s3:DeleteObject\", \"s3:ListBucketMultipartUploads\",
+                              \"s3:AbortMultipartUpload\", \"s3:ListMultipartUploadParts\"
+                              ], \"Resource\": \"*\" } ] }"
+                            type: string
+                          ingressARN:
+                            description: "The referenced role must have a trust relationship
+                              that allows it to be assumed via web identity. https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html.
+                              Example: { \"Version\": \"2012-10-17\", \"Statement\":
+                              [ { \"Effect\": \"Allow\", \"Principal\": { \"Federated\":
+                              \"{{ .ProviderARN }}\" }, \"Action\": \"sts:AssumeRoleWithWebIdentity\",
+                              \"Condition\": { \"StringEquals\": { \"{{ .ProviderName
+                              }}:sub\": {{ .ServiceAccounts }} } } } ] } \n IngressARN
+                              is an ARN value referencing a role appropriate for the
+                              Ingress Operator. \n The following is an example of
+                              a valid policy document: \n { \"Version\": \"2012-10-17\",
+                              \"Statement\": [ { \"Effect\": \"Allow\", \"Action\":
+                              [ \"elasticloadbalancing:DescribeLoadBalancers\", \"tag:GetResources\",
+                              \"route53:ListHostedZones\" ], \"Resource\": \"*\" },
+                              { \"Effect\": \"Allow\", \"Action\": [ \"route53:ChangeResourceRecordSets\"
+                              ], \"Resource\": [ \"arn:aws:route53:::PUBLIC_ZONE_ID\",
+                              \"arn:aws:route53:::PRIVATE_ZONE_ID\" ] } ] }"
+                            type: string
+                          kubeCloudControllerARN:
+                            description: "KubeCloudControllerARN is an ARN value referencing
+                              a role appropriate for the KCM/KCC. Source: https://cloud-provider-aws.sigs.k8s.io/prerequisites/#iam-policies
+                              \n The following is an example of a valid policy document:
+                              \n { \"Version\": \"2012-10-17\", \"Statement\": [ {
+                              \"Action\": [ \"autoscaling:DescribeAutoScalingGroups\",
+                              \"autoscaling:DescribeLaunchConfigurations\", \"autoscaling:DescribeTags\",
+                              \"ec2:DescribeAvailabilityZones\", \"ec2:DescribeInstances\",
+                              \"ec2:DescribeImages\", \"ec2:DescribeRegions\", \"ec2:DescribeRouteTables\",
+                              \"ec2:DescribeSecurityGroups\", \"ec2:DescribeSubnets\",
+                              \"ec2:DescribeVolumes\", \"ec2:CreateSecurityGroup\",
+                              \"ec2:CreateTags\", \"ec2:CreateVolume\", \"ec2:ModifyInstanceAttribute\",
+                              \"ec2:ModifyVolume\", \"ec2:AttachVolume\", \"ec2:AuthorizeSecurityGroupIngress\",
+                              \"ec2:CreateRoute\", \"ec2:DeleteRoute\", \"ec2:DeleteSecurityGroup\",
+                              \"ec2:DeleteVolume\", \"ec2:DetachVolume\", \"ec2:RevokeSecurityGroupIngress\",
+                              \"ec2:DescribeVpcs\", \"elasticloadbalancing:AddTags\",
+                              \"elasticloadbalancing:AttachLoadBalancerToSubnets\",
+                              \"elasticloadbalancing:ApplySecurityGroupsToLoadBalancer\",
+                              \"elasticloadbalancing:CreateLoadBalancer\", \"elasticloadbalancing:CreateLoadBalancerPolicy\",
+                              \"elasticloadbalancing:CreateLoadBalancerListeners\",
+                              \"elasticloadbalancing:ConfigureHealthCheck\", \"elasticloadbalancing:DeleteLoadBalancer\",
+                              \"elasticloadbalancing:DeleteLoadBalancerListeners\",
+                              \"elasticloadbalancing:DescribeLoadBalancers\", \"elasticloadbalancing:DescribeLoadBalancerAttributes\",
+                              \"elasticloadbalancing:DetachLoadBalancerFromSubnets\",
+                              \"elasticloadbalancing:DeregisterInstancesFromLoadBalancer\",
+                              \"elasticloadbalancing:ModifyLoadBalancerAttributes\",
+                              \"elasticloadbalancing:RegisterInstancesWithLoadBalancer\",
+                              \"elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer\",
+                              \"elasticloadbalancing:AddTags\", \"elasticloadbalancing:CreateListener\",
+                              \"elasticloadbalancing:CreateTargetGroup\", \"elasticloadbalancing:DeleteListener\",
+                              \"elasticloadbalancing:DeleteTargetGroup\", \"elasticloadbalancing:DeregisterTargets\",
+                              \"elasticloadbalancing:DescribeListeners\", \"elasticloadbalancing:DescribeLoadBalancerPolicies\",
+                              \"elasticloadbalancing:DescribeTargetGroups\", \"elasticloadbalancing:DescribeTargetHealth\",
+                              \"elasticloadbalancing:ModifyListener\", \"elasticloadbalancing:ModifyTargetGroup\",
+                              \"elasticloadbalancing:RegisterTargets\", \"elasticloadbalancing:SetLoadBalancerPoliciesOfListener\",
+                              \"iam:CreateServiceLinkedRole\", \"kms:DescribeKey\"
+                              ], \"Resource\": [ \"*\" ], \"Effect\": \"Allow\" }
+                              ] }"
+                            type: string
+                          networkARN:
+                            description: "NetworkARN is an ARN value referencing a
+                              role appropriate for the Network Operator. \n The following
+                              is an example of a valid policy document: \n { \"Version\":
+                              \"2012-10-17\", \"Statement\": [ { \"Effect\": \"Allow\",
+                              \"Action\": [ \"ec2:DescribeInstances\", \"ec2:DescribeInstanceStatus\",
+                              \"ec2:DescribeInstanceTypes\", \"ec2:UnassignPrivateIpAddresses\",
+                              \"ec2:AssignPrivateIpAddresses\", \"ec2:UnassignIpv6Addresses\",
+                              \"ec2:AssignIpv6Addresses\", \"ec2:DescribeSubnets\",
+                              \"ec2:DescribeNetworkInterfaces\" ], \"Resource\": \"*\"
+                              } ] }"
+                            type: string
+                          nodePoolManagementARN:
+                            description: "NodePoolManagementARN is an ARN value referencing
+                              a role appropriate for the CAPI Controller. \n The following
+                              is an example of a valid policy document: \n { \"Version\":
+                              \"2012-10-17\", \"Statement\": [ { \"Action\": [ \"ec2:AssociateRouteTable\",
+                              \"ec2:AttachInternetGateway\", \"ec2:AuthorizeSecurityGroupIngress\",
+                              \"ec2:CreateInternetGateway\", \"ec2:CreateNatGateway\",
+                              \"ec2:CreateRoute\", \"ec2:CreateRouteTable\", \"ec2:CreateSecurityGroup\",
+                              \"ec2:CreateSubnet\", \"ec2:CreateTags\", \"ec2:DeleteInternetGateway\",
+                              \"ec2:DeleteNatGateway\", \"ec2:DeleteRouteTable\",
+                              \"ec2:DeleteSecurityGroup\", \"ec2:DeleteSubnet\", \"ec2:DeleteTags\",
+                              \"ec2:DescribeAccountAttributes\", \"ec2:DescribeAddresses\",
+                              \"ec2:DescribeAvailabilityZones\", \"ec2:DescribeImages\",
+                              \"ec2:DescribeInstances\", \"ec2:DescribeInternetGateways\",
+                              \"ec2:DescribeNatGateways\", \"ec2:DescribeNetworkInterfaces\",
+                              \"ec2:DescribeNetworkInterfaceAttribute\", \"ec2:DescribeRouteTables\",
+                              \"ec2:DescribeSecurityGroups\", \"ec2:DescribeSubnets\",
+                              \"ec2:DescribeVpcs\", \"ec2:DescribeVpcAttribute\",
+                              \"ec2:DescribeVolumes\", \"ec2:DetachInternetGateway\",
+                              \"ec2:DisassociateRouteTable\", \"ec2:DisassociateAddress\",
+                              \"ec2:ModifyInstanceAttribute\", \"ec2:ModifyNetworkInterfaceAttribute\",
+                              \"ec2:ModifySubnetAttribute\", \"ec2:RevokeSecurityGroupIngress\",
+                              \"ec2:RunInstances\", \"ec2:TerminateInstances\", \"tag:GetResources\",
+                              \"ec2:CreateLaunchTemplate\", \"ec2:CreateLaunchTemplateVersion\",
+                              \"ec2:DescribeLaunchTemplates\", \"ec2:DescribeLaunchTemplateVersions\",
+                              \"ec2:DeleteLaunchTemplate\", \"ec2:DeleteLaunchTemplateVersions\"
+                              ], \"Resource\": [ \"*\" ], \"Effect\": \"Allow\" },
+                              { \"Condition\": { \"StringLike\": { \"iam:AWSServiceName\":
+                              \"elasticloadbalancing.amazonaws.com\" } }, \"Action\":
+                              [ \"iam:CreateServiceLinkedRole\" ], \"Resource\": [
+                              \"arn:*:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing\"
+                              ], \"Effect\": \"Allow\" }, { \"Action\": [ \"iam:PassRole\"
+                              ], \"Resource\": [ \"arn:*:iam::*:role/*-worker-role\"
+                              ], \"Effect\": \"Allow\" }, { \"Effect\": \"Allow\",
+                              \"Action\": [ \"kms:Decrypt\", \"kms:ReEncrypt\", \"kms:GenerateDataKeyWithoutPlainText\",
+                              \"kms:DescribeKey\" ], \"Resource\": \"*\" }, { \"Effect\":
+                              \"Allow\", \"Action\": [ \"kms:CreateGrant\" ], \"Resource\":
+                              \"*\", \"Condition\": { \"Bool\": { \"kms:GrantIsForAWSResource\":
+                              true } } } ] }"
+                            type: string
+                          storageARN:
+                            description: "StorageARN is an ARN value referencing a
+                              role appropriate for the Storage Operator. \n The following
+                              is an example of a valid policy document: \n { \"Version\":
+                              \"2012-10-17\", \"Statement\": [ { \"Effect\": \"Allow\",
+                              \"Action\": [ \"ec2:AttachVolume\", \"ec2:CreateSnapshot\",
+                              \"ec2:CreateTags\", \"ec2:CreateVolume\", \"ec2:DeleteSnapshot\",
+                              \"ec2:DeleteTags\", \"ec2:DeleteVolume\", \"ec2:DescribeInstances\",
+                              \"ec2:DescribeSnapshots\", \"ec2:DescribeTags\", \"ec2:DescribeVolumes\",
+                              \"ec2:DescribeVolumesModifications\", \"ec2:DetachVolume\",
+                              \"ec2:ModifyVolume\" ], \"Resource\": \"*\" } ] }"
+                            type: string
+                        required:
+                        - controlPlaneOperatorARN
+                        - imageRegistryARN
+                        - ingressARN
+                        - kubeCloudControllerARN
+                        - networkARN
+                        - nodePoolManagementARN
+                        - storageARN
+                        type: object
+                      serviceEndpoints:
+                        description: "ServiceEndpoints specifies optional custom endpoints
+                          which will override the default service endpoint of specific
+                          AWS Services. \n There must be only one ServiceEndpoint
+                          for a given service name."
+                        items:
+                          description: AWSServiceEndpoint stores the configuration
+                            for services to override existing defaults of AWS Services.
+                          properties:
+                            name:
+                              description: Name is the name of the AWS service. This
+                                must be provided and cannot be empty.
+                              type: string
+                            url:
+                              description: URL is fully qualified URI with scheme
+                                https, that overrides the default generated endpoint
+                                for a client. This must be provided and cannot be
+                                empty.
+                              pattern: ^https://
+                              type: string
+                          required:
+                          - name
+                          - url
+                          type: object
+                        type: array
+                    required:
+                    - region
+                    - rolesRef
+                    type: object
+                  azure:
+                    description: Azure defines azure specific settings
+                    properties:
+                      credentials:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      location:
+                        type: string
+                      machineIdentityID:
+                        type: string
+                      resourceGroup:
+                        type: string
+                      securityGroupName:
+                        type: string
+                      subnetName:
+                        type: string
+                      subscriptionID:
+                        type: string
+                      vnetID:
+                        type: string
+                      vnetName:
+                        type: string
+                    required:
+                    - credentials
+                    - location
+                    - machineIdentityID
+                    - resourceGroup
+                    - securityGroupName
+                    - subnetName
+                    - subscriptionID
+                    - vnetID
+                    - vnetName
+                    type: object
+                  ibmcloud:
+                    description: IBMCloud defines IBMCloud specific settings for components
+                    properties:
+                      providerType:
+                        description: ProviderType is a specific supported infrastructure
+                          provider within IBM Cloud.
+                        type: string
+                    type: object
+                  kubevirt:
+                    description: KubeVirt defines KubeVirt specific settings for cluster
+                      components.
+                    properties:
+                      baseDomainPassthrough:
+                        description: "BaseDomainPassthrough toggles whether or not
+                          an automatically generated base domain for the guest cluster
+                          should be used that is a subdomain of the management cluster's
+                          *.apps DNS. \n For the KubeVirt platform, the basedomain
+                          can be autogenerated using the *.apps domain of the management/infra
+                          hosting cluster This makes the guest cluster's base domain
+                          a subdomain of the hypershift infra/mgmt cluster's base
+                          domain. \n Example: Infra/Mgmt cluster's DNS Base: example.com
+                          Cluster: mgmt-cluster.example.com Apps:    *.apps.mgmt-cluster.example.com
+                          KubeVirt Guest cluster's DNS Base: apps.mgmt-cluster.example.com
+                          Cluster: guest.apps.mgmt-cluster.example.com Apps: *.apps.guest.apps.mgmt-cluster.example.com
+                          \n This is possible using OCP wildcard routes"
+                        type: boolean
+                        x-kubernetes-validations:
+                        - message: baseDomainPassthrough is immutable
+                          rule: self == oldSelf
+                      credentials:
+                        description: "Credentials defines the client credentials used
+                          when creating KubeVirt virtual machines. Defining credentials
+                          is only necessary when the KubeVirt virtual machines are
+                          being placed on a cluster separate from the one hosting
+                          the Hosted Control Plane components. \n The default behavior
+                          when Credentials is not defined is for the KubeVirt VMs
+                          to be placed on the same cluster and namespace as the Hosted
+                          Control Plane."
+                        properties:
+                          infraKubeConfigSecret:
+                            description: InfraKubeConfigSecret is a reference to a
+                              secret that contains the kubeconfig for the external
+                              infra cluster that will be used to host the KubeVirt
+                              virtual machines for this cluster.
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                            x-kubernetes-validations:
+                            - message: infraKubeConfigSecret is immutable
+                              rule: self == oldSelf
+                          infraNamespace:
+                            description: InfraNamespace defines the namespace on the
+                              external infra cluster that is used to host the KubeVirt
+                              virtual machines. This namespace must already exist
+                              before creating the HostedCluster and the kubeconfig
+                              referenced in the InfraKubeConfigSecret must have access
+                              to manage the required resources within this namespace.
+                            type: string
+                            x-kubernetes-validations:
+                            - message: infraNamespace is immutable
+                              rule: self == oldSelf
+                        required:
+                        - infraNamespace
+                        type: object
+                      generateID:
+                        description: GenerateID is used to uniquely apply a name suffix
+                          to resources associated with kubevirt infrastructure resources
+                        maxLength: 11
+                        type: string
+                        x-kubernetes-validations:
+                        - message: Kubevirt GenerateID is immutable once set
+                          rule: self == oldSelf
+                      storageDriver:
+                        description: StorageDriver defines how the KubeVirt CSI driver
+                          exposes StorageClasses on the infra cluster (hosting the
+                          VMs) to the guest cluster.
+                        properties:
+                          manual:
+                            description: Manual is used to explicilty define how the
+                              infra storageclasses are mapped to guest storageclasses
+                            properties:
+                              storageClassMapping:
+                                description: "StorageClassMapping maps StorageClasses
+                                  on the infra cluster hosting the KubeVirt VMs to
+                                  StorageClasses that are made available within the
+                                  Guest Cluster. \n NOTE: It is possible that not
+                                  all capablities of an infra cluster's storageclass
+                                  will be present for the corresponding guest clusters
+                                  storageclass."
+                                items:
+                                  properties:
+                                    guestStorageClassName:
+                                      description: GuestStorageClassName is the name
+                                        that the corresponding storageclass will be
+                                        called within the guest cluster
+                                      type: string
+                                    infraStorageClassName:
+                                      description: InfraStorageClassName is the name
+                                        of the infra cluster storage class that will
+                                        be exposed into the guest.
+                                      type: string
+                                  required:
+                                  - guestStorageClassName
+                                  - infraStorageClassName
+                                  type: object
+                                type: array
+                                x-kubernetes-validations:
+                                - message: storageClassMapping is immutable
+                                  rule: self == oldSelf
+                            type: object
+                            x-kubernetes-validations:
+                            - message: storageDriver.Manual is immutable
+                              rule: self == oldSelf
+                          type:
+                            default: Default
+                            description: Type represents the type of kubevirt csi
+                              driver configuration to use
+                            enum:
+                            - None
+                            - Default
+                            - Manual
+                            type: string
+                            x-kubernetes-validations:
+                            - message: storageDriver.Type is immutable
+                              rule: self == oldSelf
+                        type: object
+                        x-kubernetes-validations:
+                        - message: storageDriver is immutable
+                          rule: self == oldSelf
+                    type: object
+                    x-kubernetes-validations:
+                    - message: Kubevirt GenerateID is required once set
+                      rule: '!has(oldSelf.generateID) || has(self.generateID)'
+                  powervs:
+                    description: PowerVS specifies configuration for clusters running
+                      on IBMCloud Power VS Service. This field is immutable. Once
+                      set, It can't be changed.
+                    properties:
+                      accountID:
+                        description: AccountID is the IBMCloud account id. This field
+                          is immutable. Once set, It can't be changed.
+                        type: string
+                      cisInstanceCRN:
+                        description: CISInstanceCRN is the IBMCloud CIS Service Instance's
+                          Cloud Resource Name This field is immutable. Once set, It
+                          can't be changed.
+                        pattern: '^crn:'
+                        type: string
+                      imageRegistryOperatorCloudCreds:
+                        description: ImageRegistryOperatorCloudCreds is a reference
+                          to a secret containing ibm cloud credentials for image registry
+                          operator to get authenticated with ibm cloud.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      ingressOperatorCloudCreds:
+                        description: IngressOperatorCloudCreds is a reference to a
+                          secret containing ibm cloud credentials for ingress operator
+                          to get authenticated with ibm cloud.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      kubeCloudControllerCreds:
+                        description: "KubeCloudControllerCreds is a reference to a
+                          secret containing cloud credentials with permissions matching
+                          the cloud controller policy. This field is immutable. Once
+                          set, It can't be changed. \n TODO(dan): document the \"cloud
+                          controller policy\""
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodePoolManagementCreds:
+                        description: "NodePoolManagementCreds is a reference to a
+                          secret containing cloud credentials with permissions matching
+                          the node pool management policy. This field is immutable.
+                          Once set, It can't be changed. \n TODO(dan): document the
+                          \"node pool management policy\""
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      region:
+                        description: Region is the IBMCloud region in which the cluster
+                          resides. This configures the OCP control plane cloud integrations,
+                          and is used by NodePool to resolve the correct boot image
+                          for a given release. This field is immutable. Once set,
+                          It can't be changed.
+                        type: string
+                      resourceGroup:
+                        description: ResourceGroup is the IBMCloud Resource Group
+                          in which the cluster resides. This field is immutable. Once
+                          set, It can't be changed.
+                        type: string
+                      serviceInstanceID:
+                        description: "ServiceInstance is the reference to the Power
+                          VS service on which the server instance(VM) will be created.
+                          Power VS service is a container for all Power VS instances
+                          at a specific geographic region. serviceInstance can be
+                          created via IBM Cloud catalog or CLI. ServiceInstanceID
+                          is the unique identifier that can be obtained from IBM Cloud
+                          UI or IBM Cloud cli. \n More detail about Power VS service
+                          instance. https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-creating-power-virtual-server
+                          \n This field is immutable. Once set, It can't be changed."
+                        type: string
+                      storageOperatorCloudCreds:
+                        description: StorageOperatorCloudCreds is a reference to a
+                          secret containing ibm cloud credentials for storage operator
+                          to get authenticated with ibm cloud.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      subnet:
+                        description: Subnet is the subnet to use for control plane
+                          cloud resources. This field is immutable. Once set, It can't
+                          be changed.
+                        properties:
+                          id:
+                            description: ID of resource
+                            type: string
+                          name:
+                            description: Name of resource
+                            type: string
+                        type: object
+                      vpc:
+                        description: VPC specifies IBM Cloud PowerVS Load Balancing
+                          configuration for the control plane. This field is immutable.
+                          Once set, It can't be changed.
+                        properties:
+                          name:
+                            description: Name for VPC to used for all the service
+                              load balancer. This field is immutable. Once set, It
+                              can't be changed.
+                            type: string
+                          region:
+                            description: Region is the IBMCloud region in which VPC
+                              gets created, this VPC used for all the ingress traffic
+                              into the OCP cluster. This field is immutable. Once
+                              set, It can't be changed.
+                            type: string
+                          subnet:
+                            description: Subnet is the subnet to use for load balancer.
+                              This field is immutable. Once set, It can't be changed.
+                            type: string
+                          zone:
+                            description: Zone is the availability zone where load
+                              balancer cloud resources are created. This field is
+                              immutable. Once set, It can't be changed.
+                            type: string
+                        required:
+                        - name
+                        - region
+                        type: object
+                      zone:
+                        description: Zone is the availability zone where control plane
+                          cloud resources are created. This field is immutable. Once
+                          set, It can't be changed.
+                        type: string
+                    required:
+                    - accountID
+                    - cisInstanceCRN
+                    - imageRegistryOperatorCloudCreds
+                    - ingressOperatorCloudCreds
+                    - kubeCloudControllerCreds
+                    - nodePoolManagementCreds
+                    - region
+                    - resourceGroup
+                    - serviceInstanceID
+                    - storageOperatorCloudCreds
+                    - subnet
+                    - vpc
+                    - zone
+                    type: object
+                  type:
+                    description: Type is the type of infrastructure provider for the
+                      cluster.
+                    enum:
+                    - AWS
+                    - None
+                    - IBMCloud
+                    - Agent
+                    - KubeVirt
+                    - Azure
+                    - PowerVS
+                    type: string
+                required:
+                - type
+                type: object
+              pullSecret:
+                description: PullSecret references a pull secret to be injected into
+                  the container runtime of all cluster nodes. The secret must have
+                  a key named ".dockerconfigjson" whose value is the pull secret JSON.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              release:
+                description: "Release specifies the desired OCP release payload for
+                  the hosted cluster. \n Updating this field will trigger a rollout
+                  of the control plane. The behavior of the rollout will be driven
+                  by the ControllerAvailabilityPolicy and InfrastructureAvailabilityPolicy."
+                properties:
+                  image:
+                    description: Image is the image pullspec of an OCP release payload
+                      image.
+                    pattern: ^(\w+\S+)$
+                    type: string
+                required:
+                - image
+                type: object
+              secretEncryption:
+                description: SecretEncryption specifies a Kubernetes secret encryption
+                  strategy for the control plane.
+                properties:
+                  aescbc:
+                    description: AESCBC defines metadata about the AESCBC secret encryption
+                      strategy
+                    properties:
+                      activeKey:
+                        description: ActiveKey defines the active key used to encrypt
+                          new secrets
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      backupKey:
+                        description: BackupKey defines the old key during the rotation
+                          process so previously created secrets can continue to be
+                          decrypted until they are all re-encrypted with the active
+                          key.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - activeKey
+                    type: object
+                  kms:
+                    description: KMS defines metadata about the kms secret encryption
+                      strategy
+                    properties:
+                      aws:
+                        description: AWS defines metadata about the configuration
+                          of the AWS KMS Secret Encryption provider
+                        properties:
+                          activeKey:
+                            description: ActiveKey defines the active key used to
+                              encrypt new secrets
+                            properties:
+                              arn:
+                                description: ARN is the Amazon Resource Name for the
+                                  encryption key
+                                pattern: '^arn:'
+                                type: string
+                            required:
+                            - arn
+                            type: object
+                          auth:
+                            description: Auth defines metadata about the management
+                              of credentials used to interact with AWS KMS
+                            properties:
+                              awsKms:
+                                description: "The referenced role must have a trust
+                                  relationship that allows it to be assumed via web
+                                  identity. https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html.
+                                  Example: { \"Version\": \"2012-10-17\", \"Statement\":
+                                  [ { \"Effect\": \"Allow\", \"Principal\": { \"Federated\":
+                                  \"{{ .ProviderARN }}\" }, \"Action\": \"sts:AssumeRoleWithWebIdentity\",
+                                  \"Condition\": { \"StringEquals\": { \"{{ .ProviderName
+                                  }}:sub\": {{ .ServiceAccounts }} } } } ] } \n AWSKMSARN
+                                  is an ARN value referencing a role appropriate for
+                                  managing the auth via the AWS KMS key. \n The following
+                                  is an example of a valid policy document: \n { \"Version\":
+                                  \"2012-10-17\", \"Statement\": [ { \"Effect\": \"Allow\",
+                                  \"Action\": [ \"kms:Encrypt\", \"kms:Decrypt\",
+                                  \"kms:ReEncrypt*\", \"kms:GenerateDataKey*\", \"kms:DescribeKey\"
+                                  ], \"Resource\": %q } ] }"
+                                type: string
+                            required:
+                            - awsKms
+                            type: object
+                          backupKey:
+                            description: BackupKey defines the old key during the
+                              rotation process so previously created secrets can continue
+                              to be decrypted until they are all re-encrypted with
+                              the active key.
+                            properties:
+                              arn:
+                                description: ARN is the Amazon Resource Name for the
+                                  encryption key
+                                pattern: '^arn:'
+                                type: string
+                            required:
+                            - arn
+                            type: object
+                          region:
+                            description: Region contains the AWS region
+                            type: string
+                        required:
+                        - activeKey
+                        - auth
+                        - region
+                        type: object
+                      azure:
+                        description: Azure defines metadata about the configuration
+                          of the Azure KMS Secret Encryption provider using Azure
+                          key vault
+                        properties:
+                          keyName:
+                            description: KeyName is the name of the keyvault key used
+                              for encrypt/decrypt
+                            type: string
+                          keyVaultName:
+                            description: 'KeyVaultName is the name of the keyvault.
+                              Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+                              Your Microsoft Entra application used to create the
+                              cluster must be authorized to access this keyvault,
+                              e.g using the AzureCLI: `az keyvault set-policy -n $KEYVAULT_NAME
+                              --key-permissions decrypt encrypt --spn <YOUR APPLICATION
+                              CLIENT ID>`'
+                            type: string
+                          keyVersion:
+                            description: KeyVersion contains the version of the key
+                              to use
+                            type: string
+                          location:
+                            description: Location contains the Azure region
+                            type: string
+                        required:
+                        - keyName
+                        - keyVaultName
+                        - keyVersion
+                        type: object
+                      ibmcloud:
+                        description: IBMCloud defines metadata for the IBM Cloud KMS
+                          encryption strategy
+                        properties:
+                          auth:
+                            description: Auth defines metadata for how authentication
+                              is done with IBM Cloud KMS
+                            properties:
+                              managed:
+                                description: Managed defines metadata around the service
+                                  to service authentication strategy for the IBM Cloud
+                                  KMS system (all provider managed).
+                                type: object
+                              type:
+                                description: Type defines the IBM Cloud KMS authentication
+                                  strategy
+                                enum:
+                                - Managed
+                                - Unmanaged
+                                type: string
+                              unmanaged:
+                                description: Unmanaged defines the auth metadata the
+                                  customer provides to interact with IBM Cloud KMS
+                                properties:
+                                  credentials:
+                                    description: Credentials should reference a secret
+                                      with a key field of IBMCloudIAMAPIKeySecretKey
+                                      that contains a apikey to call IBM Cloud KMS
+                                      APIs
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                required:
+                                - credentials
+                                type: object
+                            required:
+                            - type
+                            type: object
+                          keyList:
+                            description: KeyList defines the list of keys used for
+                              data encryption
+                            items:
+                              description: IBMCloudKMSKeyEntry defines metadata for
+                                an IBM Cloud KMS encryption key
+                              properties:
+                                correlationID:
+                                  description: CorrelationID is an identifier used
+                                    to track all api call usage from hypershift
+                                  type: string
+                                crkID:
+                                  description: CRKID is the customer rook key id
+                                  type: string
+                                instanceID:
+                                  description: InstanceID is the id for the key protect
+                                    instance
+                                  type: string
+                                keyVersion:
+                                  description: KeyVersion is a unique number associated
+                                    with the key. The number increments whenever a
+                                    new key is enabled for data encryption.
+                                  type: integer
+                                url:
+                                  description: URL is the url to call key protect
+                                    apis over
+                                  pattern: ^https://
+                                  type: string
+                              required:
+                              - correlationID
+                              - crkID
+                              - instanceID
+                              - keyVersion
+                              - url
+                              type: object
+                            type: array
+                          region:
+                            description: Region is the IBM Cloud region
+                            type: string
+                        required:
+                        - auth
+                        - keyList
+                        - region
+                        type: object
+                      provider:
+                        description: Provider defines the KMS provider
+                        enum:
+                        - IBMCloud
+                        - AWS
+                        - Azure
+                        type: string
+                    required:
+                    - provider
+                    type: object
+                  type:
+                    description: Type defines the type of kube secret encryption being
+                      used
+                    enum:
+                    - kms
+                    - aescbc
+                    type: string
+                required:
+                - type
+                type: object
+              serviceAccountSigningKey:
+                description: ServiceAccountSigningKey is a reference to a secret containing
+                  the private key used by the service account token issuer. The secret
+                  is expected to contain a single key named "key". If not specified,
+                  a service account signing key will be generated automatically for
+                  the cluster. When specifying a service account signing key, a IssuerURL
+                  must also be specified.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              services:
+                description: "Services specifies how individual control plane services
+                  are published from the hosting cluster of the control plane. \n
+                  If a given service is not present in this list, it will be exposed
+                  publicly by default."
+                items:
+                  description: ServicePublishingStrategyMapping specifies how individual
+                    control plane services are published from the hosting cluster
+                    of a control plane.
+                  properties:
+                    service:
+                      description: Service identifies the type of service being published.
+                      enum:
+                      - APIServer
+                      - OAuthServer
+                      - OIDC
+                      - Konnectivity
+                      - Ignition
+                      - OVNSbDb
+                      type: string
+                    servicePublishingStrategy:
+                      description: ServicePublishingStrategy specifies how to publish
+                        Service.
+                      properties:
+                        loadBalancer:
+                          description: LoadBalancer configures exposing a service
+                            using a LoadBalancer.
+                          properties:
+                            hostname:
+                              description: Hostname is the name of the DNS record
+                                that will be created pointing to the LoadBalancer.
+                              type: string
+                          type: object
+                        nodePort:
+                          description: NodePort configures exposing a service using
+                            a NodePort.
+                          properties:
+                            address:
+                              description: Address is the host/ip that the NodePort
+                                service is exposed over.
+                              type: string
+                            port:
+                              description: Port is the port of the NodePort service.
+                                If <=0, the port is dynamically assigned when the
+                                service is created.
+                              format: int32
+                              type: integer
+                          required:
+                          - address
+                          type: object
+                        route:
+                          description: Route configures exposing a service using a
+                            Route.
+                          properties:
+                            hostname:
+                              description: Hostname is the name of the DNS record
+                                that will be created pointing to the Route.
+                              type: string
+                          type: object
+                        type:
+                          description: Type is the publishing strategy used for the
+                            service.
+                          enum:
+                          - LoadBalancer
+                          - NodePort
+                          - Route
+                          - None
+                          - S3
+                          type: string
+                      required:
+                      - type
+                      type: object
+                  required:
+                  - service
+                  - servicePublishingStrategy
+                  type: object
+                type: array
+              sshKey:
+                description: SSHKey references an SSH key to be injected into all
+                  cluster node sshd servers. The secret must have a single key "id_rsa.pub"
+                  whose value is the public part of an SSH key.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - networking
+            - platform
+            - pullSecret
+            - release
+            - services
+            - sshKey
+            type: object
+          status:
+            description: Status is the latest observed status of the HostedCluster.
+            properties:
+              conditions:
+                description: Conditions represents the latest available observations
+                  of a control plane's current state.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint contains the endpoint information
+                  by which external clients can access the control plane. This is
+                  populated after the infrastructure is ready.
+                properties:
+                  host:
+                    description: Host is the hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: Port is the port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              ignitionEndpoint:
+                description: IgnitionEndpoint is the endpoint injected in the ign
+                  config userdata. It exposes the config for instances to become kubernetes
+                  nodes.
+                type: string
+              kubeadminPassword:
+                description: KubeadminPassword is a reference to the secret that contains
+                  the initial kubeadmin user password for the guest cluster.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              kubeconfig:
+                description: KubeConfig is a reference to the secret containing the
+                  default kubeconfig for the cluster.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              oauthCallbackURLTemplate:
+                description: OAuthCallbackURLTemplate contains a template for the
+                  URL to use as a callback for identity providers. The [identity-provider-name]
+                  placeholder must be replaced with the name of an identity provider
+                  defined on the HostedCluster. This is populated after the infrastructure
+                  is ready.
+                type: string
+              platform:
+                description: Platform contains platform-specific status of the HostedCluster
+                properties:
+                  aws:
+                    description: AWSPlatformStatus contains status specific to the
+                      AWS platform
+                    properties:
+                      defaultWorkerSecurityGroupID:
+                        description: DefaultWorkerSecurityGroupID is the ID of a security
+                          group created by the control plane operator. It is used
+                          for NodePools that don't specify a security group.
+                        type: string
+                    type: object
+                type: object
+              version:
+                description: Version is the status of the release version applied
+                  to the HostedCluster.
+                properties:
+                  availableUpdates:
+                    description: availableUpdates contains updates recommended for
+                      this cluster. Updates which appear in conditionalUpdates but
+                      not in availableUpdates may expose this cluster to known issues.
+                      This list may be empty if no updates are recommended, if the
+                      update service is unavailable, or if an invalid channel has
+                      been specified.
+                    items:
+                      description: Release represents an OpenShift release image and
+                        associated metadata.
+                      properties:
+                        channels:
+                          description: channels is the set of Cincinnati channels
+                            to which the release currently belongs.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        image:
+                          description: image is a container image location that contains
+                            the update. When this field is part of spec, image is
+                            optional if version is specified and the availableUpdates
+                            field contains a matching version.
+                          type: string
+                        url:
+                          description: url contains information about this release.
+                            This URL is set by the 'url' metadata property on a release
+                            or the metadata returned by the update API and should
+                            be displayed as a link in user interfaces. The URL field
+                            may not be set for test or nightly releases.
+                          type: string
+                        version:
+                          description: version is a semantic version identifying the
+                            update version. When this field is part of spec, version
+                            is optional if image is specified.
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  conditionalUpdates:
+                    description: conditionalUpdates contains the list of updates that
+                      may be recommended for this cluster if it meets specific required
+                      conditions. Consumers interested in the set of updates that
+                      are actually recommended for this cluster should use availableUpdates.
+                      This list may be empty if no updates are recommended, if the
+                      update service is unavailable, or if an empty or invalid channel
+                      has been specified.
+                    items:
+                      description: ConditionalUpdate represents an update which is
+                        recommended to some clusters on the version the current cluster
+                        is reconciling, but which may not be recommended for the current
+                        cluster.
+                      properties:
+                        conditions:
+                          description: 'conditions represents the observations of
+                            the conditional update''s current status. Known types
+                            are: * Evaluating, for whether the cluster-version operator
+                            will attempt to evaluate any risks[].matchingRules. *
+                            Recommended, for whether the update is recommended for
+                            the current cluster.'
+                          items:
+                            description: "Condition contains details for one aspect
+                              of the current state of this API Resource. --- This
+                              struct is intended for direct use as an array at the
+                              field path .status.conditions.  For example, \n type
+                              FooStatus struct{ // Represents the observations of
+                              a foo's current state. // Known .status.conditions.type
+                              are: \"Available\", \"Progressing\", and \"Degraded\"
+                              // +patchMergeKey=type // +patchStrategy=merge // +listType=map
+                              // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                              patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                              \n // other fields }"
+                            properties:
+                              lastTransitionTime:
+                                description: lastTransitionTime is the last time the
+                                  condition transitioned from one status to another.
+                                  This should be when the underlying condition changed.  If
+                                  that is not known, then using the time when the
+                                  API field changed is acceptable.
+                                format: date-time
+                                type: string
+                              message:
+                                description: message is a human readable message indicating
+                                  details about the transition. This may be an empty
+                                  string.
+                                maxLength: 32768
+                                type: string
+                              observedGeneration:
+                                description: observedGeneration represents the .metadata.generation
+                                  that the condition was set based upon. For instance,
+                                  if .metadata.generation is currently 12, but the
+                                  .status.conditions[x].observedGeneration is 9, the
+                                  condition is out of date with respect to the current
+                                  state of the instance.
+                                format: int64
+                                minimum: 0
+                                type: integer
+                              reason:
+                                description: reason contains a programmatic identifier
+                                  indicating the reason for the condition's last transition.
+                                  Producers of specific condition types may define
+                                  expected values and meanings for this field, and
+                                  whether the values are considered a guaranteed API.
+                                  The value should be a CamelCase string. This field
+                                  may not be empty.
+                                maxLength: 1024
+                                minLength: 1
+                                pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                type: string
+                              status:
+                                description: status of the condition, one of True,
+                                  False, Unknown.
+                                enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                                type: string
+                              type:
+                                description: type of condition in CamelCase or in
+                                  foo.example.com/CamelCase. --- Many .condition.type
+                                  values are consistent across resources like Available,
+                                  but because arbitrary conditions can be useful (see
+                                  .node.status.conditions), the ability to deconflict
+                                  is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                type: string
+                            required:
+                            - lastTransitionTime
+                            - message
+                            - reason
+                            - status
+                            - type
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - type
+                          x-kubernetes-list-type: map
+                        release:
+                          description: release is the target of the update.
+                          properties:
+                            channels:
+                              description: channels is the set of Cincinnati channels
+                                to which the release currently belongs.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            image:
+                              description: image is a container image location that
+                                contains the update. When this field is part of spec,
+                                image is optional if version is specified and the
+                                availableUpdates field contains a matching version.
+                              type: string
+                            url:
+                              description: url contains information about this release.
+                                This URL is set by the 'url' metadata property on
+                                a release or the metadata returned by the update API
+                                and should be displayed as a link in user interfaces.
+                                The URL field may not be set for test or nightly releases.
+                              type: string
+                            version:
+                              description: version is a semantic version identifying
+                                the update version. When this field is part of spec,
+                                version is optional if image is specified.
+                              type: string
+                          type: object
+                        risks:
+                          description: risks represents the range of issues associated
+                            with updating to the target release. The cluster-version
+                            operator will evaluate all entries, and only recommend
+                            the update if there is at least one entry and all entries
+                            recommend the update.
+                          items:
+                            description: ConditionalUpdateRisk represents a reason
+                              and cluster-state for not recommending a conditional
+                              update.
+                            properties:
+                              matchingRules:
+                                description: matchingRules is a slice of conditions
+                                  for deciding which clusters match the risk and which
+                                  do not. The slice is ordered by decreasing precedence.
+                                  The cluster-version operator will walk the slice
+                                  in order, and stop after the first it can successfully
+                                  evaluate. If no condition can be successfully evaluated,
+                                  the update will not be recommended.
+                                items:
+                                  description: ClusterCondition is a union of typed
+                                    cluster conditions.  The 'type' property determines
+                                    which of the type-specific properties are relevant.
+                                    When evaluated on a cluster, the condition may
+                                    match, not match, or fail to evaluate.
+                                  properties:
+                                    promql:
+                                      description: promQL represents a cluster condition
+                                        based on PromQL.
+                                      properties:
+                                        promql:
+                                          description: PromQL is a PromQL query classifying
+                                            clusters. This query query should return
+                                            a 1 in the match case and a 0 in the does-not-match
+                                            case. Queries which return no time series,
+                                            or which return values besides 0 or 1,
+                                            are evaluation failures.
+                                          type: string
+                                      required:
+                                      - promql
+                                      type: object
+                                    type:
+                                      description: type represents the cluster-condition
+                                        type. This defines the members and semantics
+                                        of any additional properties.
+                                      enum:
+                                      - Always
+                                      - PromQL
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                minItems: 1
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              message:
+                                description: message provides additional information
+                                  about the risk of updating, in the event that matchingRules
+                                  match the cluster state. This is only to be consumed
+                                  by humans. It may contain Line Feed characters (U+000A),
+                                  which should be rendered as new lines.
+                                minLength: 1
+                                type: string
+                              name:
+                                description: name is the CamelCase reason for not
+                                  recommending a conditional update, in the event
+                                  that matchingRules match the cluster state.
+                                minLength: 1
+                                type: string
+                              url:
+                                description: url contains information about this risk.
+                                format: uri
+                                minLength: 1
+                                type: string
+                            required:
+                            - matchingRules
+                            - message
+                            - name
+                            - url
+                            type: object
+                          minItems: 1
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                      required:
+                      - release
+                      - risks
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  desired:
+                    description: desired is the version that the cluster is reconciling
+                      towards. If the cluster is not yet fully initialized desired
+                      will be set with the information available, which may be an
+                      image or a tag.
+                    properties:
+                      channels:
+                        description: channels is the set of Cincinnati channels to
+                          which the release currently belongs.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      image:
+                        description: image is a container image location that contains
+                          the update. When this field is part of spec, image is optional
+                          if version is specified and the availableUpdates field contains
+                          a matching version.
+                        type: string
+                      url:
+                        description: url contains information about this release.
+                          This URL is set by the 'url' metadata property on a release
+                          or the metadata returned by the update API and should be
+                          displayed as a link in user interfaces. The URL field may
+                          not be set for test or nightly releases.
+                        type: string
+                      version:
+                        description: version is a semantic version identifying the
+                          update version. When this field is part of spec, version
+                          is optional if image is specified.
+                        type: string
+                    type: object
+                  history:
+                    description: history contains a list of the most recent versions
+                      applied to the cluster. This value may be empty during cluster
+                      startup, and then will be updated when a new update is being
+                      applied. The newest update is first in the list and it is ordered
+                      by recency. Updates in the history have state Completed if the
+                      rollout completed - if an update was failing or halfway applied
+                      the state will be Partial. Only a limited amount of update history
+                      is preserved.
+                    items:
+                      description: UpdateHistory is a single attempted update to the
+                        cluster.
+                      properties:
+                        acceptedRisks:
+                          description: acceptedRisks records risks which were accepted
+                            to initiate the update. For example, it may menition an
+                            Upgradeable=False or missing signature that was overriden
+                            via desiredUpdate.force, or an update that was initiated
+                            despite not being in the availableUpdates set of recommended
+                            update targets.
+                          type: string
+                        completionTime:
+                          description: completionTime, if set, is when the update
+                            was fully applied. The update that is currently being
+                            applied will have a null completion time. Completion time
+                            will always be set for entries that are not the current
+                            update (usually to the started time of the next update).
+                          format: date-time
+                          nullable: true
+                          type: string
+                        image:
+                          description: image is a container image location that contains
+                            the update. This value is always populated.
+                          type: string
+                        startedTime:
+                          description: startedTime is the time at which the update
+                            was started.
+                          format: date-time
+                          type: string
+                        state:
+                          description: state reflects whether the update was fully
+                            applied. The Partial state indicates the update is not
+                            fully applied, while the Completed state indicates the
+                            update was successfully rolled out at least once (all
+                            parts of the update successfully applied).
+                          type: string
+                        verified:
+                          description: verified indicates whether the provided update
+                            was properly verified before it was installed. If this
+                            is false the cluster may not be trusted. Verified does
+                            not cover upgradeable checks that depend on the cluster
+                            state at the time when the update target was accepted.
+                          type: boolean
+                        version:
+                          description: version is a semantic version identifying the
+                            update version. If the requested image does not define
+                            a version, or if a failure occurs retrieving the image,
+                            this value may be empty.
+                          type: string
+                      required:
+                      - completionTime
+                      - image
+                      - startedTime
+                      - state
+                      - verified
+                      type: object
+                    type: array
+                  observedGeneration:
+                    description: observedGeneration reports which version of the spec
+                      is being synced. If this value is not equal to metadata.generation,
+                      then the desired and conditions fields may represent a previous
+                      version.
+                    format: int64
+                    type: integer
+                required:
+                - availableUpdates
+                - desired
+                - observedGeneration
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -34,7 +35,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	hyperv1beta1 "github.com/openshift/hypershift/api/v1beta1"
 	operatorv1 "github.com/operator-framework/api/pkg/operators/v1"
@@ -283,6 +286,15 @@ func (o *AgentOptions) runControllerManager(ctx context.Context) error {
 	if err = autoImportController.SetupWithManager(mgr); err != nil {
 		metrics.AddonAgentFailedToStartBool.Set(1)
 		return fmt.Errorf("unable to create auto-import controller: %s, err: %w", util.AutoImportControllerName, err)
+	}
+
+	HcpKubeconfigChangeWatcher := &HcpKubeconfigChangeWatcher{
+		hubClient: hubClient, spokeClient: spokeKubeClient, log: o.Log.WithName("hcp-kubeconfig-watcher"),
+	}
+
+	if err = HcpKubeconfigChangeWatcher.SetupWithManager(mgr); err != nil {
+		metrics.AddonAgentFailedToStartBool.Set(1)
+		return fmt.Errorf("unable to create hcp kubeconfig watcher: %s, err: %w", "HcpKubeconfigChangeWatcher", err)
 	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
@@ -1138,8 +1150,76 @@ func (c *agentController) deleteManagedCluster(ctx context.Context, hc *hyperv1b
 func (c *agentController) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&hyperv1beta1.HostedCluster{}).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 10}).
+		WithEventFilter(hostedClusterEventFilters()).
 		Complete(c)
+}
+
+func hostedClusterEventFilters() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			newHc, newOK := e.ObjectNew.(*hyperv1beta1.HostedCluster)
+			oldHc, oldOK := e.ObjectOld.(*hyperv1beta1.HostedCluster)
+
+			if !newOK || !oldOK {
+				return false
+			}
+
+			if newHc.DeletionTimestamp != nil {
+				return false
+			}
+
+			newKASCondition := metav1.Condition{}
+			oldKASCondition := metav1.Condition{}
+
+			for _, condition := range newHc.Status.Conditions {
+				if condition.Type == string(hyperv1beta1.HostedClusterAvailable) {
+					newKASCondition = condition
+					break
+				}
+			}
+
+			for _, condition := range oldHc.Status.Conditions {
+				if condition.Type == string(hyperv1beta1.HostedClusterAvailable) {
+					oldKASCondition = condition
+					break
+				}
+			}
+
+			if newKASCondition.Status == metav1.ConditionTrue && (newKASCondition.Status != oldKASCondition.Status) {
+				return true
+			}
+
+			if !reflect.DeepEqual(oldHc.GetAnnotations(), newHc.GetAnnotations()) {
+				return true
+			}
+
+			if !reflect.DeepEqual(oldHc.Status.KubeConfig, newHc.Status.KubeConfig) {
+				return true
+			}
+
+			if !reflect.DeepEqual(oldHc.Status.KubeadminPassword, newHc.Status.KubeadminPassword) {
+				return true
+			}
+
+			if oldHc.Status.Version != nil && newHc.Status.Version != nil {
+				if !reflect.DeepEqual(oldHc.Status.Version.History, newHc.Status.Version.History) {
+					return true
+				}
+			}
+
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return true
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
 }
 
 func NewCleanupCommand(addonName string, logger logr.Logger) *cobra.Command {

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -839,7 +839,7 @@ func getHostedCluster(hcNN types.NamespacedName) *hyperv1beta1.HostedCluster {
 	hc := &hyperv1beta1.HostedCluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "HostedCluster",
-			APIVersion: "hypershift.openshift.io/v1alpha1",
+			APIVersion: "hypershift.openshift.io/v1beta1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      hcNN.Name,

--- a/pkg/agent/auto_import_controller.go
+++ b/pkg/agent/auto_import_controller.go
@@ -19,8 +19,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 const (
@@ -40,27 +38,12 @@ type AutoImportController struct {
 	log         logr.Logger
 }
 
-var AutoImportPredicateFunctions = predicate.Funcs{
-	CreateFunc: func(e event.CreateEvent) bool {
-		return true
-	},
-	UpdateFunc: func(e event.UpdateEvent) bool {
-		return false
-	},
-	DeleteFunc: func(e event.DeleteEvent) bool {
-		return false
-	},
-	GenericFunc: func(e event.GenericEvent) bool {
-		return false
-	},
-}
-
 // SetupWithManager sets up the controller with the Manager.
 func (c *AutoImportController) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&hyperv1beta1.HostedCluster{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
-		WithEventFilter(AutoImportPredicateFunctions).
+		WithEventFilter(hostedClusterEventFilters()).
 		Complete(c)
 }
 
@@ -80,9 +63,8 @@ func (c *AutoImportController) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	// check if controlplane is available, if not then requeue until it is
 	if hc.Status.Conditions == nil || len(hc.Status.Conditions) == 0 || !c.isHostedControlPlaneAvailable(hc.Status) {
-		// wait for cluster to become available, check again in a minute
-		c.log.Info(fmt.Sprintf("hosted control plane of (%s) is unavailable, retrying in 1 minute", req.NamespacedName))
-		return ctrl.Result{Requeue: true, RequeueAfter: time.Duration(1) * time.Minute}, nil
+		c.log.Info(fmt.Sprintf("hostedcluster %s's control plane is not ready yet.", hc.Name))
+		return ctrl.Result{}, nil
 	}
 	// once available, create managed cluster
 	if err := c.createManagedCluster(*hc, ctx); err != nil {

--- a/pkg/agent/auto_import_controller_test.go
+++ b/pkg/agent/auto_import_controller_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/go-logr/zapr"
 	hyperv1beta1 "github.com/openshift/hypershift/api/v1beta1"
@@ -317,8 +316,8 @@ func TestHCPUnavailable(t *testing.T) {
 
 	res, err := AICtrl.Reconcile(ctx, ctrl.Request{NamespacedName: hcNN})
 	assert.Nil(t, err, "no error when waiting for control plane")
-	checkRes := ctrl.Result{Requeue: true, RequeueAfter: time.Duration(1) * time.Minute}
-	assert.EqualValues(t, checkRes, res, "should requeue")
+	checkRes := ctrl.Result{}
+	assert.EqualValues(t, checkRes, res, "should not requeue")
 
 }
 

--- a/pkg/agent/hcp_kubeconfig_watcher.go
+++ b/pkg/agent/hcp_kubeconfig_watcher.go
@@ -1,0 +1,112 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	hyperv1beta1 "github.com/openshift/hypershift/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+const (
+	adminKubeconfigSuffix = "admin-kubeconfig"
+	ownerRefKind          = "HostedCluster"
+)
+
+type HcpKubeconfigChangeWatcher struct {
+	hubClient   client.Client
+	spokeClient client.Client
+	log         logr.Logger
+}
+
+var HcpKubeconfigChangeWatcherPredicateFunctions = predicate.Funcs{
+	CreateFunc: func(e event.CreateEvent) bool {
+		return false
+	},
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		if !strings.HasSuffix(e.ObjectNew.GetName(), adminKubeconfigSuffix) {
+			return false
+		}
+
+		ownerRefs := e.ObjectNew.GetOwnerReferences()
+
+		for _, owner := range ownerRefs {
+			if owner.Kind == ownerRefKind {
+				return true
+			}
+		}
+
+		return false
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return false
+	},
+	GenericFunc: func(e event.GenericEvent) bool {
+		return false
+	},
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (c *HcpKubeconfigChangeWatcher) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Secret{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 5}).
+		WithEventFilter(HcpKubeconfigChangeWatcherPredicateFunctions).
+		Complete(c)
+}
+
+func (c *HcpKubeconfigChangeWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	c.log.Info(fmt.Sprintf("Hosted Cluster admin kubeconfig %s updated.", req.Name))
+
+	theSecret := &corev1.Secret{}
+	err := c.spokeClient.Get(ctx, req.NamespacedName, theSecret)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	hcFound := false
+	hostedClusterObj := &hyperv1beta1.HostedCluster{}
+	secretOwners := theSecret.GetOwnerReferences()
+	for _, owner := range secretOwners {
+		if owner.Kind == ownerRefKind {
+			hcNN := types.NamespacedName{Namespace: req.Namespace, Name: owner.Name}
+			err = c.spokeClient.Get(ctx, hcNN, hostedClusterObj)
+			if err != nil {
+				c.log.Error(err, fmt.Sprintf("Failed to find the owning hosted cluster %s.", owner.Name))
+				return ctrl.Result{}, err
+			}
+			hcFound = true
+		}
+	}
+
+	if !hcFound {
+		c.log.Error(err, fmt.Sprintf("Failed to find an owning hosted cluster for this admin kubeconfig %s.", req.Name))
+		return ctrl.Result{}, err
+	}
+
+	originalHC := hostedClusterObj.DeepCopy()
+
+	// Add/update the annotation to the hostedcluster
+	if hostedClusterObj.ObjectMeta.Annotations == nil { // Create the annotation map if it doesn't exist
+		hostedClusterObj.ObjectMeta.Annotations = make(map[string]string)
+	}
+
+	currentTime := time.Now()
+	hostedClusterObj.Annotations[hcAnnotation] = currentTime.Format(time.RFC3339)
+	c.log.Info(fmt.Sprintf("Annotated %s with %s", hostedClusterObj.Name, hcAnnotation))
+
+	if err := c.spokeClient.Patch(ctx, hostedClusterObj, client.MergeFromWithOptions(originalHC)); err != nil { //Add/update hostedcluster annotation
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/pkg/agent/hcp_kubeconfig_watcher_test.go
+++ b/pkg/agent/hcp_kubeconfig_watcher_test.go
@@ -1,0 +1,148 @@
+package agent
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	hyperv1beta1 "github.com/openshift/hypershift/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const testHcNamespace = "hc-test-1"
+const testHcName = "hc-test-1"
+const adminKubeconfigSecret = testHcName + "-admin-kubeconfig"
+
+var _ = Describe("Hosted cluster kubeconfig secret change watcher", Ordered, func() {
+	ctx := context.Background()
+
+	BeforeAll(func() {
+		ctx = context.TODO()
+		By("Create the hosted cluster namespace")
+		hcNs := corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testHcNamespace,
+			},
+		}
+		Expect(k8sClient.Create(ctx, &hcNs)).Should(Succeed())
+
+		By("creating a hosted cluster")
+
+		hc := getHostedCluster(types.NamespacedName{Namespace: testHcNamespace, Name: testHcName})
+		hsStatus := &hyperv1beta1.HostedClusterStatus{
+			KubeConfig: &corev1.LocalObjectReference{Name: "kubeconfig"},
+			Conditions: []metav1.Condition{{Type: string(hyperv1beta1.HostedClusterAvailable), Status: metav1.ConditionTrue, Reason: hyperv1beta1.AsExpectedReason}},
+			Version: &hyperv1beta1.ClusterVersionStatus{
+				History: []configv1.UpdateHistory{{State: configv1.CompletedUpdate}},
+			},
+		}
+		hc.Status = *hsStatus
+		Expect(k8sClient.Create(ctx, hc)).Should(Succeed())
+	})
+
+	Context("When the hosted cluster admin kubeconfig secret is created", func() {
+		It("Should not do add the annotation to the hosted cluster", func() {
+
+			By("creating the admin kubeconfig")
+
+			kubeconfig := getAdminKubeconfigSecret(types.NamespacedName{Namespace: testHcNamespace, Name: adminKubeconfigSecret})
+			Expect(k8sClient.Create(ctx, kubeconfig)).Should(Succeed())
+
+			time.Sleep(time.Second * 5)
+
+			hostedCluster := &hyperv1beta1.HostedCluster{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: testHcNamespace, Name: testHcName}, hostedCluster)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hostedCluster.Annotations).To(BeNil())
+		})
+	})
+
+	Context("When the hosted cluster admin kubeconfig secret is deleted", func() {
+		It("Should not do add the annotation to the hosted cluster", func() {
+
+			By("deleting the admin kubeconfig")
+
+			kubeconfig := &corev1.Secret{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: testHcNamespace, Name: adminKubeconfigSecret}, kubeconfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Delete(ctx, kubeconfig)).Should(Succeed())
+
+			time.Sleep(time.Second * 5)
+
+			hostedCluster := &hyperv1beta1.HostedCluster{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Namespace: testHcNamespace, Name: testHcName}, hostedCluster)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hostedCluster.Annotations).To(BeNil())
+		})
+	})
+
+	Context("When the hosted cluster admin kubeconfig secret is updated", func() {
+		It("Should add the annotation to the hosted cluster", func() {
+
+			By("creating the admin kubeconfig")
+
+			kubeconfig := getAdminKubeconfigSecret(types.NamespacedName{Namespace: testHcNamespace, Name: adminKubeconfigSecret})
+			Expect(k8sClient.Create(ctx, kubeconfig)).Should(Succeed())
+
+			time.Sleep(time.Second * 5)
+
+			hostedCluster := &hyperv1beta1.HostedCluster{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: testHcNamespace, Name: testHcName}, hostedCluster)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hostedCluster.Annotations).To(BeNil())
+
+			newKubeconfig := &corev1.Secret{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Namespace: testHcNamespace, Name: adminKubeconfigSecret}, newKubeconfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			newKubeconfig.Data = map[string][]byte{
+				"kubeadmin": []byte("newkubeconfig"),
+			}
+			Expect(k8sClient.Update(ctx, newKubeconfig)).Should(Succeed())
+
+			Eventually(func() string {
+				if err := k8sClient.Get(ctx,
+					types.NamespacedName{Namespace: testHcNamespace, Name: testHcName},
+					hostedCluster); err != nil {
+					return ""
+				}
+				return hostedCluster.Annotations[hcAnnotation]
+			}).WithTimeout(10 * time.Second).ShouldNot(Equal(""))
+		})
+	})
+})
+
+func getAdminKubeconfigSecret(secretNN types.NamespacedName) *corev1.Secret {
+	hostedCluster := &hyperv1beta1.HostedCluster{}
+	err := k8sClient.Get(ctx, types.NamespacedName{Namespace: testHcNamespace, Name: testHcName}, hostedCluster)
+	Expect(err).NotTo(HaveOccurred())
+
+	hc := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretNN.Name,
+			Namespace: secretNN.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "hypershift.openshift.io/v1beta1",
+					Kind:       "HostedCluster",
+					Name:       testHcName,
+					UID:        hostedCluster.UID,
+				},
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"kubeadmin": []byte("test"),
+		},
+	}
+	return hc
+}

--- a/pkg/agent/suite_test.go
+++ b/pkg/agent/suite_test.go
@@ -79,6 +79,13 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
+	err = (&HcpKubeconfigChangeWatcher{
+		spokeClient: k8sManager.GetClient(),
+		hubClient:   k8sManager.GetClient(),
+		log:         zapLogger.WithName("hcp-kubeconfig-watcher-test"),
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
 	go func() {
 		defer GinkgoRecover()
 		err = k8sManager.Start(ctx)


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* This optimizes the agent's reconciliation rate by filtering out unimportant HostedCluster resource events. This change reduces the number of reconciliations by 82% percent per hosted cluster. 

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  When there are a large number of hosted clusters, the resource events can create a bottleneck in the agent controller's reconciliation queue causing some of the important events to be lost in the queue. 

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-18288

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
	github.com/stolostron/hypershift-addon-operator/cmd		coverage: 0.0% of statements
	github.com/stolostron/hypershift-addon-operator/pkg/util		coverage: 0.0% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	39.575s	coverage: 69.1% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	176.133s	coverage: 84.6% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/manager	121.353s	coverage: 60.4% of statements
ok  	github.com/stolostron/hypershift-addon-operator/pkg/metrics	0.783s	coverage: 35.7% of statements
```
