### PR TITLE
ACM-22317 Reconcile at the agent startup

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1211,7 +1211,7 @@ func (c *agentController) SetupWithManager(mgr ctrl.Manager) error {
 func hostedClusterEventFilters() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			return false
+			return true
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			newHc, newOK := e.ObjectNew.(*hyperv1beta1.HostedCluster)


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Previously, the hosted cluster create resource event was ignored by the agent to reduce the reconciliation frequency. This PR makes the agent to reconcile on HostedCluster create event.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  The agent does not do anything meaningful when a new hosted cluster is created because its kube API server is not ready. However, when the agent starts up, we want the agent to reconcile all existing hosted clusters to ensure that it did not miss any hosted clusters while the agent was down.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://issues.redhat.com/browse/ACM-22317

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
