### PR TITLE
ACM-18678: fix the auto-import of managed cluster's hosted cluster

### DIFF
--- a/docs/hosting_cluster_topologies.md
+++ b/docs/hosting_cluster_topologies.md
@@ -136,6 +136,30 @@ Since the hosted control planes run on the managed OCP clusters' nodes, the numb
 
 ### Enable the addon by using clusteradm CLI
 
+Before enabling the hypershift-addon, configure the addon deployment to disable the hosted cluster discovery by setting spec.disableHCDiscovery to true in `hypershift-addon-deploy-config` addondeploymentconfig.
+
+```
+oc edit addondeploymentconfig hypershift-addon-deploy-config -n multicluster-engine
+```
+
+```yaml
+spec:
+  agentInstallNamespace: open-cluster-management-agent-addon
+  customizedVariables:
+  - name: hcMaxNumber
+    value: "80"
+  - name: hcThresholdNumber
+    value: "60"
+  - name: disableHCDiscovery
+    value: "true"
+  nodePlacement:
+    tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/infra
+      operator: Exists
+```
+
+
 [Install the clusteradmin CLI](https://open-cluster-management.io/getting-started/quick-start/#install-clusteradm-cli-tool) and run the following command to enable the `hypershift-addon` for `managed-ocp-cluster-1` managed cluster.
 
 ```

--- a/pkg/manager/manifests/templates/deployment.yaml
+++ b/pkg/manager/manifests/templates/deployment.yaml
@@ -94,9 +94,9 @@ spec:
         - name: DISABLE_HO_MANAGEMENT
           value: "{{ .disableHOManagement }}"
 {{- end }}
-{{- if eq .enableHCDiscovery "true" }}
-        - name: ENABLE_HC_DISCOVERY
-          value: "{{ .enableHCDiscovery }}"
+{{- if eq .disableHCDiscovery "true" }}
+        - name: DISABLE_HC_DISCOVERY
+          value: "{{ .disableHCDiscovery }}"
 {{- end }}
 {{- if or (eq .discoveryPrefix "") (.discoveryPrefix)}}
         - name: DISCOVERY_PREFIX


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* the topology described in https://github.com/stolostron/hypershift-addon-operator/blob/main/docs/hosting_cluster_topologies.md#mce-managed-aka-spoke-leaf-ocp-cluster-as-a-hosting-cluster does not work.  This is due to a mismatch between the environment variable name set in the YAML template and the code that controls the flow.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  To fix the auto-import of hosted clusters from a managed cluster.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-18678

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
