### PR TITLE
Add repository url label to container images

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -24,6 +24,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 COPY --from=builder /go/src/github.com/stolostron/hypershift-addon-operator/bin/hypershift-addon .
 
 LABEL com.redhat.component="multicluster-engine-hypershift-addon-operator-container" \
+      url="https://github.com/stolostron/hypershift-addon-operator" \
       name="multicluster-engine/hypershift-addon-operator" \
       version="2.9" \
       summary="multicluster-engine-hypershift-addon-operator" \


### PR DESCRIPTION
This pull request adds the repository URL as the 'url' label to container images.

**Related Issue:** https://issues.redhat.com/browse/ACM-23275

**Epic Goal:** All ACM and MCE container images should define the url label pointing to their source repository instead of the generic 'https://www.redhat.com' value.

**Target Branch:** backplane-2.10

**Components affected:** hypershift-addon-operator

**Branch details:** hypershift-addon-operator (branch: backplane-2.10)

**Label added:**
- url: https://github.com/stolostron/hypershift-addon-operator

This change improves traceability and helps identify the source repository for each container image, which is especially important for components like kube-rbac-proxy that exist in multiple organizations.