### PR TITLE
Add Azure private install support for hypershift addon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,11 @@ ifndef ignore-not-found
 endif
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
-ENVTEST_PACKAGE ?= sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+# Keep setup-envtest aligned with controller-runtime to avoid
+# requiring a newer Go toolchain than this repo uses in CI.
+# Use Replace.Version when go.mod replaces controller-runtime (see require vs replace).
+ENVTEST_VERSION ?= $(shell go list -m -f '{{if .Replace}}{{.Replace.Version}}{{else}}{{.Version}}{{end}}' sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
+ENVTEST_PACKAGE ?= sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
 .PHONY: envtest
 envtest: ## Download envtest-setup locally if necessary.
 	$(call go-get-tool,$(ENVTEST),$(ENVTEST_PACKAGE))

--- a/docs/configuration/azure_private_hosted_cluster.md
+++ b/docs/configuration/azure_private_hosted_cluster.md
@@ -1,0 +1,161 @@
+# Configuring Azure Private Hosted Clusters with hypershift-addon
+
+This document explains how to configure `hypershift-addon` so the addon agent installs the HyperShift operator with Azure private platform settings.
+
+The goal is to make operator installation include:
+
+- `--private-platform Azure`
+- `--azure-pls-resource-group <resource-group>`
+- `--azure-private-secret hypershift-operator-azure-credentials` (injected automatically by the addon)
+
+## What this enables
+
+With this configuration:
+
+- The addon agent reads Azure private install flags from `hypershift-operator-install-flags` in `local-cluster`.
+- The addon agent detects `hypershift-operator-azure-credentials` on hub (`local-cluster` namespace), copies it to `hypershift` namespace on spoke, and re-installs the operator when this secret changes.
+- The HyperShift operator is installed in Azure private mode and can be used to create private Azure hosted clusters.
+
+## Prerequisites
+
+- ACM/MCE with `hypershift-addon` enabled on `local-cluster`.
+- `oc` CLI access to the hub cluster.
+- Azure private connectivity prerequisites for your environment (networking, DNS, permissions, and resource group for Private Link Service components).
+- HyperShift CLI (`hcp`) available for creating hosted clusters.
+
+## 1) Prepare Azure private credentials file
+
+Create the credentials file that will be stored in the secret as key `credentials`.
+
+If you already have an Azure credentials file used by `hcp create cluster azure`, you can reuse it and skip to step 2.
+
+Example flow to create a service principal and file:
+
+```bash
+AZ_SUBSCRIPTION_ID="<subscription-id>"
+AZ_TENANT_ID="<tenant-id>"
+AZ_LOCATION="eastus"
+AZ_RG="<resource-group>"
+
+az login
+az account set --subscription "${AZ_SUBSCRIPTION_ID}"
+
+SP_JSON=$(az ad sp create-for-rbac \
+  --name "hypershift-private-sp" \
+  --role Contributor \
+  --scopes "/subscriptions/${AZ_SUBSCRIPTION_ID}" \
+  --sdk-auth)
+```
+
+Extract values and write a credentials env file:
+
+```bash
+AZ_APP_ID=$(echo "${SP_JSON}" | jq -r '.clientId')
+AZ_PASSWORD=$(echo "${SP_JSON}" | jq -r '.clientSecret')
+
+cat > azure-private-credentials.json <<EOF
+AZURE_CLIENT_ID=${AZ_APP_ID}
+AZURE_CLIENT_SECRET=${AZ_PASSWORD}
+AZURE_TENANT_ID=${AZ_TENANT_ID}
+AZURE_SUBSCRIPTION_ID=${AZ_SUBSCRIPTION_ID}
+AZURE_RESOURCE_GROUP=${AZ_RG}
+AZURE_LOCATION=${AZ_LOCATION}
+EOF
+```
+
+Validate file content before creating the secret:
+
+```bash
+cat azure-private-credentials.json
+```
+
+## 2) Create Azure private credentials secret on hub
+
+Create the secret in `local-cluster` namespace with key `credentials`:
+
+```bash
+oc create secret generic hypershift-operator-azure-credentials \
+  -n local-cluster \
+  --from-file=credentials=./azure-private-credentials.json
+```
+
+## 3) Configure HyperShift operator install flags
+
+Create or update `hypershift-operator-install-flags` in `local-cluster` namespace:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hypershift-operator-install-flags
+  namespace: local-cluster
+data:
+  installFlagsToAdd: "--private-platform Azure --azure-pls-resource-group abcd-rg"
+  installFlagsToRemove: ""
+```
+
+Apply it:
+
+```bash
+oc apply -f hypershift-operator-install-flags.yaml
+```
+
+## 4) Verify addon-driven operator installation
+
+Check addon status:
+
+```bash
+oc get managedclusteraddons -n local-cluster hypershift-addon
+```
+
+Check install jobs:
+
+```bash
+oc get jobs -n open-cluster-management-agent-addon
+```
+
+Inspect latest install job args and logs:
+
+```bash
+oc get job -n open-cluster-management-agent-addon -o yaml
+oc logs -n open-cluster-management-agent-addon job/<hypershift-install-job-name>
+```
+
+Confirm Azure secret was copied to HyperShift namespace:
+
+```bash
+oc get secret hypershift-operator-azure-credentials -n hypershift
+```
+
+Confirm operator deployment includes private Azure flags:
+
+```bash
+oc get deploy operator -n hypershift -o yaml
+```
+
+## 5) Create Azure hosted cluster
+
+After operator installation is healthy, create a hosted cluster using HyperShift CLI:
+
+```bash
+hcp create cluster azure --help
+```
+
+Then run your `hcp create cluster azure ...` command with your Azure-specific values.
+
+## Behavior notes
+
+- The addon checks watched resources every 2 minutes. If the Azure secret or install flags configmap changes, the addon re-installs HyperShift operator.
+- The managed Azure private secret name must be:
+  - `hypershift-operator-azure-credentials`
+- If `--private-platform Azure` is set but `--azure-pls-resource-group` or the Azure credentials secret is missing, operator installation fails with a validation error.
+
+## Troubleshooting
+
+- If install job fails, inspect:
+  - `oc describe job <job-name> -n open-cluster-management-agent-addon`
+  - `oc logs job/<job-name> -n open-cluster-management-agent-addon`
+- Ensure:
+  - secret exists in `local-cluster` and has `credentials` key
+  - configmap flags are syntactically correct and include required Azure private options
+  - resource group in `--azure-pls-resource-group` exists and is correct

--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -64,7 +64,11 @@ func (c *UpgradeController) RunHypershiftCmdWithRetires(
 
 	}
 
-	return fmt.Errorf("failed to install the hypershift operator and apply its crd after %v retires, err: %w", attempts, err)
+	return fmt.Errorf(
+		"failed to install the hypershift operator and apply its crd after %v retires, err: %w",
+		attempts,
+		err,
+	)
 }
 
 func getRandInt(m int64) int64 {
@@ -76,7 +80,10 @@ func getRandInt(m int64) int64 {
 	return n.Int64()
 }
 
-func (c *UpgradeController) runHypershiftRender(ctx context.Context, args []string) ([]unstructured.Unstructured, error) {
+func (c *UpgradeController) runHypershiftRender(
+	ctx context.Context,
+	args []string,
+) ([]unstructured.Unstructured, error) {
 	out := []unstructured.Unstructured{}
 	if c.hypershiftInstallExecutor == nil {
 		return out, fmt.Errorf("failed to run hypershift cmd, no install executor specified")
@@ -186,7 +193,8 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 	// If the hypershift operator installation failed in the previous attempt, no checking. We need to
 	// install again.
 	// For now, assume that secrets did not change (MCE upgrade or pod re-cycle scenarios)
-	// If controllerStartup = false, we are here because the image override configmap or some operator secrets have changed. No check required.
+	// If controllerStartup = false, we are here because the image override configmap
+	// or some operator secrets have changed. No check required.
 	reinstallCheckRequired := (operatorDeployment != nil) && controllerStartup && !c.installfailed
 
 	c.log.Info("reinstallCheckRequired = " + strconv.FormatBool(reinstallCheckRequired))
@@ -215,6 +223,7 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 	awsPlatform := false
 	oidcBucket := true
 	privateLinkCreds := true
+	azurePrivateCreds := true
 
 	//Attempt to retrieve oidc bucket secret
 	bucketSecretKey := types.NamespacedName{Name: util.HypershiftBucketSecretName, Namespace: c.clusterName}
@@ -239,11 +248,27 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 	// cache the private link secret for comparison againt the hub's to detect any change
 	c.privateLinkSecret = *spl
 
+	// Attempt to retrieve Azure private credentials
+	azurePrivateSecretKey := types.NamespacedName{Name: util.HypershiftAzurePrivateSecretName, Namespace: c.clusterName}
+	sAzurePrivate := &corev1.Secret{}
+	if err := c.hubClient.Get(ctx, azurePrivateSecretKey, sAzurePrivate); err != nil {
+		c.log.Info(fmt.Sprintf("azure private secret(%s) not found on the hub.", azurePrivateSecretKey))
+		azurePrivateCreds = false
+	}
+	// cache the Azure private secret for comparison against the hub's to detect any change
+	c.azurePrivateSecret = *sAzurePrivate
+
 	//Platform is aws if either secret exists
 	awsPlatform = oidcBucket || privateLinkCreds
 	c.awsPlatform = awsPlatform
 	if !awsPlatform {
-		c.log.Info(fmt.Sprintf("bucket secret(%s) and private link secret(%s) not found on the hub, installing hypershift operator for non-AWS platform.", bucketSecretKey, privateSecretKey))
+		c.log.Info(
+			fmt.Sprintf(
+				"bucket secret(%s) and private link secret(%s) not found on the hub, installing for non-AWS platform.",
+				bucketSecretKey,
+				privateSecretKey,
+			),
+		)
 	}
 
 	args := []string{
@@ -324,6 +349,29 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 	// Get the hypershift operator installation flags configmap from the hub
 	installFlagsCM, _ := c.getConfigMapFromHub(util.HypershiftInstallFlagsCM)
 	c.installFlagsConfigmap = installFlagsCM
+	installFlagsToAdd := []string{}
+	if installFlagsCM.Data != nil {
+		installFlagsToAdd = strings.Fields(installFlagsCM.Data["installFlagsToAdd"])
+	}
+
+	if strings.EqualFold(getParamValue(installFlagsToAdd, "--private-platform"), "Azure") {
+		if getParamValue(installFlagsToAdd, "--azure-pls-resource-group") == "" {
+			return fmt.Errorf(
+				"azure private platform requires --azure-pls-resource-group in %s configmap",
+				util.HypershiftInstallFlagsCM,
+			)
+		}
+
+		if !azurePrivateCreds {
+			return fmt.Errorf("azure private secret(%s) was not found on the hub", azurePrivateSecretKey)
+		}
+
+		if err := c.createSpokeSecret(ctx, sAzurePrivate); err != nil {
+			return err
+		}
+		// The managed Azure private secret name is fixed, so inject it automatically.
+		args = append(args, "--azure-private-secret", util.HypershiftAzurePrivateSecretName)
+	}
 
 	hypershiftImage := c.operatorImage
 	imageStreamCMData := make(map[string]string, 0)
@@ -345,9 +393,10 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 			!(c.operatorImagesUpdated(im, *operatorDeployment) ||
 				c.secretDataUpdated(util.HypershiftBucketSecretName, *se) ||
 				c.secretDataUpdated(util.HypershiftPrivateLinkSecretName, *spl) ||
+				c.secretDataUpdated(util.HypershiftAzurePrivateSecretName, *sAzurePrivate) ||
 				c.secretDataUpdated(util.HypershiftExternalDNSSecretName, *sExtDNS) ||
 				c.configmapDataUpdated(util.HypershiftInstallFlagsCM, installFlagsCM)) {
-			c.log.Info("no change in hypershift operator images, secrets and install flags, skipping hypershift operator installation")
+			c.log.Info("no image/secret/install-flag change, skip hypershift operator installation")
 			return nil
 		}
 	} else {
@@ -403,6 +452,9 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 	if err := c.saveSecretLocally(ctx, spl); err != nil { // private link secret
 		return err
 	}
+	if err := c.saveSecretLocally(ctx, sAzurePrivate); err != nil { // azure private secret
+		return err
+	}
 	if err := c.saveSecretLocally(ctx, sExtDNS); err != nil { // external DNS secret
 		return err
 	}
@@ -441,11 +493,15 @@ func (c *UpgradeController) buildOtherInstallFlags(installFlagsCM corev1.ConfigM
 	telemetryArgs := []string{
 		"--platform-monitoring", "OperatorOnly",
 	}
-	if !contains(flagsToRemove, "--platform-monitoring") { // if the flagsToRemove contains --platform-monitoring, do not add it
-		if contains(flagsToAdd, "--platform-monitoring") { // if the flagsToAdd contains --platform-monitoring, get the value from the list
+	// If flagsToRemove contains --platform-monitoring, do not add it.
+	if !contains(flagsToRemove, "--platform-monitoring") {
+		// If flagsToAdd contains --platform-monitoring, use its value.
+		if contains(flagsToAdd, "--platform-monitoring") {
 			val := getParamValue(flagsToAdd, "--platform-monitoring")
 			if val == "" {
-				c.log.Info("--platform-monitoring does not have any value in installParamsToAdd, setting it to default [ --platform-monitoringOperatorOnly ]")
+				c.log.Info(
+					"--platform-monitoring has no value in installParamsToAdd; using default [ --platform-monitoring OperatorOnly ]",
+				)
 				args = append(args, telemetryArgs...)
 			} else {
 				c.log.Info(fmt.Sprintf("updating the install flag [ --platform-monitoring %s ]", val))
@@ -530,17 +586,28 @@ func getParamValue(s []string, e string) string {
 	return ""
 }
 
-func (c *UpgradeController) createAwsSpokeSecret(ctx context.Context, hubSecret *corev1.Secret, regionRequired bool) error {
+func (c *UpgradeController) createAwsSpokeSecret(
+	ctx context.Context,
+	hubSecret *corev1.Secret,
+	regionRequired bool,
+) error {
 	spokeSecret := hubSecret.DeepCopy()
 
 	region := hubSecret.Data["region"]
 	awsSecretKey := hubSecret.Data["aws-secret-access-key"]
 	awsKeyId := hubSecret.Data["aws-access-key-id"]
-	if (hubSecret.Data["credentials"] == nil && (awsKeyId == nil || awsSecretKey == nil)) || (region == nil && regionRequired) {
+	missingCreds := hubSecret.Data["credentials"] == nil && (awsKeyId == nil || awsSecretKey == nil)
+	missingRegion := region == nil && regionRequired
+	if missingCreds || missingRegion {
 		return fmt.Errorf("secret(%s/%s) does not contain a valid credential or region", hubSecret.Namespace, hubSecret.Name)
 	} else {
 		if awsSecretKey != nil {
-			spokeSecret.Data["credentials"] = []byte(fmt.Sprintf("[default]\naws_access_key_id = %s\naws_secret_access_key = %s", awsKeyId, awsSecretKey))
+			credentials := fmt.Sprintf(
+				"[default]\naws_access_key_id = %s\naws_secret_access_key = %s",
+				awsKeyId,
+				awsSecretKey,
+			)
+			spokeSecret.Data["credentials"] = []byte(credentials)
 		}
 	}
 
@@ -555,7 +622,14 @@ func (c *UpgradeController) createSpokeSecret(ctx context.Context, hubSecret *co
 			Namespace: hypershiftOperatorKey.Namespace,
 		},
 	}
-	c.log.Info(fmt.Sprintf("createorupdate the the secret (%s/%s) on cluster %s", hypershiftOperatorKey.Namespace, hubSecret.Name, hubSecret.Namespace))
+	c.log.Info(
+		fmt.Sprintf(
+			"createorupdate the the secret (%s/%s) on cluster %s",
+			hypershiftOperatorKey.Namespace,
+			hubSecret.Name,
+			hubSecret.Namespace,
+		),
+	)
 	_, err := controllerutil.CreateOrUpdate(ctx, c.spokeUncachedClient, spokeSecret, func() error {
 		spokeSecret.Data = map[string][]byte{
 			"credentials": hubSecret.Data["credentials"],
@@ -575,7 +649,14 @@ func (c *UpgradeController) saveSecretLocally(ctx context.Context, hubSecret *co
 				Namespace: c.addonNamespace,
 			},
 		}
-		c.log.Info(fmt.Sprintf("save the secret (%s/%s) locally on cluster %s", c.addonNamespace, hubSecret.Name, c.clusterName))
+		c.log.Info(
+			fmt.Sprintf(
+				"save the secret (%s/%s) locally on cluster %s",
+				c.addonNamespace,
+				hubSecret.Name,
+				c.clusterName,
+			),
+		)
 		_, err := controllerutil.CreateOrUpdate(ctx, c.spokeUncachedClient, spokeSecret, func() error {
 			spokeSecret.Data = hubSecret.Data
 			return nil
@@ -593,7 +674,14 @@ func (c *UpgradeController) saveConfigmapLocally(ctx context.Context, hubConfigm
 				Namespace: c.addonNamespace,
 			},
 		}
-		c.log.Info(fmt.Sprintf("save the configmap (%s/%s) locally on cluster %s", c.addonNamespace, hubConfigmap.Name, c.clusterName))
+		c.log.Info(
+			fmt.Sprintf(
+				"save the configmap (%s/%s) locally on cluster %s",
+				c.addonNamespace,
+				hubConfigmap.Name,
+				c.clusterName,
+			),
+		)
 		_, err := controllerutil.CreateOrUpdate(ctx, c.spokeUncachedClient, spokeConfigmap, func() error {
 			spokeConfigmap.Data = hubConfigmap.Data
 			return nil
@@ -655,7 +743,13 @@ func (c *UpgradeController) isHypershiftOperatorByMCE(ctx context.Context) bool 
 	obj := &appsv1.Deployment{}
 
 	if err := c.spokeUncachedClient.Get(ctx, hypershiftOperatorKey, obj); err != nil {
-		c.log.Info(fmt.Sprintf("hypershift operator %s deployment not found after install, err: %v", hypershiftOperatorKey, err))
+		c.log.Info(
+			fmt.Sprintf(
+				"hypershift operator %s deployment not found after install, err: %v",
+				hypershiftOperatorKey,
+				err,
+			),
+		)
 		return false
 	}
 
@@ -790,7 +884,12 @@ func (c *UpgradeController) readInDownstreamOverride() ([]byte, error) {
 	// Override the image values in the installer provided imagestream with this
 	imUpgradeConfigMap, _ := c.getConfigMapFromHub(util.HypershiftOverrideImagesCM)
 	if imUpgradeConfigMap.Data != nil {
-		c.log.Info(fmt.Sprintf("found %s configmap, overriding hypershift images in the imagestream", util.HypershiftOverrideImagesCM))
+		c.log.Info(
+			fmt.Sprintf(
+				"found %s configmap, overriding hypershift images in the imagestream",
+				util.HypershiftOverrideImagesCM,
+			),
+		)
 
 		im, err = c.getUpdatedImageStream(im, imUpgradeConfigMap.Data)
 		if err != nil {
@@ -916,7 +1015,12 @@ func getContainerEnvVar(envVars []corev1.EnvVar, imageName string) string {
 }
 
 func (c *UpgradeController) secretDataUpdated(secretName string, secret corev1.Secret) bool {
-	c.log.Info(fmt.Sprintf("comparing hypershift operator installation secret(%s) to the locally saved secret", secretName))
+	c.log.Info(
+		fmt.Sprintf(
+			"comparing hypershift operator installation secret(%s) to the locally saved secret",
+			secretName,
+		),
+	)
 	secretKey := types.NamespacedName{Name: secretName, Namespace: c.addonNamespace}
 	localSecret := &corev1.Secret{}
 	if err := c.spokeUncachedClient.Get(context.TODO(), secretKey, localSecret); err != nil && !apierrors.IsNotFound(err) {
@@ -932,7 +1036,12 @@ func (c *UpgradeController) secretDataUpdated(secretName string, secret corev1.S
 }
 
 func (c *UpgradeController) configmapDataUpdated(cmName string, cm corev1.ConfigMap) bool {
-	c.log.Info(fmt.Sprintf("comparing hypershift operator installation flags configmap(%s) to the locally saved configmap", cmName))
+	c.log.Info(
+		fmt.Sprintf(
+			"comparing hypershift operator installation flags configmap(%s) to the locally saved configmap",
+			cmName,
+		),
+	)
 	cmKey := types.NamespacedName{Name: cmName, Namespace: c.addonNamespace}
 	localCM := &corev1.ConfigMap{}
 	if err := c.spokeUncachedClient.Get(context.TODO(), cmKey, localCM); err != nil && !apierrors.IsNotFound(err) {

--- a/pkg/install/hypershift_test.go
+++ b/pkg/install/hypershift_test.go
@@ -966,6 +966,120 @@ func TestRunHypershiftInstallPrivateLinkExternalDNS(t *testing.T) {
 	assert.Nil(t, err, "is nil if cleanup is succcessful")
 }
 
+func TestRunHypershiftInstallPrivateAzure(t *testing.T) {
+	ctx := context.Background()
+
+	zapLog, _ := zap.NewDevelopment()
+	client := initClient()
+	aCtrl := &UpgradeController{
+		spokeUncachedClient:       client,
+		hubClient:                 client,
+		log:                       zapr.NewLogger(zapLog),
+		addonNamespace:            "addon",
+		operatorImage:             "my-test-image",
+		clusterName:               "cluster1",
+		pullSecret:                "pull-secret",
+		hypershiftInstallExecutor: &HypershiftTestCliExecutor{},
+	}
+
+	addonNs := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: aCtrl.addonNamespace,
+		},
+	}
+	aCtrl.hubClient.Create(ctx, addonNs)
+	defer aCtrl.hubClient.Delete(ctx, addonNs)
+
+	pullSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      aCtrl.pullSecret,
+			Namespace: aCtrl.addonNamespace,
+		},
+		Data: map[string][]byte{
+			".dockerconfigjson": []byte(`docker-pull-secret`),
+		},
+	}
+	aCtrl.hubClient.Create(ctx, pullSecret)
+
+	installFlagsConfigmap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.HypershiftInstallFlagsCM,
+			Namespace: aCtrl.clusterName,
+		},
+		Data: map[string]string{
+			"installFlagsToAdd": "--private-platform Azure --azure-pls-resource-group abcd-rg",
+		},
+	}
+	err := aCtrl.hubClient.Create(ctx, installFlagsConfigmap)
+	assert.Nil(t, err, "is nil when install flags configmap is created successfully")
+	defer aCtrl.hubClient.Delete(ctx, installFlagsConfigmap)
+
+	azurePrivateSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.HypershiftAzurePrivateSecretName,
+			Namespace: aCtrl.clusterName,
+		},
+		Data: map[string][]byte{
+			"credentials": []byte(`azure-private-credentials`),
+		},
+	}
+	aCtrl.hubClient.Create(ctx, azurePrivateSecret)
+	defer aCtrl.hubClient.Delete(ctx, azurePrivateSecret)
+
+	err = installHyperShiftOperator(t, ctx, aCtrl, false)
+	defer deleteAllInstallJobs(ctx, aCtrl.spokeUncachedClient, aCtrl.addonNamespace)
+	assert.Nil(t, err, "is nil if install HyperShift is successful")
+
+	// Check hypershift-operator-azure-credentials secret exists in hypershift namespace
+	spokeAzureSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.HypershiftAzurePrivateSecretName,
+			Namespace: "hypershift",
+		},
+	}
+	err = aCtrl.spokeUncachedClient.Get(ctx, ctrlClient.ObjectKeyFromObject(spokeAzureSecret), spokeAzureSecret)
+	assert.Nil(t, err, "is nil when Azure private secret is found in hypershift namespace")
+	assert.Equal(t, []byte(`azure-private-credentials`), spokeAzureSecret.Data["credentials"], "the credentials should be equal if the copy was a success")
+
+	installJobList := &kbatch.JobList{}
+	err = aCtrl.spokeUncachedClient.List(ctx, installJobList)
+	if assert.Nil(t, err, "listing jobs should succeed: %s", err) {
+		if assert.Equal(t, 1, len(installJobList.Items), "there should be exactly one install job") {
+			installJob := installJobList.Items[0]
+			expectArgs := []string{
+				"--namespace", "hypershift",
+				"--azure-private-secret", util.HypershiftAzurePrivateSecretName,
+				"--hypershift-image", "my-test-image",
+				"--platform-monitoring", "OperatorOnly",
+				"--enable-uwm-telemetry-remote-write",
+				"--enable-defaulting-webhook",
+				"--enable-validating-webhook",
+				"--private-platform", "Azure",
+				"--azure-pls-resource-group", "abcd-rg",
+			}
+			// Flag order varies (e.g. --azure-private-secret is injected before --hypershift-image);
+			// compare as sets so the test stays stable.
+			assert.ElementsMatch(
+				t,
+				expectArgs,
+				installJob.Spec.Template.Spec.Containers[0].Args,
+				"mismatched container arguments",
+			)
+		}
+	}
+
+	// Check hypershift-operator-azure-credentials secret exists in addon namespace
+	localAzurePrivateSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.HypershiftAzurePrivateSecretName,
+			Namespace: aCtrl.addonNamespace,
+		},
+	}
+	err = aCtrl.spokeUncachedClient.Get(ctx, ctrlClient.ObjectKeyFromObject(localAzurePrivateSecret), localAzurePrivateSecret)
+	assert.Nil(t, err, "is nil when locally saved Azure private secret is found")
+	assert.Equal(t, []byte(`azure-private-credentials`), localAzurePrivateSecret.Data["credentials"], "the credentials should be equal if the local save was a success")
+}
+
 func TestRunHypershiftInstallEnableRHOBS(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/install/upgrade.go
+++ b/pkg/install/upgrade.go
@@ -36,6 +36,7 @@ type UpgradeController struct {
 	bucketSecret              corev1.Secret
 	extDnsSecret              corev1.Secret
 	privateLinkSecret         corev1.Secret
+	azurePrivateSecret        corev1.Secret
 	imageOverrideConfigmap    corev1.ConfigMap
 	installFlagsConfigmap     corev1.ConfigMap
 	reinstallNeeded           bool // this is used only for code test
@@ -120,6 +121,13 @@ func (c *UpgradeController) installOptionsChanged() bool {
 	newPrivateLinkSecret, err := c.getSecretFromHub(util.HypershiftPrivateLinkSecretName)
 	if err == nil && c.secretDataChanged(newPrivateLinkSecret, c.privateLinkSecret, util.HypershiftPrivateLinkSecretName) {
 		c.privateLinkSecret = newPrivateLinkSecret // save the new secret for the next cycle of comparison
+		return true
+	}
+
+	// check for changes in Azure private secret
+	newAzurePrivateSecret, err := c.getSecretFromHub(util.HypershiftAzurePrivateSecretName)
+	if err == nil && c.secretDataChanged(newAzurePrivateSecret, c.azurePrivateSecret, util.HypershiftAzurePrivateSecretName) {
+		c.azurePrivateSecret = newAzurePrivateSecret // save the new secret for the next cycle of comparison
 		return true
 	}
 

--- a/pkg/install/upgrade_test.go
+++ b/pkg/install/upgrade_test.go
@@ -428,6 +428,108 @@ func TestPrivateLinkSecretChanges(t *testing.T) {
 
 }
 
+func TestAzurePrivateSecretChanges(t *testing.T) {
+	ctx := context.Background()
+
+	zapLog, _ := zap.NewDevelopment()
+	client := initClient()
+	controller := &UpgradeController{
+		spokeUncachedClient:       client,
+		hubClient:                 client,
+		log:                       zapr.NewLogger(zapLog),
+		addonNamespace:            "addon",
+		operatorImage:             "my-test-image",
+		clusterName:               "cluster1",
+		pullSecret:                "pull-secret",
+		hypershiftInstallExecutor: &HypershiftTestCliExecutor{},
+		azurePrivateSecret:        corev1.Secret{},
+	}
+
+	newAzurePrivateSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.HypershiftAzurePrivateSecretName,
+			Namespace: controller.clusterName,
+		},
+		Data: map[string][]byte{
+			"credentials": []byte(`my-credential-file`),
+		},
+	}
+	controller.hubClient.Create(ctx, newAzurePrivateSecret)
+
+	assert.Eventually(t, func() bool {
+		theSecret := &corev1.Secret{}
+		err := controller.hubClient.Get(ctx, types.NamespacedName{Namespace: controller.clusterName, Name: util.HypershiftAzurePrivateSecretName}, theSecret)
+		return err == nil
+	}, 10*time.Second, 1*time.Second, "The test Azure private secret was created successfully")
+
+	controller.Start()
+
+	assert.Eventually(t, func() bool {
+		return controller.reinstallNeeded
+	}, 10*time.Second, 1*time.Second, "The Azure private secret has changed. The hypershift operator needs to be re-installed")
+
+	controller.Stop()
+
+	changedAzurePrivateSecret := &corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      util.HypershiftAzurePrivateSecretName,
+			Namespace: controller.clusterName,
+		},
+		Data: map[string][]byte{
+			"credentials": []byte(`my-new-credential-file`),
+		},
+	}
+
+	controller.hubClient.Update(ctx, changedAzurePrivateSecret)
+
+	assert.Eventually(t, func() bool {
+		theSecret := &corev1.Secret{}
+		err := controller.hubClient.Get(ctx, types.NamespacedName{Namespace: controller.clusterName, Name: util.HypershiftAzurePrivateSecretName}, theSecret)
+		if err == nil {
+			return string(theSecret.Data["credentials"]) == "my-new-credential-file"
+		}
+		return false
+	}, 10*time.Second, 1*time.Second, "The Azure private secret was updated successfully")
+
+	controller.startup = false
+	controller.installfailed = false
+	controller.Start()
+
+	assert.Eventually(t, func() bool {
+		return controller.reinstallNeeded
+	}, 10*time.Second, 1*time.Second, "The Azure private secret was updated. The hypershift operator needs to be re-installed")
+
+	controller.Stop()
+
+	controller.hubClient.Delete(ctx, newAzurePrivateSecret)
+
+	assert.Eventually(t, func() bool {
+		theSecret := &corev1.Secret{}
+		err := controller.hubClient.Get(ctx, types.NamespacedName{Namespace: controller.clusterName, Name: util.HypershiftAzurePrivateSecretName}, theSecret)
+		return errors.IsNotFound(err)
+	}, 10*time.Second, 1*time.Second, "The test Azure private secret was deleted successfully")
+
+	controller.Start()
+
+	assert.Eventually(t, func() bool {
+		return controller.reinstallNeeded
+	}, 10*time.Second, 1*time.Second, "The Azure private secret was removed. The hypershift operator needs to be re-installed")
+
+	controller.Stop()
+
+	controller.startup = false
+	controller.installfailed = false
+
+	controller.hubClient = initErrorClient()
+	controller.Start()
+
+	assert.Eventually(t, func() bool {
+		return !controller.reinstallNeeded
+	}, 10*time.Second, 1*time.Second, "The agent fails to get the Azure private secret from the hub. The hypershift operator should not be re-installed")
+
+	controller.Stop()
+}
+
 func TestInstallFlagChanges(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -58,10 +58,11 @@ const (
 	ImageStreamAgentCapiProvider    = "cluster-api-provider-agent"
 	ImageStreamHypershiftOperator   = "hypershift-operator"
 
-	HypershiftBucketSecretName      = "hypershift-operator-oidc-provider-s3-credentials"
-	HypershiftPrivateLinkSecretName = "hypershift-operator-private-link-credentials"
-	HypershiftExternalDNSSecretName = "hypershift-operator-external-dns-credentials"
-	ManagedClusterAnnoKey           = "cluster.open-cluster-management.io/managedcluster-name"
+	HypershiftBucketSecretName       = "hypershift-operator-oidc-provider-s3-credentials"
+	HypershiftPrivateLinkSecretName  = "hypershift-operator-private-link-credentials"
+	HypershiftAzurePrivateSecretName = "hypershift-operator-azure-credentials"
+	HypershiftExternalDNSSecretName  = "hypershift-operator-external-dns-credentials"
+	ManagedClusterAnnoKey            = "cluster.open-cluster-management.io/managedcluster-name"
 
 	// HyperShift install job
 	HypershiftInstallJobName           = "hypershift-install-job-"


### PR DESCRIPTION


<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Detect and watch hypershift-operator-azure-credentials for reinstall triggers. 
* Handle Azure private install flags/validation and copy Azure private secret to hypershift. 
* Add Azure private install/change tests and add Azure private configuration docs.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  Support Azure private link 
 Ref: https://redhat.atlassian.net/browse/ACM-31405

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
*  Ref: https://redhat.atlassian.net/browse/ACM-31405

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
make test
go fmt ./...
go vet ./...
go: creating new go.mod: module tmp
Downloading sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
go: -d flag is deprecated. -d=true is a no-op
go: downloading sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20260324065417-8c5081a9b6ba
go: added github.com/go-logr/logr v1.4.3
go: added github.com/go-logr/zapr v1.3.0
go: added github.com/spf13/afero v1.12.0
go: added github.com/spf13/pflag v1.0.9
go: added go.uber.org/multierr v1.10.0
go: added go.uber.org/zap v1.27.0
go: added go.yaml.in/yaml/v2 v2.4.3
go: added golang.org/x/text v0.33.0
go: added sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20260324065417-8c5081a9b6ba
go: added sigs.k8s.io/yaml v1.6.0
KUBEBUILDER_ASSETS="/Users/yiraekim/Library/Application Support/io.kubebuilder.envtest/k8s/1.28.3-darwin-arm64" go test github.com/stolostron/hypershift-addon-operator/cmd github.com/stolostron/hypershift-addon-operator/pkg/agent github.com/stolostron/hypershift-addon-operator/pkg/install github.com/stolostron/hypershift-addon-operator/pkg/manager github.com/stolostron/hypershift-addon-operator/pkg/metrics github.com/stolostron/hypershift-addon-operator/pkg/util -coverprofile cover.out
        github.com/stolostron/hypershift-addon-operator/cmd             coverage: 0.0% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/agent       68.556s coverage: 70.2% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/install     147.683s        coverage: 86.5% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/manager     132.807s        coverage: 68.2% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/metrics     1.619s  coverage: 100.0% of statements
        github.com/stolostron/hypershift-addon-operator/pkg/util                coverage: 0.0% of statements
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide for configuring HyperShift operator installation in Azure private mode, including credential creation, ConfigMap flags, install verification, reconciliation behavior, and troubleshooting.

* **New Features**
  * Support for using Azure private credentials during HyperShift operator installs; credentials are propagated to the target namespace and installs re-trigger when secrets or install flags change.

* **Tests**
  * Added tests covering Azure private secret install flows and controller behavior on secret create/update/delete.

* **Chores**
  * Improved envtest/tooling version selection in the Makefile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->