### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for hypershift-addon-operator-mce-29

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -24,7 +24,8 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 COPY --from=builder /go/src/github.com/stolostron/hypershift-addon-operator/bin/hypershift-addon .
 
 LABEL com.redhat.component="multicluster-engine-hypershift-addon-operator-container" \
-      name="multicluster-engine/hypershift-addon-operator" \
+      name="multicluster-engine/hypershift-addon-rhel9-operator" \
+      cpe="cpe:/a:redhat:multicluster_engine:2.9::el9" \
       version="2.9" \
       summary="multicluster-engine-hypershift-addon-operator" \
       io.openshift.tags="data,images" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
