### PR TITLE
Delete managed cluster

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -662,6 +662,12 @@ func (c *agentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		if apierrors.IsNotFound(err) {
 			c.log.Info(fmt.Sprintf("remove hostedcluster(%s) secrets on hub, since hostedcluster is gone", req.NamespacedName))
 
+			hc.Name = req.Name // Since the HC is already deleted, set the HC name as the reconcile event name which is the deleted HC name
+			// Try to delete the managed cluster
+			if err := c.deleteManagedCluster(ctx, hc); err != nil {
+				c.log.Error(err, "failed to delete the managed cluster")
+			}
+
 			return ctrl.Result{}, deleteMirrorSecrets("")
 		}
 


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* This is a regression problem that when a hosted cluster is deleted, the corresponding managed cluster is no longer deleted.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  This PR is to fix the problem stated above.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* 

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
