### PR TITLE
ACM-32271 - Propagate HostedCluster CR labels to ManagedCluster upon import

### DIFF
--- a/pkg/agent/managedcluster_sync_controller.go
+++ b/pkg/agent/managedcluster_sync_controller.go
@@ -122,6 +122,8 @@ func (c *LabelAgent) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				c.log.Error(err, "error removing HC propagated labels from hub", "hubMC", hubMCName)
 				return ctrl.Result{}, err
 			}
+		} else if !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, err
 		}
 	}
 

--- a/pkg/agent/managedcluster_sync_controller.go
+++ b/pkg/agent/managedcluster_sync_controller.go
@@ -28,6 +28,7 @@ import (
 const (
 	propagatedLabelAnnotation   = "hypershift.open-cluster-management.io/propagated-labels"
 	hcPropagatedLabelAnnotation = "hypershift.open-cluster-management.io/hc-propagated-labels"
+	autoInfraLabelName          = "hypershift.openshift.io/auto-created-for-infra"
 )
 
 type LabelAgent struct {
@@ -88,7 +89,7 @@ func (c *LabelAgent) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	// HC sync (highest priority -- HC labels override everything)
-	hc, err := c.findHostedCluster(ctx, spokeMC.Name)
+	hc, err := c.findHostedCluster(ctx, spokeMC)
 	if err != nil {
 		c.log.Error(err, "error finding HostedCluster", "spokeMC", spokeMC.Name)
 		return ctrl.Result{}, err
@@ -155,26 +156,56 @@ func (c *LabelAgent) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 }
 
 // findHostedCluster searches for the HostedCluster that corresponds to the given
-// spoke ManagedCluster name. Checks the managedcluster-name annotation first,
-// then falls back to name match.
+// spoke ManagedCluster. Match priority:
+//  1. HC has managedcluster-name annotation matching the MC name (explicit, authoritative)
+//  2. HC spec.infraID matches the MC's auto-created-for-infra label (system-generated, unique)
+//  3. HC name matches MC name (fallback, rejects ambiguous duplicates)
 func (c *LabelAgent) findHostedCluster(
-	ctx context.Context, mcName string,
+	ctx context.Context, spokeMC *clusterv1.ManagedCluster,
 ) (*hyperv1beta1.HostedCluster, error) {
 	hcList := &hyperv1beta1.HostedClusterList{}
 	if err := c.spokeClient.List(ctx, hcList); err != nil {
 		return nil, err
 	}
+
+	mcName := spokeMC.Name
+	mcInfraID := spokeMC.Labels[autoInfraLabelName]
+
+	var nameMatches []hyperv1beta1.HostedCluster
+
 	for i := range hcList.Items {
 		hc := &hcList.Items[i]
+
 		if annoName := hc.Annotations[util.ManagedClusterAnnoKey]; len(annoName) > 0 {
 			if annoName == mcName {
 				return hc, nil
 			}
-		} else if hc.Name == mcName {
+			continue
+		}
+
+		if len(mcInfraID) > 0 && hc.Spec.InfraID == mcInfraID {
 			return hc, nil
 		}
+
+		if hc.Name == mcName {
+			nameMatches = append(nameMatches, hcList.Items[i])
+		}
 	}
-	return nil, nil
+
+	switch len(nameMatches) {
+	case 0:
+		return nil, nil
+	case 1:
+		return &nameMatches[0], nil
+	default:
+		namespaces := make([]string, len(nameMatches))
+		for i := range nameMatches {
+			namespaces[i] = nameMatches[i].Namespace
+		}
+		c.log.Info("multiple HostedClusters match by name, add the managedcluster-name annotation to disambiguate",
+			"mcName", mcName, "namespaces", namespaces)
+		return nil, nil
+	}
 }
 
 // isSystemLabel returns true if the label key is managed by OCM/system
@@ -218,7 +249,8 @@ func isSystemLabel(key string) bool {
 }
 
 // syncHCLabelsToSpoke applies non-system HostedCluster labels to the spoke MC.
-// HC is the highest-priority source and always overwrites existing values.
+// Only new keys or already-tracked keys are propagated. If a key exists on the
+// spoke but is not HC-tracked, it is skipped (matching values auto-track).
 // Tracked via the hc-propagated-labels annotation. If a key was previously
 // hub-tracked (in propagated-labels), HC takes ownership by removing it.
 func (c *LabelAgent) syncHCLabelsToSpoke(
@@ -237,12 +269,24 @@ func (c *LabelAgent) syncHCLabelsToSpoke(
 		if isSystemLabel(key) {
 			continue
 		}
-		existingValue, exists := spokeLabels[key]
-		if !exists || existingValue != value {
+		spokeValue, existsOnSpoke := spokeLabels[key]
+		managed := false
+		if !existsOnSpoke {
 			spokeLabels[key] = value
 			changed = true
+			managed = true
+		} else if spokeValue != value {
+			if previousHCTracking[key] {
+				spokeLabels[key] = value
+				changed = true
+				managed = true
+			}
+		} else {
+			managed = true
 		}
-		hcLabelsToTrack[key] = true
+		if managed {
+			hcLabelsToTrack[key] = true
+		}
 	}
 
 	// Remove labels previously HC-tracked but no longer on the HC
@@ -287,8 +331,9 @@ func (c *LabelAgent) syncHCLabelsToSpoke(
 }
 
 // syncHCLabelsToHub applies non-system HostedCluster labels to the ACM hub MC.
-// HC always overwrites existing values. Tracked via the hc-propagated-labels
-// annotation on the hub MC, which hub sync uses to skip HC-owned keys.
+// Only new keys or already-tracked keys are propagated. If a key exists on the
+// hub but is not HC-tracked, it is skipped (matching values auto-track).
+// Tracked via the hc-propagated-labels annotation on the hub MC.
 func (c *LabelAgent) syncHCLabelsToHub(
 	ctx context.Context, hubMC *clusterv1.ManagedCluster, hc *hyperv1beta1.HostedCluster,
 ) error {
@@ -305,12 +350,24 @@ func (c *LabelAgent) syncHCLabelsToHub(
 		if isSystemLabel(key) {
 			continue
 		}
-		existingValue, exists := hubLabels[key]
-		if !exists || existingValue != value {
+		hubValue, existsOnHub := hubLabels[key]
+		managed := false
+		if !existsOnHub {
 			hubLabels[key] = value
 			changed = true
+			managed = true
+		} else if hubValue != value {
+			if previousHCTracking[key] {
+				hubLabels[key] = value
+				changed = true
+				managed = true
+			}
+		} else {
+			managed = true
 		}
-		hcLabelsToTrack[key] = true
+		if managed {
+			hcLabelsToTrack[key] = true
+		}
 	}
 
 	for key := range previousHCTracking {

--- a/pkg/agent/managedcluster_sync_controller.go
+++ b/pkg/agent/managedcluster_sync_controller.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	hyperv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/stolostron/hypershift-addon-operator/pkg/util"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
@@ -23,7 +25,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-const propagatedLabelAnnotation = "hypershift.open-cluster-management.io/propagated-labels"
+const (
+	propagatedLabelAnnotation   = "hypershift.open-cluster-management.io/propagated-labels"
+	hcPropagatedLabelAnnotation = "hypershift.open-cluster-management.io/hc-propagated-labels"
+)
 
 type LabelAgent struct {
 	hubClient        client.Client
@@ -43,11 +48,16 @@ func (c *LabelAgent) SetupWithManager(mgr ctrl.Manager) error {
 			source.Kind(c.hubCache, &clusterv1.ManagedCluster{},
 				handler.TypedEnqueueRequestsFromMapFunc(c.mapHubMCToSpokeMC)),
 		).
+		Watches(&hyperv1beta1.HostedCluster{},
+			handler.EnqueueRequestsFromMapFunc(c.mapHCToSpokeMC),
+			builder.WithPredicates(hcLabelEventFilters()),
+		).
 		Complete(c)
 }
 
-// Reconcile syncs non-system labels from the ACM hub ManagedCluster to the
-// corresponding spoke ManagedCluster, correcting drift and tracking propagated keys.
+// Reconcile syncs labels from the HostedCluster and ACM hub ManagedCluster to the
+// corresponding spoke ManagedCluster. HC labels have the highest priority, followed
+// by admin-added hub labels.
 func (c *LabelAgent) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	c.log.Info("reconciling label sync", "managedcluster", req.Name)
 
@@ -77,26 +87,92 @@ func (c *LabelAgent) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
-	// Compute the hub MC name using getHubMCName(spokeMC.Name)
-	hubMCName := c.getHubMCName(spokeMC.Name)
+	// HC sync (highest priority -- HC labels override everything)
+	hc, err := c.findHostedCluster(ctx, spokeMC.Name)
+	if err != nil {
+		c.log.Error(err, "error finding HostedCluster", "spokeMC", spokeMC.Name)
+		return ctrl.Result{}, err
+	}
 
-	// Fetch the hub MC using c.hubClient.Get()
-	// If not found, log and requeue
+	if hc != nil {
+		if err := c.syncHCLabelsToSpoke(ctx, spokeMC, hc); err != nil {
+			c.log.Error(err, "error syncing HC labels to spoke", "hc", hc.Name, "spokeMC", spokeMC.Name)
+			return ctrl.Result{}, err
+		}
+
+		hubMCName := c.getHubMCName(spokeMC.Name)
+		hubMC := &clusterv1.ManagedCluster{}
+		if err := c.hubClient.Get(ctx, types.NamespacedName{Name: hubMCName}, hubMC); err == nil {
+			if err := c.syncHCLabelsToHub(ctx, hubMC, hc); err != nil {
+				c.log.Error(err, "error syncing HC labels to hub", "hc", hc.Name, "hubMC", hubMCName)
+				return ctrl.Result{}, err
+			}
+		} else if !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+	} else {
+		if err := c.removeHCPropagatedLabels(ctx, spokeMC); err != nil {
+			c.log.Error(err, "error removing HC propagated labels from spoke", "spokeMC", spokeMC.Name)
+			return ctrl.Result{}, err
+		}
+		hubMCName := c.getHubMCName(spokeMC.Name)
+		hubMC := &clusterv1.ManagedCluster{}
+		if err := c.hubClient.Get(ctx, types.NamespacedName{Name: hubMCName}, hubMC); err == nil {
+			if err := c.removeHCPropagatedLabelsFromHub(ctx, hubMC); err != nil {
+				c.log.Error(err, "error removing HC propagated labels from hub", "hubMC", hubMCName)
+				return ctrl.Result{}, err
+			}
+		}
+	}
+
+	// Re-fetch spoke MC to get latest state after HC sync may have modified it
+	if err := c.spokeClient.Get(ctx, req.NamespacedName, spokeMC); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	// Hub sync (only admin-added labels, skip HC-owned keys on hub)
+	hubMCName := c.getHubMCName(spokeMC.Name)
 	hubMC := &clusterv1.ManagedCluster{}
 	if err := c.hubClient.Get(ctx, types.NamespacedName{Name: hubMCName}, hubMC); err != nil {
 		if apierrors.IsNotFound(err) {
-			c.log.Info("hub ManagedCluster not found, removing propagated labels", "name", hubMCName)
-			return ctrl.Result{}, c.removePropagatedLabels(ctx, spokeMC)
+			c.log.Info("hub ManagedCluster not found, removing hub propagated labels", "name", hubMCName)
+			return ctrl.Result{}, c.removeHubPropagatedLabels(ctx, spokeMC)
 		}
 		c.log.Error(err, "error getting ManagedCluster from ACM hub", "name", hubMCName)
 		return ctrl.Result{}, err
 	}
 
-	if err := c.syncLabelsFromHub(ctx, spokeMC, hubMC); err != nil {
-		c.log.Error(err, "error syncing labels", "hubMC", hubMCName, "spokeMC", spokeMC.Name)
+	if err := c.syncHubLabelsToSpoke(ctx, spokeMC, hubMC); err != nil {
+		c.log.Error(err, "error syncing hub labels to spoke", "hubMC", hubMCName, "spokeMC", spokeMC.Name)
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil
+}
+
+// findHostedCluster searches for the HostedCluster that corresponds to the given
+// spoke ManagedCluster name. Checks the managedcluster-name annotation first,
+// then falls back to name match.
+func (c *LabelAgent) findHostedCluster(
+	ctx context.Context, mcName string,
+) (*hyperv1beta1.HostedCluster, error) {
+	hcList := &hyperv1beta1.HostedClusterList{}
+	if err := c.spokeClient.List(ctx, hcList); err != nil {
+		return nil, err
+	}
+	for i := range hcList.Items {
+		hc := &hcList.Items[i]
+		if annoName := hc.Annotations[util.ManagedClusterAnnoKey]; len(annoName) > 0 {
+			if annoName == mcName {
+				return hc, nil
+			}
+		} else if hc.Name == mcName {
+			return hc, nil
+		}
+	}
+	return nil, nil
 }
 
 // isSystemLabel returns true if the label key is managed by OCM/system
@@ -139,22 +215,134 @@ func isSystemLabel(key string) bool {
 	return false
 }
 
-// syncLabelsFromHub applies non-system labels from the hub MC to the spoke MC,
-// using the tracking annotation to manage additions, updates, and removals.
-func (c *LabelAgent) syncLabelsFromHub(
-	ctx context.Context, spokeMC, hubMC *clusterv1.ManagedCluster,
+// syncHCLabelsToSpoke applies non-system HostedCluster labels to the spoke MC.
+// HC is the highest-priority source and always overwrites existing values.
+// Tracked via the hc-propagated-labels annotation. If a key was previously
+// hub-tracked (in propagated-labels), HC takes ownership by removing it.
+func (c *LabelAgent) syncHCLabelsToSpoke(
+	ctx context.Context, spokeMC *clusterv1.ManagedCluster, hc *hyperv1beta1.HostedCluster,
 ) error {
-	// Read the current tracking annotation (propagatedLabelsAnno) from spokeMC
-	// Parse the comma-separated list of previously propagated label keys
-	previousAnnotationTracking := map[string]bool{}
-	if annotations := spokeMC.Annotations[propagatedLabelAnnotation]; annotations != "" {
-		for _, key := range strings.Split(annotations, ",") {
-			previousAnnotationTracking[key] = true
+	previousHCTracking := parseAnnotation(spokeMC.Annotations[hcPropagatedLabelAnnotation])
+
+	hcLabelsToTrack := map[string]bool{}
+	spokeLabels := spokeMC.DeepCopy().Labels
+	if spokeLabels == nil {
+		spokeLabels = map[string]string{}
+	}
+	changed := false
+
+	for key, value := range hc.Labels {
+		if isSystemLabel(key) {
+			continue
+		}
+		existingValue, exists := spokeLabels[key]
+		if !exists || existingValue != value {
+			spokeLabels[key] = value
+			changed = true
+		}
+		hcLabelsToTrack[key] = true
+	}
+
+	// Remove labels previously HC-tracked but no longer on the HC
+	for key := range previousHCTracking {
+		if !hcLabelsToTrack[key] {
+			delete(spokeLabels, key)
+			changed = true
 		}
 	}
 
-	// Build the set of labels to propagate from hubMC
-	// For each hub label, skip if isSystemLabel(key)
+	// If HC is taking over any hub-tracked keys, remove them from hub tracking
+	previousHubTracking := parseAnnotation(spokeMC.Annotations[propagatedLabelAnnotation])
+	updatedHubTracking := map[string]bool{}
+	hubTrackingModified := false
+	for key := range previousHubTracking {
+		if hcLabelsToTrack[key] {
+			hubTrackingModified = true
+		} else {
+			updatedHubTracking[key] = true
+		}
+	}
+
+	hcTrackingChanged := !maps.Equal(hcLabelsToTrack, previousHCTracking)
+
+	if !changed && !hcTrackingChanged && !hubTrackingModified {
+		return nil
+	}
+
+	patch := client.MergeFrom(spokeMC.DeepCopy())
+	spokeMC.Labels = spokeLabels
+	if spokeMC.Annotations == nil {
+		spokeMC.Annotations = map[string]string{}
+	}
+
+	setOrDeleteAnnotation(spokeMC, hcPropagatedLabelAnnotation, joinSortedKeys(hcLabelsToTrack))
+
+	if hubTrackingModified {
+		setOrDeleteAnnotation(spokeMC, propagatedLabelAnnotation, joinSortedKeys(updatedHubTracking))
+	}
+
+	return c.spokeClient.Patch(ctx, spokeMC, patch)
+}
+
+// syncHCLabelsToHub applies non-system HostedCluster labels to the ACM hub MC.
+// HC always overwrites existing values. Tracked via the hc-propagated-labels
+// annotation on the hub MC, which hub sync uses to skip HC-owned keys.
+func (c *LabelAgent) syncHCLabelsToHub(
+	ctx context.Context, hubMC *clusterv1.ManagedCluster, hc *hyperv1beta1.HostedCluster,
+) error {
+	previousHCTracking := parseAnnotation(hubMC.Annotations[hcPropagatedLabelAnnotation])
+
+	hcLabelsToTrack := map[string]bool{}
+	hubLabels := hubMC.DeepCopy().Labels
+	if hubLabels == nil {
+		hubLabels = map[string]string{}
+	}
+	changed := false
+
+	for key, value := range hc.Labels {
+		if isSystemLabel(key) {
+			continue
+		}
+		existingValue, exists := hubLabels[key]
+		if !exists || existingValue != value {
+			hubLabels[key] = value
+			changed = true
+		}
+		hcLabelsToTrack[key] = true
+	}
+
+	for key := range previousHCTracking {
+		if !hcLabelsToTrack[key] {
+			delete(hubLabels, key)
+			changed = true
+		}
+	}
+
+	hcTrackingChanged := !maps.Equal(hcLabelsToTrack, previousHCTracking)
+
+	if !changed && !hcTrackingChanged {
+		return nil
+	}
+
+	patch := client.MergeFrom(hubMC.DeepCopy())
+	hubMC.Labels = hubLabels
+	if hubMC.Annotations == nil {
+		hubMC.Annotations = map[string]string{}
+	}
+
+	setOrDeleteAnnotation(hubMC, hcPropagatedLabelAnnotation, joinSortedKeys(hcLabelsToTrack))
+
+	return c.hubClient.Patch(ctx, hubMC, patch)
+}
+
+// syncHubLabelsToSpoke applies non-system labels from the hub MC to the spoke MC,
+// using the tracking annotation to manage additions, updates, and removals.
+// Labels owned by HC (in hc-propagated-labels on the hub MC) are skipped.
+func (c *LabelAgent) syncHubLabelsToSpoke(
+	ctx context.Context, spokeMC, hubMC *clusterv1.ManagedCluster,
+) error {
+	previousAnnotationTracking := parseAnnotation(spokeMC.Annotations[propagatedLabelAnnotation])
+	hcOwnedOnHub := parseAnnotation(hubMC.Annotations[hcPropagatedLabelAnnotation])
 
 	// Apply sync rules:
 	// - Hub has label, Spoke does not -> add to spoke, record in tracking
@@ -169,6 +357,9 @@ func (c *LabelAgent) syncLabelsFromHub(
 	changed := false
 	for hubKey, hubValue := range hubMC.Labels {
 		if isSystemLabel(hubKey) {
+			continue
+		}
+		if hcOwnedOnHub[hubKey] {
 			continue
 		}
 
@@ -201,45 +392,23 @@ func (c *LabelAgent) syncLabelsFromHub(
 		}
 	}
 
-	// Check if the tracking annotation needs updating in case labels match on hub and spoke but isnt tracked
-	if !changed && len(labelsToPropagate) == len(previousAnnotationTracking) {
-		allMatch := true
-		for key := range labelsToPropagate {
-			if !previousAnnotationTracking[key] {
-				allMatch = false
-				break
-			}
-		}
-		if allMatch {
-			return nil
-		}
+	if !changed && maps.Equal(labelsToPropagate, previousAnnotationTracking) {
+		return nil
 	}
 
-	// If changes were made, patch the spoke MC using client.MergeFrom()
-	// Update both labels and the tracking annotation
-	keys := make([]string, 0, len(labelsToPropagate))
-	for key := range labelsToPropagate {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-
-	// create a patch
 	patch := client.MergeFrom(spokeMC.DeepCopy())
-	// set the labels calculated to the spoke
 	spokeMC.Labels = spokeLabels
 	if spokeMC.Annotations == nil {
 		spokeMC.Annotations = map[string]string{}
 	}
-	// add labels propagated in the annotations
-	spokeMC.Annotations[propagatedLabelAnnotation] = strings.Join(keys, ",")
+	spokeMC.Annotations[propagatedLabelAnnotation] = joinSortedKeys(labelsToPropagate)
 
-	// patch the spoke with labels and annotations
 	return c.spokeClient.Patch(ctx, spokeMC, patch)
 }
 
-// removePropagatedLabels removes all previously propagated labels from the spoke
+// removeHubPropagatedLabels removes all hub-propagated labels from the spoke
 // ManagedCluster and clears the tracking annotation. Called when the hub MC is deleted.
-func (c *LabelAgent) removePropagatedLabels(ctx context.Context, spokeMC *clusterv1.ManagedCluster) error {
+func (c *LabelAgent) removeHubPropagatedLabels(ctx context.Context, spokeMC *clusterv1.ManagedCluster) error {
 	anno := spokeMC.Annotations[propagatedLabelAnnotation]
 	if anno == "" {
 		return nil
@@ -251,8 +420,44 @@ func (c *LabelAgent) removePropagatedLabels(ctx context.Context, spokeMC *cluste
 	}
 	delete(spokeMC.Annotations, propagatedLabelAnnotation)
 
-	c.log.Info("removing propagated labels from spoke", "spokeMC", spokeMC.Name, "labels", anno)
+	c.log.Info("removing hub propagated labels from spoke", "spokeMC", spokeMC.Name, "labels", anno)
 	return c.spokeClient.Patch(ctx, spokeMC, patch)
+}
+
+// removeHCPropagatedLabels removes all HC-propagated labels from the spoke
+// ManagedCluster and clears the hc-propagated-labels annotation.
+func (c *LabelAgent) removeHCPropagatedLabels(ctx context.Context, spokeMC *clusterv1.ManagedCluster) error {
+	anno := spokeMC.Annotations[hcPropagatedLabelAnnotation]
+	if anno == "" {
+		return nil
+	}
+
+	patch := client.MergeFrom(spokeMC.DeepCopy())
+	for _, key := range strings.Split(anno, ",") {
+		delete(spokeMC.Labels, key)
+	}
+	delete(spokeMC.Annotations, hcPropagatedLabelAnnotation)
+
+	c.log.Info("removing HC propagated labels from spoke", "spokeMC", spokeMC.Name, "labels", anno)
+	return c.spokeClient.Patch(ctx, spokeMC, patch)
+}
+
+// removeHCPropagatedLabelsFromHub removes all HC-propagated labels from the hub
+// ManagedCluster and clears the hc-propagated-labels annotation.
+func (c *LabelAgent) removeHCPropagatedLabelsFromHub(ctx context.Context, hubMC *clusterv1.ManagedCluster) error {
+	anno := hubMC.Annotations[hcPropagatedLabelAnnotation]
+	if anno == "" {
+		return nil
+	}
+
+	patch := client.MergeFrom(hubMC.DeepCopy())
+	for _, key := range strings.Split(anno, ",") {
+		delete(hubMC.Labels, key)
+	}
+	delete(hubMC.Annotations, hcPropagatedLabelAnnotation)
+
+	c.log.Info("removing HC propagated labels from hub", "hubMC", hubMC.Name, "labels", anno)
+	return c.hubClient.Patch(ctx, hubMC, patch)
 }
 
 // mapHubMCToSpokeMC translates a hub ManagedCluster event into a reconcile
@@ -264,6 +469,20 @@ func (c *LabelAgent) mapHubMCToSpokeMC(ctx context.Context, hubMC *clusterv1.Man
 	}
 	return []reconcile.Request{
 		{NamespacedName: types.NamespacedName{Name: spokeMCName}},
+	}
+}
+
+// mapHCToSpokeMC translates a HostedCluster event into a reconcile request
+// for the corresponding spoke ManagedCluster. Checks the managedcluster-name
+// annotation first, then falls back to HC name.
+func (c *LabelAgent) mapHCToSpokeMC(ctx context.Context, obj client.Object) []reconcile.Request {
+	if annoName := obj.GetAnnotations()[util.ManagedClusterAnnoKey]; len(annoName) > 0 {
+		return []reconcile.Request{
+			{NamespacedName: types.NamespacedName{Name: annoName}},
+		}
+	}
+	return []reconcile.Request{
+		{NamespacedName: types.NamespacedName{Name: obj.GetName()}},
 	}
 }
 
@@ -297,16 +516,14 @@ func (c *LabelAgent) getHubMCName(spokeMCName string) string {
 }
 
 // labelEventFilters filters spoke ManagedCluster events to only process hosted clusters.
-// Both create and update events are handled to correct spoke-side label drift.
+// Triggers on label changes, tracking annotation changes, or created-via annotation changes.
 func labelEventFilters() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			mc, ok := e.Object.(*clusterv1.ManagedCluster)
-
 			if !ok {
 				return false
 			}
-
 			return mc.Annotations[createdViaAnno] == createdViaHypershift
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
@@ -314,10 +531,17 @@ func labelEventFilters() predicate.Predicate {
 			if !ok {
 				return false
 			}
-			if maps.Equal(e.ObjectOld.GetLabels(), e.ObjectNew.GetLabels()) {
+			if mc.Annotations[createdViaAnno] != createdViaHypershift {
 				return false
 			}
-			return mc.Annotations[createdViaAnno] == createdViaHypershift
+			if !maps.Equal(e.ObjectOld.GetLabels(), e.ObjectNew.GetLabels()) {
+				return true
+			}
+			oldAnno := e.ObjectOld.GetAnnotations()
+			newAnno := e.ObjectNew.GetAnnotations()
+			return oldAnno[propagatedLabelAnnotation] != newAnno[propagatedLabelAnnotation] ||
+				oldAnno[hcPropagatedLabelAnnotation] != newAnno[hcPropagatedLabelAnnotation] ||
+				oldAnno[createdViaAnno] != newAnno[createdViaAnno]
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			return false
@@ -325,5 +549,51 @@ func labelEventFilters() predicate.Predicate {
 		GenericFunc: func(e event.GenericEvent) bool {
 			return false
 		},
+	}
+}
+
+// hcLabelEventFilters filters HostedCluster events to trigger on label changes
+// and deletions (for cleanup of HC-propagated labels).
+func hcLabelEventFilters() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return !maps.Equal(e.ObjectOld.GetLabels(), e.ObjectNew.GetLabels())
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return true
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+func parseAnnotation(anno string) map[string]bool {
+	result := map[string]bool{}
+	if anno != "" {
+		for _, key := range strings.Split(anno, ",") {
+			result[key] = true
+		}
+	}
+	return result
+}
+
+func joinSortedKeys(m map[string]bool) string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, ",")
+}
+
+func setOrDeleteAnnotation(mc *clusterv1.ManagedCluster, key, value string) {
+	if value != "" {
+		mc.Annotations[key] = value
+	} else {
+		delete(mc.Annotations, key)
 	}
 }

--- a/pkg/agent/managedcluster_sync_controller.go
+++ b/pkg/agent/managedcluster_sync_controller.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"maps"
 	"os"
 	"sort"
@@ -30,6 +31,8 @@ const (
 	hcPropagatedLabelAnnotation = "hypershift.open-cluster-management.io/hc-propagated-labels"
 	autoInfraLabelName          = "hypershift.openshift.io/auto-created-for-infra"
 )
+
+var errAmbiguousHCMatch = errors.New("multiple HostedClusters match by name")
 
 type LabelAgent struct {
 	hubClient        client.Client
@@ -90,12 +93,13 @@ func (c *LabelAgent) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	// HC sync (highest priority -- HC labels override everything)
 	hc, err := c.findHostedCluster(ctx, spokeMC)
-	if err != nil {
+	if errors.Is(err, errAmbiguousHCMatch) {
+		// Multiple HCs share the same name; skip HC sync entirely to avoid
+		// propagating from the wrong HC or cleaning up labels that are still valid.
+	} else if err != nil {
 		c.log.Error(err, "error finding HostedCluster", "spokeMC", spokeMC.Name)
 		return ctrl.Result{}, err
-	}
-
-	if hc != nil {
+	} else if hc != nil {
 		if err := c.syncHCLabelsToSpoke(ctx, spokeMC, hc); err != nil {
 			c.log.Error(err, "error syncing HC labels to spoke", "hc", hc.Name, "spokeMC", spokeMC.Name)
 			return ctrl.Result{}, err
@@ -204,7 +208,7 @@ func (c *LabelAgent) findHostedCluster(
 		}
 		c.log.Info("multiple HostedClusters match by name, add the managedcluster-name annotation to disambiguate",
 			"mcName", mcName, "namespaces", namespaces)
-		return nil, nil
+		return nil, errAmbiguousHCMatch
 	}
 }
 

--- a/pkg/agent/managedcluster_sync_controller_test.go
+++ b/pkg/agent/managedcluster_sync_controller_test.go
@@ -23,566 +23,297 @@ import (
 )
 
 const (
-	testAnnotationEnvTeamTier = "env,team,tier"
-	testHubMCName             = "mce-my-hc"
-	testAutoCreatedForInfra   = "hypershift.openshift.io/auto-created-for-infra"
+	testHubMCName           = "mce-my-hc"
+	testAutoCreatedForInfra = "hypershift.openshift.io/auto-created-for-infra"
+	testCustomMCName        = "custom-name"
 )
 
 func strPtr(s string) *string { return &s }
 
 func initLabelSyncClient(t *testing.T) (client.Client, client.Client) {
 	scheme := runtime.NewScheme()
-	err := clusterv1.AddToScheme(scheme)
-	assert.Nil(t, err)
-	err = hyperv1beta1.AddToScheme(scheme)
-	assert.Nil(t, err)
-
-	spokeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	hubClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	return spokeClient, hubClient
+	assert.Nil(t, clusterv1.AddToScheme(scheme))
+	assert.Nil(t, hyperv1beta1.AddToScheme(scheme))
+	return fake.NewClientBuilder().WithScheme(scheme).Build(),
+		fake.NewClientBuilder().WithScheme(scheme).Build()
 }
+
+func newLabelAgent(t *testing.T, spoke, hub client.Client, clusterName string) *LabelAgent {
+	zapLog, _ := zap.NewDevelopment()
+	return &LabelAgent{
+		hubClient:        hub,
+		spokeClient:      spoke,
+		clusterName:      clusterName,
+		localClusterName: "local-cluster",
+		log:              zapr.NewLogger(zapLog),
+	}
+}
+
+func reconcileAndGet(
+	t *testing.T, lc *LabelAgent, spoke client.Client, name string,
+) *clusterv1.ManagedCluster {
+	_, err := lc.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: name},
+	})
+	assert.Nil(t, err)
+	mc := &clusterv1.ManagedCluster{}
+	assert.Nil(t, spoke.Get(context.Background(), types.NamespacedName{Name: name}, mc))
+	return mc
+}
+
+// --- Hub-to-spoke label propagation ---
 
 func TestLabelPropagation(t *testing.T) {
 	tests := []struct {
-		name                   string
-		spokeHostedCluster     *clusterv1.ManagedCluster
-		hubHostedCluster       *clusterv1.ManagedCluster
-		importedMCEName        string
-		localClusterName       string
-		expectedLabels         map[string]string
-		notExpectedLabels      []string
-		discoveryPrefix        *string
-		expectedAnnotationKeys []string
+		name               string
+		spokeMC            *clusterv1.ManagedCluster
+		hubMC              *clusterv1.ManagedCluster
+		clusterName        string
+		localClusterName   string
+		discoveryPrefix    *string
+		expectedLabels     map[string]string
+		notExpectedLabels  []string
+		expectedAnnoKeys   []string
 	}{
 		{
-			name: "new hub labels propagated to spoke",
-			spokeHostedCluster: &clusterv1.ManagedCluster{
+			name: "hub labels propagated to spoke",
+			spokeMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "hostedcluster",
-					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
-					Labels:      map[string]string{},
-				},
-			},
-			hubHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "imported-mce-hostedcluster",
-					Annotations: map[string]string{},
-					Labels:      map[string]string{"newLabel": "newValue"},
-				},
-			},
-			importedMCEName: "imported-mce",
-			expectedLabels: map[string]string{
-				"newLabel": "newValue",
-			},
-		},
-		{
-			name: "dont override existing labels that isn't being tracked",
-			spokeHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "hostedcluster",
-					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
-					Labels:      map[string]string{"existingLabel": "oldValue"},
-				},
-			},
-			hubHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "imported-mce-hostedcluster",
-					Annotations: map[string]string{},
-					Labels:      map[string]string{"existingLabel": "newValue"},
-				},
-			},
-			importedMCEName: "imported-mce",
-			expectedLabels: map[string]string{
-				"existingLabel": "oldValue",
-			},
-		},
-		{
-			name: "override existing labels that is being tracked",
-			spokeHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "hostedcluster",
-					Annotations: map[string]string{createdViaAnno: createdViaHypershift, propagatedLabelAnnotation: "existingLabel"},
-					Labels:      map[string]string{"existingLabel": "oldValue"},
-				},
-			},
-			hubHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "imported-mce-hostedcluster",
-					Annotations: map[string]string{},
-					Labels:      map[string]string{"existingLabel": "newValue"},
-				},
-			},
-			importedMCEName: "imported-mce",
-			expectedLabels: map[string]string{
-				"existingLabel": "newValue",
-			},
-		},
-		{
-			name: "system labels by exact key are not propagated",
-			spokeHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "hostedcluster",
+					Name:        "hc1",
 					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
 				},
 			},
-			hubHostedCluster: &clusterv1.ManagedCluster{
+			hubMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "imported-mce-hostedcluster",
-					Labels: map[string]string{"vendor": "OpenShift", "cloud": "Amazon", "clusterID": "abc-123", "env": "prod"},
+					Name:   "mce-hc1",
+					Labels: map[string]string{"env": "prod", "team": "backend"},
 				},
 			},
-			importedMCEName: "imported-mce",
-			expectedLabels: map[string]string{
-				"env": "prod",
-			},
-			notExpectedLabels: []string{"vendor", "cloud", "clusterID"},
+			clusterName:    "mce",
+			expectedLabels: map[string]string{"env": "prod", "team": "backend"},
+			expectedAnnoKeys: []string{"env", "team"},
 		},
 		{
-			name: "system labels by prefix are not propagated",
-			spokeHostedCluster: &clusterv1.ManagedCluster{
+			name: "untracked label not overwritten",
+			spokeMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "hostedcluster",
+					Name:        "hc1",
+					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
+					Labels:      map[string]string{"env": "local-val"},
+				},
+			},
+			hubMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "mce-hc1",
+					Labels: map[string]string{"env": "hub-val"},
+				},
+			},
+			clusterName:    "mce",
+			expectedLabels: map[string]string{"env": "local-val"},
+		},
+		{
+			name: "tracked label overridden by hub",
+			spokeMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "hc1",
+					Annotations: map[string]string{
+						createdViaAnno:            createdViaHypershift,
+						propagatedLabelAnnotation: "env",
+					},
+					Labels: map[string]string{"env": "old"},
+				},
+			},
+			hubMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "mce-hc1",
+					Labels: map[string]string{"env": "new"},
+				},
+			},
+			clusterName:    "mce",
+			expectedLabels: map[string]string{"env": "new"},
+		},
+		{
+			name: "system labels filtered by key and prefix",
+			spokeMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "hc1",
 					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
 				},
 			},
-			hubHostedCluster: &clusterv1.ManagedCluster{
+			hubMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "imported-mce-hostedcluster",
+					Name: "mce-hc1",
 					Labels: map[string]string{
-						"feature.open-cluster-management.io/addon-search":      "available",
-						"hypershift.open-cluster-management.io/discovery-type": "MultiClusterEngineHCP",
-						"team": "backend",
+						"vendor": "OpenShift", "cloud": "Amazon", "region": "us-east-1",
+						"feature.open-cluster-management.io/addon-search": "available",
+						"env": "prod",
 					},
 				},
 			},
-			importedMCEName: "imported-mce",
-			expectedLabels: map[string]string{
-				"team": "backend",
-			},
-			notExpectedLabels: []string{
-				"feature.open-cluster-management.io/addon-search",
-				"hypershift.open-cluster-management.io/discovery-type",
-			},
+			clusterName:       "mce",
+			expectedLabels:    map[string]string{"env": "prod"},
+			notExpectedLabels: []string{"vendor", "cloud", "region", "feature.open-cluster-management.io/addon-search"},
 		},
 		{
-			name: "removed hub label is deleted from spoke",
-			spokeHostedCluster: &clusterv1.ManagedCluster{
+			name: "hub label removed from spoke",
+			spokeMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "hostedcluster",
-					Annotations: map[string]string{createdViaAnno: createdViaHypershift, propagatedLabelAnnotation: "env,team"},
-					Labels:      map[string]string{"env": "prod", "team": "backend"},
+					Name: "hc1",
+					Annotations: map[string]string{
+						createdViaAnno:            createdViaHypershift,
+						propagatedLabelAnnotation: "env,team",
+					},
+					Labels: map[string]string{"env": "prod", "team": "backend", "local": "keep"},
 				},
 			},
-			hubHostedCluster: &clusterv1.ManagedCluster{
+			hubMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "imported-mce-hostedcluster",
+					Name:   "mce-hc1",
 					Labels: map[string]string{"env": "prod"},
 				},
 			},
-			importedMCEName: "imported-mce",
-			expectedLabels: map[string]string{
-				"env": "prod",
-			},
+			clusterName:       "mce",
+			expectedLabels:    map[string]string{"env": "prod", "local": "keep"},
 			notExpectedLabels: []string{"team"},
 		},
 		{
-			name: "spoke local labels are preserved alongside propagated labels",
-			spokeHostedCluster: &clusterv1.ManagedCluster{
+			name: "hub MC not found cleans up tracked labels",
+			spokeMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "hostedcluster",
-					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
-					Labels:      map[string]string{"local-label": "local-value"},
+					Name: "hc1",
+					Annotations: map[string]string{
+						createdViaAnno:            createdViaHypershift,
+						propagatedLabelAnnotation: "env,team",
+					},
+					Labels: map[string]string{"env": "prod", "team": "backend", "local": "keep"},
 				},
 			},
-			hubHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "imported-mce-hostedcluster",
-					Labels: map[string]string{"env": "prod"},
-				},
-			},
-			importedMCEName: "imported-mce",
-			expectedLabels: map[string]string{
-				"local-label": "local-value",
-				"env":         "prod",
-			},
+			hubMC:             nil,
+			clusterName:       "mce",
+			expectedLabels:    map[string]string{"local": "keep"},
+			notExpectedLabels: []string{"env", "team"},
 		},
 		{
-			name: "custom discovery prefix - labels propagate",
-			spokeHostedCluster: &clusterv1.ManagedCluster{
+			name: "custom discovery prefix",
+			spokeMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "hostedcluster",
+					Name:        "hc1",
 					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
 				},
 			},
-			hubHostedCluster: &clusterv1.ManagedCluster{
+			hubMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "custom-hostedcluster",
+					Name:   "custom-hc1",
 					Labels: map[string]string{"env": "prod"},
 				},
 			},
-			importedMCEName: "imported-mce",
+			clusterName:     "mce",
 			discoveryPrefix: strPtr("custom"),
-			expectedLabels: map[string]string{
-				"env": "prod",
-			},
+			expectedLabels:  map[string]string{"env": "prod"},
 		},
 		{
-			name: "empty discovery prefix - hub name equals spoke name",
-			spokeHostedCluster: &clusterv1.ManagedCluster{
+			name: "local-cluster skips reconcile",
+			spokeMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "hostedcluster",
-					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
-				},
-			},
-			hubHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "hostedcluster",
-					Labels: map[string]string{"env": "staging"},
-				},
-			},
-			importedMCEName: "imported-mce",
-			discoveryPrefix: strPtr(""),
-			expectedLabels: map[string]string{
-				"env": "staging",
-			},
-		},
-		{
-			name: "local-cluster agent skips reconcile",
-			spokeHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "hostedcluster",
+					Name:        "hc1",
 					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
 					Labels:      map[string]string{"existing": "value"},
 				},
 			},
-			hubHostedCluster: &clusterv1.ManagedCluster{
+			hubMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "local-cluster-hostedcluster",
+					Name:   "local-cluster-hc1",
 					Labels: map[string]string{"env": "prod"},
 				},
 			},
-			importedMCEName:  "local-cluster",
-			localClusterName: "local-cluster",
-			expectedLabels: map[string]string{
-				"existing": "value",
-			},
+			clusterName:       "local-cluster",
+			localClusterName:  "local-cluster",
+			expectedLabels:    map[string]string{"existing": "value"},
 			notExpectedLabels: []string{"env"},
 		},
 		{
-			name: "missing created-via annotation skips reconcile",
-			spokeHostedCluster: &clusterv1.ManagedCluster{
+			name: "missing annotation skips reconcile",
+			spokeMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "hostedcluster",
+					Name:   "hc1",
 					Labels: map[string]string{"existing": "value"},
 				},
 			},
-			hubHostedCluster: &clusterv1.ManagedCluster{
+			hubMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "imported-mce-hostedcluster",
+					Name:   "mce-hc1",
 					Labels: map[string]string{"env": "prod"},
 				},
 			},
-			importedMCEName: "imported-mce",
-			expectedLabels: map[string]string{
-				"existing": "value",
-			},
+			clusterName:       "mce",
+			expectedLabels:    map[string]string{"existing": "value"},
 			notExpectedLabels: []string{"env"},
 		},
 		{
-			name: "hub MC not found - propagated labels removed, local labels kept",
-			spokeHostedCluster: &clusterv1.ManagedCluster{
+			name: "idempotent when already synced",
+			spokeMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "hostedcluster",
-					Annotations: map[string]string{createdViaAnno: createdViaHypershift, propagatedLabelAnnotation: "env,team"},
-					Labels:      map[string]string{"existing": "value", "env": "prod", "team": "backend"},
+					Name: "hc1",
+					Annotations: map[string]string{
+						createdViaAnno:            createdViaHypershift,
+						propagatedLabelAnnotation: "env",
+					},
+					Labels: map[string]string{"env": "prod"},
 				},
 			},
-			hubHostedCluster: nil,
-			importedMCEName:  "imported-mce",
-			expectedLabels: map[string]string{
-				"existing": "value",
+			hubMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "mce-hc1",
+					Labels: map[string]string{"env": "prod"},
+				},
 			},
-			notExpectedLabels: []string{"env", "team"},
+			clusterName:    "mce",
+			expectedLabels: map[string]string{"env": "prod"},
 		},
 		{
-			name: "hub has nil labels - previously tracked labels removed",
-			spokeHostedCluster: &clusterv1.ManagedCluster{
+			name: "matching labels auto-tracked",
+			spokeMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "hostedcluster",
-					Annotations: map[string]string{createdViaAnno: createdViaHypershift, propagatedLabelAnnotation: "env"},
-					Labels:      map[string]string{"env": "prod", "local": "keep"},
-				},
-			},
-			hubHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "imported-mce-hostedcluster",
-				},
-			},
-			importedMCEName: "imported-mce",
-			expectedLabels: map[string]string{
-				"local": "keep",
-			},
-			notExpectedLabels: []string{"env"},
-		},
-		{
-			name: "spoke has nil labels - hub labels added",
-			spokeHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "hostedcluster",
+					Name:        "hc1",
 					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
-				},
-			},
-			hubHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "imported-mce-hostedcluster",
-					Labels: map[string]string{"env": "prod"},
-				},
-			},
-			importedMCEName: "imported-mce",
-			expectedLabels: map[string]string{
-				"env": "prod",
-			},
-			expectedAnnotationKeys: []string{"env"},
-		},
-		{
-			name: "idempotent - no changes when already synced",
-			spokeHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "hostedcluster",
-					Annotations: map[string]string{createdViaAnno: createdViaHypershift, propagatedLabelAnnotation: "env"},
 					Labels:      map[string]string{"env": "prod"},
 				},
 			},
-			hubHostedCluster: &clusterv1.ManagedCluster{
+			hubMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "imported-mce-hostedcluster",
+					Name:   "mce-hc1",
 					Labels: map[string]string{"env": "prod"},
 				},
 			},
-			importedMCEName: "imported-mce",
-			expectedLabels: map[string]string{
-				"env": "prod",
-			},
+			clusterName:      "mce",
+			expectedLabels:   map[string]string{"env": "prod"},
+			expectedAnnoKeys: []string{"env"},
 		},
 		{
-			name: "multiple labels propagated and some removed",
-			spokeHostedCluster: &clusterv1.ManagedCluster{
+			name: "multiple labels with partial removal",
+			spokeMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "hostedcluster",
-					Annotations: map[string]string{createdViaAnno: createdViaHypershift, propagatedLabelAnnotation: "env,team,old-label,deprecated"},
-					Labels:      map[string]string{"env": "prod", "team": "backend", "old-label": "remove-me", "deprecated": "remove-me-too", "local": "keep"},
+					Name: "hc1",
+					Annotations: map[string]string{
+						createdViaAnno:            createdViaHypershift,
+						propagatedLabelAnnotation: "env,team,old,deprecated",
+					},
+					Labels: map[string]string{
+						"env": "prod", "team": "backend",
+						"old": "rm", "deprecated": "rm", "local": "keep",
+					},
 				},
 			},
-			hubHostedCluster: &clusterv1.ManagedCluster{
+			hubMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "imported-mce-hostedcluster",
+					Name:   "mce-hc1",
 					Labels: map[string]string{"env": "staging", "team": "backend"},
 				},
 			},
-			importedMCEName: "imported-mce",
-			expectedLabels: map[string]string{
-				"env":   "staging",
-				"team":  "backend",
-				"local": "keep",
-			},
-			notExpectedLabels:      []string{"old-label", "deprecated"},
-			expectedAnnotationKeys: []string{"env", "team"},
-		},
-		{
-			name: "clusterset label propagated when only on hub",
-			spokeHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "hostedcluster",
-					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
-				},
-			},
-			hubHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "imported-mce-hostedcluster",
-					Labels: map[string]string{"cluster.open-cluster-management.io/clusterset": "team-a-clusters"},
-				},
-			},
-			importedMCEName: "imported-mce",
-			expectedLabels: map[string]string{
-				"cluster.open-cluster-management.io/clusterset": "team-a-clusters",
-			},
-			expectedAnnotationKeys: []string{"cluster.open-cluster-management.io/clusterset"},
-		},
-		{
-			name: "matching labels on both sides are auto-tracked",
-			spokeHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "hostedcluster",
-					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
-					Labels:      map[string]string{"cluster.open-cluster-management.io/clusterset": "default"},
-				},
-			},
-			hubHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "imported-mce-hostedcluster",
-					Labels: map[string]string{"cluster.open-cluster-management.io/clusterset": "default"},
-				},
-			},
-			importedMCEName: "imported-mce",
-			expectedLabels: map[string]string{
-				"cluster.open-cluster-management.io/clusterset": "default",
-			},
-			expectedAnnotationKeys: []string{"cluster.open-cluster-management.io/clusterset"},
-		},
-		{
-			name: "untracked label with different hub value is not overwritten",
-			spokeHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "hostedcluster",
-					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
-					Labels:      map[string]string{"cluster.open-cluster-management.io/clusterset": "default"},
-				},
-			},
-			hubHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "imported-mce-hostedcluster",
-					Labels: map[string]string{"cluster.open-cluster-management.io/clusterset": "team-a"},
-				},
-			},
-			importedMCEName: "imported-mce",
-			expectedLabels: map[string]string{
-				"cluster.open-cluster-management.io/clusterset": "default",
-			},
-		},
-		{
-			name: "tracked clusterset label updated when hub changes",
-			spokeHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "hostedcluster",
-					Annotations: map[string]string{createdViaAnno: createdViaHypershift, propagatedLabelAnnotation: "cluster.open-cluster-management.io/clusterset"},
-					Labels:      map[string]string{"cluster.open-cluster-management.io/clusterset": "default"},
-				},
-			},
-			hubHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "imported-mce-hostedcluster",
-					Labels: map[string]string{"cluster.open-cluster-management.io/clusterset": "team-a"},
-				},
-			},
-			importedMCEName: "imported-mce",
-			expectedLabels: map[string]string{
-				"cluster.open-cluster-management.io/clusterset": "team-a",
-			},
-			expectedAnnotationKeys: []string{"cluster.open-cluster-management.io/clusterset"},
-		},
-		{
-			name: "tracking annotation records propagated keys",
-			spokeHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "hostedcluster",
-					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
-				},
-			},
-			hubHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "imported-mce-hostedcluster",
-					Labels: map[string]string{"env": "prod", "team": "backend", "vendor": "OpenShift"},
-				},
-			},
-			importedMCEName: "imported-mce",
-			expectedLabels: map[string]string{
-				"env":  "prod",
-				"team": "backend",
-			},
-			notExpectedLabels:      []string{"vendor"},
-			expectedAnnotationKeys: []string{"env", "team"},
-		},
-		{
-			name: "spoke label value changed - corrected back to hub value",
-			spokeHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "hostedcluster",
-					Annotations: map[string]string{createdViaAnno: createdViaHypershift, propagatedLabelAnnotation: "env"},
-					Labels:      map[string]string{"env": "WRONG"},
-				},
-			},
-			hubHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "imported-mce-hostedcluster",
-					Labels: map[string]string{"env": "prod"},
-				},
-			},
-			importedMCEName: "imported-mce",
-			expectedLabels: map[string]string{
-				"env": "prod",
-			},
-			expectedAnnotationKeys: []string{"env"},
-		},
-		{
-			name: "spoke label deleted entirely - re-added from hub",
-			spokeHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "hostedcluster",
-					Annotations: map[string]string{createdViaAnno: createdViaHypershift, propagatedLabelAnnotation: "env,team"},
-					Labels:      map[string]string{"local": "keep"},
-				},
-			},
-			hubHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "imported-mce-hostedcluster",
-					Labels: map[string]string{"env": "prod", "team": "platform"},
-				},
-			},
-			importedMCEName: "imported-mce",
-			expectedLabels: map[string]string{
-				"env":   "prod",
-				"team":  "platform",
-				"local": "keep",
-			},
-			expectedAnnotationKeys: []string{"env", "team"},
-		},
-		{
-			name: "spoke label deleted and hub value changed simultaneously",
-			spokeHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "hostedcluster",
-					Annotations: map[string]string{createdViaAnno: createdViaHypershift, propagatedLabelAnnotation: "env,team"},
-					Labels:      map[string]string{"env": "old-value"},
-				},
-			},
-			hubHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "imported-mce-hostedcluster",
-					Labels: map[string]string{"env": "new-value", "team": "backend"},
-				},
-			},
-			importedMCEName: "imported-mce",
-			expectedLabels: map[string]string{
-				"env":  "new-value",
-				"team": "backend",
-			},
-			expectedAnnotationKeys: []string{"env", "team"},
-		},
-		{
-			name: "all propagated labels deleted from spoke - all re-added from hub",
-			spokeHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "hostedcluster",
-					Annotations: map[string]string{
-						createdViaAnno:             createdViaHypershift,
-						propagatedLabelAnnotation:  testAnnotationEnvTeamTier,
-					},
-					Labels:      map[string]string{},
-				},
-			},
-			hubHostedCluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "imported-mce-hostedcluster",
-					Labels: map[string]string{"env": "prod", "team": "platform", "tier": "frontend"},
-				},
-			},
-			importedMCEName: "imported-mce",
-			expectedLabels: map[string]string{
-				"env":  "prod",
-				"team": "platform",
-				"tier": "frontend",
-			},
-			expectedAnnotationKeys: []string{"env", "team", "tier"},
+			clusterName:       "mce",
+			expectedLabels:    map[string]string{"env": "staging", "team": "backend", "local": "keep"},
+			notExpectedLabels: []string{"old", "deprecated"},
+			expectedAnnoKeys:  []string{"env", "team"},
 		},
 	}
 
@@ -590,7 +321,6 @@ func TestLabelPropagation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			spoke, hub := initLabelSyncClient(t)
-			zapLog, _ := zap.NewDevelopment()
 
 			if tt.discoveryPrefix != nil {
 				os.Setenv("DISCOVERY_PREFIX", *tt.discoveryPrefix)
@@ -599,54 +329,39 @@ func TestLabelPropagation(t *testing.T) {
 				os.Unsetenv("DISCOVERY_PREFIX")
 			}
 
-			localClusterName := "local-cluster"
+			localCluster := "local-cluster"
 			if tt.localClusterName != "" {
-				localClusterName = tt.localClusterName
+				localCluster = tt.localClusterName
 			}
 
-			labelController := &LabelAgent{
-				hubClient:        hub,
-				spokeClient:      spoke,
-				clusterName:      tt.importedMCEName,
-				localClusterName: localClusterName,
-				log:              zapr.NewLogger(zapLog),
+			lc := newLabelAgent(t, spoke, hub, tt.clusterName)
+			lc.localClusterName = localCluster
+
+			assert.Nil(t, spoke.Create(ctx, tt.spokeMC))
+			if tt.hubMC != nil {
+				assert.Nil(t, hub.Create(ctx, tt.hubMC))
 			}
 
-			err := spoke.Create(ctx, tt.spokeHostedCluster)
-			assert.Nil(t, err)
+			mc := reconcileAndGet(t, lc, spoke, tt.spokeMC.Name)
 
-			if tt.hubHostedCluster != nil {
-				err = hub.Create(ctx, tt.hubHostedCluster)
-				assert.Nil(t, err)
+			for key, val := range tt.expectedLabels {
+				assert.Equal(t, val, mc.Labels[key], "label %s", key)
 			}
-
-			_, err = labelController.Reconcile(ctx, ctrl.Request{
-				NamespacedName: types.NamespacedName{Name: tt.spokeHostedCluster.Name},
-			})
-			assert.Nil(t, err)
-
-			retrievedMC := &clusterv1.ManagedCluster{}
-			err = spoke.Get(ctx, types.NamespacedName{Name: tt.spokeHostedCluster.Name}, retrievedMC)
-			assert.Nil(t, err)
-
-			for key, expectedValue := range tt.expectedLabels {
-				assert.Equal(t, expectedValue, retrievedMC.Labels[key], "label %s mismatch", key)
-			}
-
 			for _, key := range tt.notExpectedLabels {
-				_, exists := retrievedMC.Labels[key]
-				assert.False(t, exists, "label %s should not be on spoke", key)
+				_, exists := mc.Labels[key]
+				assert.False(t, exists, "label %s should not exist", key)
 			}
-
-			if tt.expectedAnnotationKeys != nil {
-				anno := retrievedMC.Annotations[propagatedLabelAnnotation]
-				for _, key := range tt.expectedAnnotationKeys {
-					assert.Contains(t, anno, key, "tracking annotation should contain %s", key)
+			if tt.expectedAnnoKeys != nil {
+				anno := mc.Annotations[propagatedLabelAnnotation]
+				for _, key := range tt.expectedAnnoKeys {
+					assert.Contains(t, anno, key)
 				}
 			}
 		})
 	}
 }
+
+// --- HostedCluster-to-ManagedCluster label propagation ---
 
 type hcLabelTestCase struct {
 	name                       string
@@ -662,7 +377,7 @@ type hcLabelTestCase struct {
 	expectedHubAnnoKeysOnSpoke []string
 }
 
-func hcLabelBasicCases() []hcLabelTestCase {
+func hcLabelTestCases() []hcLabelTestCase {
 	return []hcLabelTestCase{
 		{
 			name: "HC label propagated to spoke and hub",
@@ -692,7 +407,7 @@ func hcLabelBasicCases() []hcLabelTestCase {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "my-hc",
 					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
-					Labels:      map[string]string{"env": "old-local"},
+					Labels:      map[string]string{"env": "local-val"},
 				},
 			},
 			hc: &hyperv1beta1.HostedCluster{
@@ -704,10 +419,10 @@ func hcLabelBasicCases() []hcLabelTestCase {
 			hubMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: testHubMCName},
 			},
-			expectedSpokeLabels: map[string]string{"env": "old-local"},
+			expectedSpokeLabels: map[string]string{"env": "local-val"},
 		},
 		{
-			name: "HC skips hub-tracked label on spoke when not HC-tracked",
+			name: "HC skips hub-tracked label when not HC-tracked",
 			spokeMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "my-hc",
@@ -734,7 +449,7 @@ func hcLabelBasicCases() []hcLabelTestCase {
 			expectedHubAnnoKeysOnSpoke: []string{"env"},
 		},
 		{
-			name: "HC system labels are not propagated",
+			name: "HC system labels not propagated",
 			spokeMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "my-hc",
@@ -758,13 +473,8 @@ func hcLabelBasicCases() []hcLabelTestCase {
 			expectedHCAnnoKeysOnSpoke: []string{"env"},
 			notExpectedHubLabels:      []string{testAutoCreatedForInfra},
 		},
-	}
-}
-
-func hcLabelAdvancedCases() []hcLabelTestCase {
-	return []hcLabelTestCase{
 		{
-			name: "HC label removed - cleaned from spoke and hub",
+			name: "HC label removed cleans up spoke and hub",
 			spokeMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "my-hc",
@@ -776,9 +486,7 @@ func hcLabelAdvancedCases() []hcLabelTestCase {
 				},
 			},
 			hc: &hyperv1beta1.HostedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "my-hc", Namespace: "clusters",
-				},
+				ObjectMeta: metav1.ObjectMeta{Name: "my-hc", Namespace: "clusters"},
 			},
 			hubMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -792,7 +500,7 @@ func hcLabelAdvancedCases() []hcLabelTestCase {
 			notExpectedHubLabels:   []string{"env"},
 		},
 		{
-			name: "HC and admin hub labels coexist independently",
+			name: "HC and hub labels coexist independently",
 			spokeMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "my-hc",
@@ -816,7 +524,7 @@ func hcLabelAdvancedCases() []hcLabelTestCase {
 			expectedHubAnnoKeysOnSpoke: []string{"team"},
 		},
 		{
-			name: "HC with managedcluster-name annotation maps correctly",
+			name: "HC annotation match maps to correct MC",
 			spokeMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "custom-mc-name",
@@ -826,10 +534,8 @@ func hcLabelAdvancedCases() []hcLabelTestCase {
 			hc: &hyperv1beta1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "my-hc", Namespace: "clusters",
-					Labels: map[string]string{"env": "prod"},
-					Annotations: map[string]string{
-						util.ManagedClusterAnnoKey: "custom-mc-name",
-					},
+					Labels:      map[string]string{"env": "prod"},
+					Annotations: map[string]string{util.ManagedClusterAnnoKey: "custom-mc-name"},
 				},
 			},
 			hubMC: &clusterv1.ManagedCluster{
@@ -839,14 +545,12 @@ func hcLabelAdvancedCases() []hcLabelTestCase {
 			expectedHCAnnoKeysOnSpoke: []string{"env"},
 		},
 		{
-			name: "HC matched by infraID when MC has auto-created-for-infra label",
+			name: "HC matched by infraID",
 			spokeMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "my-hc",
+					Name:        "my-hc",
 					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
-					Labels: map[string]string{
-						testAutoCreatedForInfra: "my-hc-abc12",
-					},
+					Labels:      map[string]string{testAutoCreatedForInfra: "my-hc-abc12"},
 				},
 			},
 			hc: &hyperv1beta1.HostedCluster{
@@ -854,9 +558,7 @@ func hcLabelAdvancedCases() []hcLabelTestCase {
 					Name: "my-hc", Namespace: "clusters",
 					Labels: map[string]string{"env": "prod"},
 				},
-				Spec: hyperv1beta1.HostedClusterSpec{
-					InfraID: "my-hc-abc12",
-				},
+				Spec: hyperv1beta1.HostedClusterSpec{InfraID: "my-hc-abc12"},
 			},
 			hubMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: testHubMCName},
@@ -864,27 +566,64 @@ func hcLabelAdvancedCases() []hcLabelTestCase {
 			expectedSpokeLabels:      map[string]string{"env": "prod"},
 			expectedHCAnnoKeysOnSpoke: []string{"env"},
 		},
+		{
+			name: "HC deleted cleans up tracked labels",
+			spokeMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-hc",
+					Annotations: map[string]string{
+						createdViaAnno:              createdViaHypershift,
+						hcPropagatedLabelAnnotation: "env,tier",
+					},
+					Labels: map[string]string{"env": "prod", "tier": "frontend", "local": "keep"},
+				},
+			},
+			hc: nil,
+			hubMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testHubMCName,
+					Annotations: map[string]string{hcPropagatedLabelAnnotation: "env,tier"},
+					Labels:      map[string]string{"env": "prod", "tier": "frontend", "admin": "keep"},
+				},
+			},
+			expectedSpokeLabels:    map[string]string{"local": "keep"},
+			notExpectedSpokeLabels: []string{"env", "tier"},
+			expectedHubLabels:      map[string]string{"admin": "keep"},
+			notExpectedHubLabels:   []string{"env", "tier"},
+		},
+		{
+			name: "hub sync skips HC-owned labels",
+			spokeMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "my-hc",
+					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
+				},
+			},
+			hc: &hyperv1beta1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-hc", Namespace: "clusters",
+					Labels: map[string]string{"env": "prod"},
+				},
+			},
+			hubMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   testHubMCName,
+					Labels: map[string]string{"env": "staging", "team": "platform"},
+				},
+			},
+			expectedSpokeLabels:       map[string]string{"env": "prod", "team": "platform"},
+			expectedHCAnnoKeysOnSpoke:  []string{"env"},
+			expectedHubAnnoKeysOnSpoke: []string{"team"},
+		},
 	}
-}
-
-func hcLabelTestCases() []hcLabelTestCase {
-	return append(hcLabelBasicCases(), hcLabelAdvancedCases()...)
 }
 
 func runHCLabelTest(t *testing.T, tt hcLabelTestCase) {
 	t.Helper()
 	ctx := context.Background()
 	spoke, hub := initLabelSyncClient(t)
-	zapLog, _ := zap.NewDevelopment()
 	os.Unsetenv("DISCOVERY_PREFIX")
-
-	lc := &LabelAgent{
-		hubClient:        hub,
-		spokeClient:      spoke,
-		clusterName:      "mce",
-		localClusterName: "local-cluster",
-		log:              zapr.NewLogger(zapLog),
-	}
+	lc := newLabelAgent(t, spoke, hub, "mce")
 
 	assert.Nil(t, spoke.Create(ctx, tt.spokeMC))
 	if tt.hc != nil {
@@ -894,50 +633,42 @@ func runHCLabelTest(t *testing.T, tt hcLabelTestCase) {
 		assert.Nil(t, hub.Create(ctx, tt.hubMC))
 	}
 
-	_, err := lc.Reconcile(ctx, ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: tt.spokeMC.Name},
-	})
-	assert.Nil(t, err)
-
-	retrievedSpoke := &clusterv1.ManagedCluster{}
-	assert.Nil(t, spoke.Get(ctx, types.NamespacedName{Name: tt.spokeMC.Name}, retrievedSpoke))
+	mc := reconcileAndGet(t, lc, spoke, tt.spokeMC.Name)
 
 	for key, val := range tt.expectedSpokeLabels {
-		assert.Equal(t, val, retrievedSpoke.Labels[key], "spoke label %s mismatch", key)
+		assert.Equal(t, val, mc.Labels[key], "spoke label %s", key)
 	}
 	for _, key := range tt.notExpectedSpokeLabels {
-		_, exists := retrievedSpoke.Labels[key]
+		_, exists := mc.Labels[key]
 		assert.False(t, exists, "spoke label %s should not exist", key)
 	}
-
 	if tt.expectedHCAnnoKeysOnSpoke != nil {
-		anno := retrievedSpoke.Annotations[hcPropagatedLabelAnnotation]
+		anno := mc.Annotations[hcPropagatedLabelAnnotation]
 		for _, key := range tt.expectedHCAnnoKeysOnSpoke {
-			assert.Contains(t, anno, key, "spoke hc-tracking annotation should contain %s", key)
+			assert.Contains(t, anno, key)
 		}
 	}
 	if tt.expectedHubAnnoKeysOnSpoke != nil {
-		anno := retrievedSpoke.Annotations[propagatedLabelAnnotation]
+		anno := mc.Annotations[propagatedLabelAnnotation]
 		for _, key := range tt.expectedHubAnnoKeysOnSpoke {
-			assert.Contains(t, anno, key, "spoke hub-tracking annotation should contain %s", key)
+			assert.Contains(t, anno, key)
 		}
 	}
 
 	if tt.hubMC != nil {
-		retrievedHub := &clusterv1.ManagedCluster{}
-		assert.Nil(t, hub.Get(ctx, types.NamespacedName{Name: tt.hubMC.Name}, retrievedHub))
-
+		hubMC := &clusterv1.ManagedCluster{}
+		assert.Nil(t, hub.Get(ctx, types.NamespacedName{Name: tt.hubMC.Name}, hubMC))
 		for key, val := range tt.expectedHubLabels {
-			assert.Equal(t, val, retrievedHub.Labels[key], "hub label %s mismatch", key)
+			assert.Equal(t, val, hubMC.Labels[key], "hub label %s", key)
 		}
 		for _, key := range tt.notExpectedHubLabels {
-			_, exists := retrievedHub.Labels[key]
+			_, exists := hubMC.Labels[key]
 			assert.False(t, exists, "hub label %s should not exist", key)
 		}
 		if tt.expectedHCAnnoKeysOnHub != nil {
-			anno := retrievedHub.Annotations[hcPropagatedLabelAnnotation]
+			anno := hubMC.Annotations[hcPropagatedLabelAnnotation]
 			for _, key := range tt.expectedHCAnnoKeysOnHub {
-				assert.Contains(t, anno, key, "hub hc-tracking annotation should contain %s", key)
+				assert.Contains(t, anno, key)
 			}
 		}
 	}
@@ -951,158 +682,38 @@ func TestHCLabelPropagation(t *testing.T) {
 	}
 }
 
-func TestHCDeletedCleansUpLabels(t *testing.T) {
-	ctx := context.Background()
-	spoke, hub := initLabelSyncClient(t)
-	zapLog, _ := zap.NewDevelopment()
-	os.Unsetenv("DISCOVERY_PREFIX")
-
-	lc := &LabelAgent{
-		hubClient:        hub,
-		spokeClient:      spoke,
-		clusterName:      "mce",
-		localClusterName: "local-cluster",
-		log:              zapr.NewLogger(zapLog),
-	}
-
-	spokeMC := &clusterv1.ManagedCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "my-hc",
-			Annotations: map[string]string{
-				createdViaAnno:              createdViaHypershift,
-				hcPropagatedLabelAnnotation: "env,tier",
-			},
-			Labels: map[string]string{"env": "prod", "tier": "frontend", "local": "keep"},
-		},
-	}
-	hubMC := &clusterv1.ManagedCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        testHubMCName,
-			Annotations: map[string]string{hcPropagatedLabelAnnotation: "env,tier"},
-			Labels:      map[string]string{"env": "prod", "tier": "frontend", "admin-label": "keep"},
-		},
-	}
-
-	assert.Nil(t, spoke.Create(ctx, spokeMC))
-	assert.Nil(t, hub.Create(ctx, hubMC))
-
-	_, err := lc.Reconcile(ctx, ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "my-hc"},
-	})
-	assert.Nil(t, err)
-
-	retrievedSpoke := &clusterv1.ManagedCluster{}
-	assert.Nil(t, spoke.Get(ctx, types.NamespacedName{Name: "my-hc"}, retrievedSpoke))
-	assert.Equal(t, "keep", retrievedSpoke.Labels["local"])
-	_, envExists := retrievedSpoke.Labels["env"]
-	assert.False(t, envExists, "env should be removed from spoke after HC deleted")
-	_, tierExists := retrievedSpoke.Labels["tier"]
-	assert.False(t, tierExists, "tier should be removed from spoke after HC deleted")
-
-	retrievedHub := &clusterv1.ManagedCluster{}
-	assert.Nil(t, hub.Get(ctx, types.NamespacedName{Name: testHubMCName}, retrievedHub))
-	assert.Equal(t, "keep", retrievedHub.Labels["admin-label"])
-	_, envExists = retrievedHub.Labels["env"]
-	assert.False(t, envExists, "env should be removed from hub after HC deleted")
-}
-
-func TestHubSyncSkipsHCOwnedLabels(t *testing.T) {
-	ctx := context.Background()
-	spoke, hub := initLabelSyncClient(t)
-	zapLog, _ := zap.NewDevelopment()
-	os.Unsetenv("DISCOVERY_PREFIX")
-
-	lc := &LabelAgent{
-		hubClient:        hub,
-		spokeClient:      spoke,
-		clusterName:      "mce",
-		localClusterName: "local-cluster",
-		log:              zapr.NewLogger(zapLog),
-	}
-
-	spokeMC := &clusterv1.ManagedCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "my-hc",
-			Annotations: map[string]string{createdViaAnno: createdViaHypershift},
-		},
-	}
-	hc := &hyperv1beta1.HostedCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "my-hc", Namespace: "clusters",
-			Labels: map[string]string{"env": "prod"},
-		},
-	}
-	hubMC := &clusterv1.ManagedCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   testHubMCName,
-			Labels: map[string]string{"env": "staging", "team": "platform"},
-		},
-	}
-
-	assert.Nil(t, spoke.Create(ctx, spokeMC))
-	assert.Nil(t, spoke.Create(ctx, hc))
-	assert.Nil(t, hub.Create(ctx, hubMC))
-
-	_, err := lc.Reconcile(ctx, ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "my-hc"},
-	})
-	assert.Nil(t, err)
-
-	retrieved := &clusterv1.ManagedCluster{}
-	assert.Nil(t, spoke.Get(ctx, types.NamespacedName{Name: "my-hc"}, retrieved))
-
-	// HC env=prod is new to spoke (spoke had no env) → HC adds it and tracks it
-	assert.Equal(t, "prod", retrieved.Labels["env"], "HC env should be added since spoke had no env")
-	assert.Equal(t, "platform", retrieved.Labels["team"], "admin hub label should be propagated")
-
-	assert.Contains(t, retrieved.Annotations[hcPropagatedLabelAnnotation], "env")
-	assert.Contains(t, retrieved.Annotations[propagatedLabelAnnotation], "team")
-	assert.NotContains(t, retrieved.Annotations[propagatedLabelAnnotation], "env",
-		"env should not be in hub tracking since HC owns it")
-}
+// --- Multi-cluster propagation ---
 
 func TestMultiClusterLabelPropagation(t *testing.T) {
 	ctx := context.Background()
 	spoke, hub := initLabelSyncClient(t)
-	zapLog, _ := zap.NewDevelopment()
 	os.Unsetenv("DISCOVERY_PREFIX")
+	lc := newLabelAgent(t, spoke, hub, "cluster-mce")
 
-	labelController := &LabelAgent{
-		hubClient:        hub,
-		spokeClient:      spoke,
-		clusterName:      "cluster-mce",
-		localClusterName: "local-cluster",
-		log:              zapr.NewLogger(zapLog),
-	}
-
-	type clusterPair struct {
+	type pair struct {
 		spoke          *clusterv1.ManagedCluster
 		hub            *clusterv1.ManagedCluster
 		expectedLabels map[string]string
 		notExpected    []string
 	}
 
-	clusters := []clusterPair{
+	clusters := []pair{
 		{
 			spoke: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "hc-app1",
 					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
-					Labels:      map[string]string{"local-app1": "keep"},
+					Labels:      map[string]string{"local": "keep"},
 				},
 			},
 			hub: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "cluster-mce-hc-app1",
-					Labels: map[string]string{"env": "prod", "team": "platform", "vendor": "OpenShift"},
+					Labels: map[string]string{"env": "prod", "vendor": "OpenShift"},
 				},
 			},
-			expectedLabels: map[string]string{
-				"env":        "prod",
-				"team":       "platform",
-				"local-app1": "keep",
-			},
-			notExpected: []string{"vendor"},
+			expectedLabels: map[string]string{"env": "prod", "local": "keep"},
+			notExpected:    []string{"vendor"},
 		},
 		{
 			spoke: &clusterv1.ManagedCluster{
@@ -1113,83 +724,37 @@ func TestMultiClusterLabelPropagation(t *testing.T) {
 			},
 			hub: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "cluster-mce-hc-app2",
-					Labels: map[string]string{
-						"env":  "staging",
-						"tier": "backend",
-						"cluster.open-cluster-management.io/clusterset": "team-b",
-					},
+					Name:   "cluster-mce-hc-app2",
+					Labels: map[string]string{"env": "staging", "tier": "backend"},
 				},
 			},
-			expectedLabels: map[string]string{
-				"env":  "staging",
-				"tier": "backend",
-				"cluster.open-cluster-management.io/clusterset": "team-b",
-			},
-			notExpected: []string{"team"},
-		},
-		{
-			spoke: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "hc-app3",
-					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
-					Labels:      map[string]string{"cost-center": "local-value"},
-				},
-			},
-			hub: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "cluster-mce-hc-app3",
-					Labels: map[string]string{"region": "us-east-1", "cost-center": "hub-value", "compliance": "hipaa"},
-				},
-			},
-			expectedLabels: map[string]string{
-				"cost-center": "local-value",
-				"compliance":  "hipaa",
-			},
-			notExpected: []string{"region"},
+			expectedLabels: map[string]string{"env": "staging", "tier": "backend"},
 		},
 	}
 
 	for _, cp := range clusters {
-		err := spoke.Create(ctx, cp.spoke)
-		assert.Nil(t, err)
-		err = hub.Create(ctx, cp.hub)
-		assert.Nil(t, err)
-	}
-
-	for _, cp := range clusters {
-		_, err := labelController.Reconcile(ctx, ctrl.Request{
-			NamespacedName: types.NamespacedName{Name: cp.spoke.Name},
-		})
-		assert.Nil(t, err)
+		assert.Nil(t, spoke.Create(ctx, cp.spoke))
+		assert.Nil(t, hub.Create(ctx, cp.hub))
 	}
 
 	for _, cp := range clusters {
 		t.Run(cp.spoke.Name, func(t *testing.T) {
-			retrieved := &clusterv1.ManagedCluster{}
-			err := spoke.Get(ctx, types.NamespacedName{Name: cp.spoke.Name}, retrieved)
-			assert.Nil(t, err)
-
+			mc := reconcileAndGet(t, lc, spoke, cp.spoke.Name)
 			for key, val := range cp.expectedLabels {
-				assert.Equal(t, val, retrieved.Labels[key], "%s: label %s mismatch", cp.spoke.Name, key)
+				assert.Equal(t, val, mc.Labels[key], "%s: label %s", cp.spoke.Name, key)
 			}
-
 			for _, key := range cp.notExpected {
-				_, exists := retrieved.Labels[key]
-				assert.False(t, exists, "%s: label %s should not be present", cp.spoke.Name, key)
+				_, exists := mc.Labels[key]
+				assert.False(t, exists, "%s: label %s should not exist", cp.spoke.Name, key)
 			}
-
-			anno := retrieved.Annotations[propagatedLabelAnnotation]
-			assert.NotEmpty(t, anno, "%s: tracking annotation should be set", cp.spoke.Name)
 		})
 	}
 }
 
-func TestReconcileDisableDiscovery(t *testing.T) {
-	ctx := context.Background()
-	spoke, hub := initLabelSyncClient(t)
-	zapLog, _ := zap.NewDevelopment()
+// --- Edge cases ---
 
+func TestReconcileDisableDiscovery(t *testing.T) {
+	spoke, hub := initLabelSyncClient(t)
 	os.Setenv("DISABLE_HC_DISCOVERY", "true")
 	defer os.Unsetenv("DISABLE_HC_DISCOVERY")
 
@@ -1207,53 +772,38 @@ func TestReconcileDisableDiscovery(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
 	assert.Nil(t, spoke.Create(ctx, spokeMC))
 	assert.Nil(t, hub.Create(ctx, hubMC))
 
-	lc := &LabelAgent{
-		hubClient:        hub,
-		spokeClient:      spoke,
-		clusterName:      "mce",
-		localClusterName: "local-cluster",
-		log:              zapr.NewLogger(zapLog),
-	}
-
+	lc := newLabelAgent(t, spoke, hub, "mce")
 	result, err := lc.Reconcile(ctx, ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "hc1"},
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, ctrl.Result{}, result)
 
-	retrieved := &clusterv1.ManagedCluster{}
-	assert.Nil(t, spoke.Get(ctx, types.NamespacedName{Name: "hc1"}, retrieved))
-	_, exists := retrieved.Labels["env"]
+	mc := &clusterv1.ManagedCluster{}
+	assert.Nil(t, spoke.Get(ctx, types.NamespacedName{Name: "hc1"}, mc))
+	_, exists := mc.Labels["env"]
 	assert.False(t, exists, "labels should not propagate when discovery is disabled")
 }
 
 func TestReconcileSpokeNotFound(t *testing.T) {
-	ctx := context.Background()
 	spoke, hub := initLabelSyncClient(t)
-	zapLog, _ := zap.NewDevelopment()
 	os.Unsetenv("DISCOVERY_PREFIX")
+	lc := newLabelAgent(t, spoke, hub, "mce")
 
-	lc := &LabelAgent{
-		hubClient:        hub,
-		spokeClient:      spoke,
-		clusterName:      "mce",
-		localClusterName: "local-cluster",
-		log:              zapr.NewLogger(zapLog),
-	}
-
-	result, err := lc.Reconcile(ctx, ctrl.Request{
+	result, err := lc.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "does-not-exist"},
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, ctrl.Result{}, result)
 }
 
-func TestGetSpokeMCName(t *testing.T) {
-	zapLog, _ := zap.NewDevelopment()
+// --- Unit tests for helpers ---
 
+func TestGetSpokeMCName(t *testing.T) {
 	tests := []struct {
 		name            string
 		hubMCName       string
@@ -1261,39 +811,11 @@ func TestGetSpokeMCName(t *testing.T) {
 		discoveryPrefix *string
 		expected        string
 	}{
-		{
-			name:        "default prefix - matching hub MC",
-			hubMCName:   "cluster-mce-hc-app1",
-			clusterName: "cluster-mce",
-			expected:    "hc-app1",
-		},
-		{
-			name:        "default prefix - non-matching hub MC returns empty",
-			hubMCName:   "other-mce-hc-app1",
-			clusterName: "cluster-mce",
-			expected:    "",
-		},
-		{
-			name:            "custom prefix - matching hub MC",
-			hubMCName:       "custom-hc-web",
-			clusterName:     "cluster-mce",
-			discoveryPrefix: strPtr("custom"),
-			expected:        "hc-web",
-		},
-		{
-			name:            "custom prefix - non-matching hub MC returns empty",
-			hubMCName:       "other-hc-web",
-			clusterName:     "cluster-mce",
-			discoveryPrefix: strPtr("custom"),
-			expected:        "",
-		},
-		{
-			name:            "empty prefix - hub name equals spoke name",
-			hubMCName:       "hc-app1",
-			clusterName:     "cluster-mce",
-			discoveryPrefix: strPtr(""),
-			expected:        "hc-app1",
-		},
+		{"default prefix match", "cluster-mce-hc1", "cluster-mce", nil, "hc1"},
+		{"default prefix no match", "other-mce-hc1", "cluster-mce", nil, ""},
+		{"custom prefix match", "custom-hc-web", "cluster-mce", strPtr("custom"), "hc-web"},
+		{"custom prefix no match", "other-hc-web", "cluster-mce", strPtr("custom"), ""},
+		{"empty prefix returns name", "hc1", "cluster-mce", strPtr(""), "hc1"},
 	}
 
 	for _, tt := range tests {
@@ -1304,13 +826,9 @@ func TestGetSpokeMCName(t *testing.T) {
 			} else {
 				os.Unsetenv("DISCOVERY_PREFIX")
 			}
-
-			lc := &LabelAgent{
-				clusterName: tt.clusterName,
-				log:         zapr.NewLogger(zapLog),
-			}
-			result := lc.getSpokeMCName(tt.hubMCName)
-			assert.Equal(t, tt.expected, result)
+			zapLog, _ := zap.NewDevelopment()
+			lc := &LabelAgent{clusterName: tt.clusterName, log: zapr.NewLogger(zapLog)}
+			assert.Equal(t, tt.expected, lc.getSpokeMCName(tt.hubMCName))
 		})
 	}
 }
@@ -1318,28 +836,17 @@ func TestGetSpokeMCName(t *testing.T) {
 func TestMapHubMCToSpokeMC(t *testing.T) {
 	zapLog, _ := zap.NewDevelopment()
 	os.Unsetenv("DISCOVERY_PREFIX")
+	lc := &LabelAgent{clusterName: "cluster-mce", log: zapr.NewLogger(zapLog)}
 
-	lc := &LabelAgent{
-		clusterName: "cluster-mce",
-		log:         zapr.NewLogger(zapLog),
-	}
-
-	t.Run("matching hub MC returns reconcile request", func(t *testing.T) {
-		hubMC := &clusterv1.ManagedCluster{
-			ObjectMeta: metav1.ObjectMeta{Name: "cluster-mce-hc-app1"},
-		}
-		requests := lc.mapHubMCToSpokeMC(context.Background(), hubMC)
-		assert.Equal(t, []reconcile.Request{
-			{NamespacedName: types.NamespacedName{Name: "hc-app1"}},
-		}, requests)
+	t.Run("matching hub MC returns request", func(t *testing.T) {
+		mc := &clusterv1.ManagedCluster{ObjectMeta: metav1.ObjectMeta{Name: "cluster-mce-hc1"}}
+		reqs := lc.mapHubMCToSpokeMC(context.Background(), mc)
+		assert.Equal(t, []reconcile.Request{{NamespacedName: types.NamespacedName{Name: "hc1"}}}, reqs)
 	})
 
 	t.Run("non-matching hub MC returns nil", func(t *testing.T) {
-		hubMC := &clusterv1.ManagedCluster{
-			ObjectMeta: metav1.ObjectMeta{Name: "other-mce-hc-app1"},
-		}
-		requests := lc.mapHubMCToSpokeMC(context.Background(), hubMC)
-		assert.Nil(t, requests)
+		mc := &clusterv1.ManagedCluster{ObjectMeta: metav1.ObjectMeta{Name: "other-hc1"}}
+		assert.Nil(t, lc.mapHubMCToSpokeMC(context.Background(), mc))
 	})
 }
 
@@ -1347,145 +854,93 @@ func TestMapHCToSpokeMC(t *testing.T) {
 	zapLog, _ := zap.NewDevelopment()
 	lc := &LabelAgent{log: zapr.NewLogger(zapLog)}
 
-	t.Run("HC name maps to spoke MC name", func(t *testing.T) {
+	t.Run("HC name maps to spoke MC", func(t *testing.T) {
 		hc := &hyperv1beta1.HostedCluster{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-hc", Namespace: "clusters"},
 		}
-		requests := lc.mapHCToSpokeMC(context.Background(), hc)
-		assert.Equal(t, []reconcile.Request{
-			{NamespacedName: types.NamespacedName{Name: "my-hc"}},
-		}, requests)
+		reqs := lc.mapHCToSpokeMC(context.Background(), hc)
+		assert.Equal(t, []reconcile.Request{{NamespacedName: types.NamespacedName{Name: "my-hc"}}}, reqs)
 	})
 
-	t.Run("HC with managedcluster-name annotation uses annotation value", func(t *testing.T) {
+	t.Run("HC with annotation uses annotation value", func(t *testing.T) {
 		hc := &hyperv1beta1.HostedCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "my-hc", Namespace: "clusters",
-				Annotations: map[string]string{util.ManagedClusterAnnoKey: "custom-name"},
+				Annotations: map[string]string{util.ManagedClusterAnnoKey: testCustomMCName},
 			},
 		}
-		requests := lc.mapHCToSpokeMC(context.Background(), hc)
-		assert.Equal(t, []reconcile.Request{
-			{NamespacedName: types.NamespacedName{Name: "custom-name"}},
-		}, requests)
+		reqs := lc.mapHCToSpokeMC(context.Background(), hc)
+		assert.Equal(t, []reconcile.Request{{NamespacedName: types.NamespacedName{Name: testCustomMCName}}}, reqs)
 	})
 }
+
+// --- Predicate tests ---
 
 func TestLabelEventFilters(t *testing.T) {
 	pred := labelEventFilters()
 
-	hostedMC := &clusterv1.ManagedCluster{
+	hosted := &clusterv1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "hcp-cluster",
 			Annotations: map[string]string{createdViaAnno: createdViaHypershift},
 			Labels:      map[string]string{"env": "prod"},
 		},
 	}
-
-	nonHostedMC := &clusterv1.ManagedCluster{
+	nonHosted := &clusterv1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "regular-cluster",
+			Name:   "regular",
 			Labels: map[string]string{"env": "prod"},
 		},
 	}
 
-	t.Run("CreateFunc accepts hosted cluster MC", func(t *testing.T) {
-		result := pred.Create(event.CreateEvent{Object: hostedMC})
-		assert.True(t, result)
+	t.Run("Create accepts hosted MC", func(t *testing.T) {
+		assert.True(t, pred.Create(event.CreateEvent{Object: hosted}))
 	})
-
-	t.Run("CreateFunc rejects non-hosted cluster MC", func(t *testing.T) {
-		result := pred.Create(event.CreateEvent{Object: nonHostedMC})
-		assert.False(t, result)
+	t.Run("Create rejects non-hosted MC", func(t *testing.T) {
+		assert.False(t, pred.Create(event.CreateEvent{Object: nonHosted}))
 	})
-
-	t.Run("UpdateFunc accepts hosted cluster MC with label change", func(t *testing.T) {
-		oldMC := hostedMC.DeepCopy()
-		oldMC.Labels = map[string]string{"env": "staging"}
-		result := pred.Update(event.UpdateEvent{
-			ObjectOld: oldMC,
-			ObjectNew: hostedMC,
-		})
-		assert.True(t, result)
+	t.Run("Update accepts label change", func(t *testing.T) {
+		old := hosted.DeepCopy()
+		old.Labels = map[string]string{"env": "staging"}
+		assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: hosted}))
 	})
-
-	t.Run("UpdateFunc rejects hosted cluster MC with no label change", func(t *testing.T) {
-		result := pred.Update(event.UpdateEvent{
-			ObjectOld: hostedMC.DeepCopy(),
-			ObjectNew: hostedMC,
-		})
-		assert.False(t, result)
+	t.Run("Update rejects no change", func(t *testing.T) {
+		assert.False(t, pred.Update(event.UpdateEvent{ObjectOld: hosted.DeepCopy(), ObjectNew: hosted}))
 	})
-
-	t.Run("UpdateFunc rejects non-hosted cluster MC", func(t *testing.T) {
-		oldMC := nonHostedMC.DeepCopy()
-		oldMC.Labels = map[string]string{"env": "staging"}
-		result := pred.Update(event.UpdateEvent{
-			ObjectOld: oldMC,
-			ObjectNew: nonHostedMC,
-		})
-		assert.False(t, result)
+	t.Run("Update rejects non-hosted MC", func(t *testing.T) {
+		old := nonHosted.DeepCopy()
+		old.Labels = map[string]string{"env": "staging"}
+		assert.False(t, pred.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: nonHosted}))
 	})
-
-	t.Run("UpdateFunc accepts when propagated-labels annotation is removed", func(t *testing.T) {
-		oldMC := hostedMC.DeepCopy()
-		oldMC.Annotations[propagatedLabelAnnotation] = "env,team"
-		result := pred.Update(event.UpdateEvent{
-			ObjectOld: oldMC,
-			ObjectNew: hostedMC,
-		})
-		assert.True(t, result)
+	t.Run("Update accepts propagated-labels annotation removed", func(t *testing.T) {
+		old := hosted.DeepCopy()
+		old.Annotations[propagatedLabelAnnotation] = "env,team"
+		assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: hosted}))
 	})
-
-	t.Run("UpdateFunc accepts when hc-propagated-labels annotation is removed", func(t *testing.T) {
-		oldMC := hostedMC.DeepCopy()
-		oldMC.Annotations[hcPropagatedLabelAnnotation] = "env"
-		result := pred.Update(event.UpdateEvent{
-			ObjectOld: oldMC,
-			ObjectNew: hostedMC,
-		})
-		assert.True(t, result)
+	t.Run("Update accepts hc-propagated-labels annotation removed", func(t *testing.T) {
+		old := hosted.DeepCopy()
+		old.Annotations[hcPropagatedLabelAnnotation] = "env"
+		assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: hosted}))
 	})
-
-	t.Run("UpdateFunc accepts when created-via annotation is added", func(t *testing.T) {
-		oldMC := hostedMC.DeepCopy()
-		delete(oldMC.Annotations, createdViaAnno)
-		result := pred.Update(event.UpdateEvent{
-			ObjectOld: oldMC,
-			ObjectNew: hostedMC,
-		})
-		assert.True(t, result)
+	t.Run("Update accepts created-via annotation added", func(t *testing.T) {
+		old := hosted.DeepCopy()
+		delete(old.Annotations, createdViaAnno)
+		assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: hosted}))
 	})
-
-	t.Run("CreateFunc rejects non-ManagedCluster object", func(t *testing.T) {
-		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "some-pod"}}
-		result := pred.Create(event.CreateEvent{Object: pod})
-		assert.False(t, result)
+	t.Run("Create rejects non-MC object", func(t *testing.T) {
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod"}}
+		assert.False(t, pred.Create(event.CreateEvent{Object: pod}))
 	})
-
-	t.Run("UpdateFunc rejects non-ManagedCluster object", func(t *testing.T) {
-		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "some-pod"}}
-		result := pred.Update(event.UpdateEvent{
-			ObjectOld: pod,
-			ObjectNew: pod,
-		})
-		assert.False(t, result)
+	t.Run("Delete returns false", func(t *testing.T) {
+		assert.False(t, pred.Delete(event.DeleteEvent{Object: hosted}))
 	})
-
-	t.Run("DeleteFunc always returns false", func(t *testing.T) {
-		result := pred.Delete(event.DeleteEvent{Object: hostedMC})
-		assert.False(t, result)
-	})
-
-	t.Run("GenericFunc always returns false", func(t *testing.T) {
-		result := pred.Generic(event.GenericEvent{Object: hostedMC})
-		assert.False(t, result)
+	t.Run("Generic returns false", func(t *testing.T) {
+		assert.False(t, pred.Generic(event.GenericEvent{Object: hosted}))
 	})
 }
 
 func TestHCLabelEventFilters(t *testing.T) {
 	pred := hcLabelEventFilters()
-
 	hc := &hyperv1beta1.HostedCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-hc", Namespace: "clusters",
@@ -1493,79 +948,45 @@ func TestHCLabelEventFilters(t *testing.T) {
 		},
 	}
 
-	t.Run("CreateFunc accepts HC", func(t *testing.T) {
-		result := pred.Create(event.CreateEvent{Object: hc})
-		assert.True(t, result)
+	t.Run("Create accepts HC", func(t *testing.T) {
+		assert.True(t, pred.Create(event.CreateEvent{Object: hc}))
 	})
-
-	t.Run("UpdateFunc accepts HC with label change", func(t *testing.T) {
-		oldHC := hc.DeepCopy()
-		oldHC.Labels = map[string]string{"env": "staging"}
-		result := pred.Update(event.UpdateEvent{
-			ObjectOld: oldHC,
-			ObjectNew: hc,
-		})
-		assert.True(t, result)
+	t.Run("Update accepts label change", func(t *testing.T) {
+		old := hc.DeepCopy()
+		old.Labels = map[string]string{"env": "staging"}
+		assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: hc}))
 	})
-
-	t.Run("UpdateFunc rejects HC with no label change", func(t *testing.T) {
-		result := pred.Update(event.UpdateEvent{
-			ObjectOld: hc.DeepCopy(),
-			ObjectNew: hc,
-		})
-		assert.False(t, result)
+	t.Run("Update rejects no change", func(t *testing.T) {
+		assert.False(t, pred.Update(event.UpdateEvent{ObjectOld: hc.DeepCopy(), ObjectNew: hc}))
 	})
-
-	t.Run("DeleteFunc accepts HC deletion", func(t *testing.T) {
-		result := pred.Delete(event.DeleteEvent{Object: hc})
-		assert.True(t, result)
+	t.Run("Delete accepts", func(t *testing.T) {
+		assert.True(t, pred.Delete(event.DeleteEvent{Object: hc}))
 	})
-
-	t.Run("GenericFunc returns false", func(t *testing.T) {
-		result := pred.Generic(event.GenericEvent{Object: hc})
-		assert.False(t, result)
+	t.Run("Generic returns false", func(t *testing.T) {
+		assert.False(t, pred.Generic(event.GenericEvent{Object: hc}))
 	})
 }
 
+// --- Utility tests ---
+
 func TestParseAnnotation(t *testing.T) {
-	t.Run("empty string returns empty map", func(t *testing.T) {
-		result := parseAnnotation("")
-		assert.Empty(t, result)
-	})
-
-	t.Run("single key", func(t *testing.T) {
-		result := parseAnnotation("env")
-		assert.Equal(t, map[string]bool{"env": true}, result)
-	})
-
-	t.Run("multiple keys", func(t *testing.T) {
-		result := parseAnnotation(testAnnotationEnvTeamTier)
-		assert.Equal(t, map[string]bool{"env": true, "team": true, "tier": true}, result)
-	})
+	assert.Empty(t, parseAnnotation(""))
+	assert.Equal(t, map[string]bool{"env": true}, parseAnnotation("env"))
+	assert.Equal(t, map[string]bool{"env": true, "team": true, "tier": true}, parseAnnotation("env,team,tier"))
 }
 
 func TestJoinSortedKeys(t *testing.T) {
-	t.Run("empty map returns empty string", func(t *testing.T) {
-		result := joinSortedKeys(map[string]bool{})
-		assert.Equal(t, "", result)
-	})
-
-	t.Run("keys are sorted alphabetically", func(t *testing.T) {
-		result := joinSortedKeys(map[string]bool{"team": true, "env": true, "tier": true})
-		assert.Equal(t, testAnnotationEnvTeamTier, result)
-	})
+	assert.Equal(t, "", joinSortedKeys(map[string]bool{}))
+	assert.Equal(t, "env,team,tier", joinSortedKeys(map[string]bool{"team": true, "env": true, "tier": true}))
 }
 
-func TestFindHostedCluster(t *testing.T) {
-	t.Run("duplicate HC names skips propagation", func(t *testing.T) {
-		spoke, _ := initLabelSyncClient(t)
-		zapLog, _ := zap.NewDevelopment()
-		ctx := context.Background()
+// --- findHostedCluster tests ---
 
-		lc := &LabelAgent{
-			spokeClient: spoke,
-			log:         zapr.NewLogger(zapLog),
-		}
+func TestFindHostedCluster(t *testing.T) {
+	t.Run("duplicate HC names returns ambiguous error", func(t *testing.T) {
+		spoke, _ := initLabelSyncClient(t)
+		ctx := context.Background()
+		lc := newLabelAgent(t, spoke, nil, "mce")
 
 		spokeMC := &clusterv1.ManagedCluster{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1573,30 +994,22 @@ func TestFindHostedCluster(t *testing.T) {
 				Annotations: map[string]string{createdViaAnno: createdViaHypershift},
 			},
 		}
-		hc1 := &hyperv1beta1.HostedCluster{
+		assert.Nil(t, spoke.Create(ctx, &hyperv1beta1.HostedCluster{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-hc", Namespace: "ns-a"},
-		}
-		hc2 := &hyperv1beta1.HostedCluster{
+		}))
+		assert.Nil(t, spoke.Create(ctx, &hyperv1beta1.HostedCluster{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-hc", Namespace: "ns-b"},
-		}
-
-		assert.Nil(t, spoke.Create(ctx, hc1))
-		assert.Nil(t, spoke.Create(ctx, hc2))
+		}))
 
 		result, err := lc.findHostedCluster(ctx, spokeMC)
-		assert.Nil(t, err)
-		assert.Nil(t, result, "should return nil when multiple HCs match by name")
+		assert.ErrorIs(t, err, errAmbiguousHCMatch)
+		assert.Nil(t, result)
 	})
 
 	t.Run("infraID match takes priority over name", func(t *testing.T) {
 		spoke, _ := initLabelSyncClient(t)
-		zapLog, _ := zap.NewDevelopment()
 		ctx := context.Background()
-
-		lc := &LabelAgent{
-			spokeClient: spoke,
-			log:         zapr.NewLogger(zapLog),
-		}
+		lc := newLabelAgent(t, spoke, nil, "mce")
 
 		spokeMC := &clusterv1.ManagedCluster{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1605,52 +1018,39 @@ func TestFindHostedCluster(t *testing.T) {
 				Labels:      map[string]string{testAutoCreatedForInfra: "my-hc-xyz99"},
 			},
 		}
-		hc := &hyperv1beta1.HostedCluster{
+		assert.Nil(t, spoke.Create(ctx, &hyperv1beta1.HostedCluster{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-hc", Namespace: "clusters"},
 			Spec:       hyperv1beta1.HostedClusterSpec{InfraID: "my-hc-xyz99"},
-		}
-
-		assert.Nil(t, spoke.Create(ctx, hc))
+		}))
 
 		result, err := lc.findHostedCluster(ctx, spokeMC)
 		assert.Nil(t, err)
 		assert.NotNil(t, result)
 		assert.Equal(t, "my-hc", result.Name)
-		assert.Equal(t, "clusters", result.Namespace)
 	})
 
 	t.Run("annotation match takes priority over infraID", func(t *testing.T) {
 		spoke, _ := initLabelSyncClient(t)
-		zapLog, _ := zap.NewDevelopment()
 		ctx := context.Background()
-
-		lc := &LabelAgent{
-			spokeClient: spoke,
-			log:         zapr.NewLogger(zapLog),
-		}
+		lc := newLabelAgent(t, spoke, nil, "mce")
 
 		spokeMC := &clusterv1.ManagedCluster{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        "custom-name",
+				Name:        testCustomMCName,
 				Annotations: map[string]string{createdViaAnno: createdViaHypershift},
 				Labels:      map[string]string{testAutoCreatedForInfra: "my-hc-xyz99"},
 			},
 		}
-		hcByAnno := &hyperv1beta1.HostedCluster{
+		assert.Nil(t, spoke.Create(ctx, &hyperv1beta1.HostedCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "my-hc", Namespace: "clusters",
-				Annotations: map[string]string{
-					util.ManagedClusterAnnoKey: "custom-name",
-				},
+				Annotations: map[string]string{util.ManagedClusterAnnoKey: testCustomMCName},
 			},
-		}
-		hcByInfra := &hyperv1beta1.HostedCluster{
+		}))
+		assert.Nil(t, spoke.Create(ctx, &hyperv1beta1.HostedCluster{
 			ObjectMeta: metav1.ObjectMeta{Name: "other-hc", Namespace: "other-ns"},
 			Spec:       hyperv1beta1.HostedClusterSpec{InfraID: "my-hc-xyz99"},
-		}
-
-		assert.Nil(t, spoke.Create(ctx, hcByAnno))
-		assert.Nil(t, spoke.Create(ctx, hcByInfra))
+		}))
 
 		result, err := lc.findHostedCluster(ctx, spokeMC)
 		assert.Nil(t, err)

--- a/pkg/agent/managedcluster_sync_controller_test.go
+++ b/pkg/agent/managedcluster_sync_controller_test.go
@@ -563,7 +563,10 @@ func TestLabelPropagation(t *testing.T) {
 			spokeHostedCluster: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "hostedcluster",
-					Annotations: map[string]string{createdViaAnno: createdViaHypershift, propagatedLabelAnnotation: testAnnotationEnvTeamTier},
+					Annotations: map[string]string{
+						createdViaAnno:             createdViaHypershift,
+						propagatedLabelAnnotation:  testAnnotationEnvTeamTier,
+					},
 					Labels:      map[string]string{},
 				},
 			},
@@ -659,7 +662,7 @@ type hcLabelTestCase struct {
 	expectedHubAnnoKeysOnSpoke []string
 }
 
-func hcLabelTestCases() []hcLabelTestCase {
+func hcLabelBasicCases() []hcLabelTestCase {
 	return []hcLabelTestCase{
 		{
 			name: "HC label propagated to spoke and hub",
@@ -684,7 +687,7 @@ func hcLabelTestCases() []hcLabelTestCase {
 			expectedHCAnnoKeysOnHub:   []string{"env"},
 		},
 		{
-			name: "HC label overrides existing spoke label",
+			name: "HC skips existing untracked spoke label",
 			spokeMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "my-hc",
@@ -701,16 +704,18 @@ func hcLabelTestCases() []hcLabelTestCase {
 			hubMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: testHubMCName},
 			},
-			expectedSpokeLabels:      map[string]string{"env": "prod"},
-			expectedHCAnnoKeysOnSpoke: []string{"env"},
+			expectedSpokeLabels: map[string]string{"env": "old-local"},
 		},
 		{
-			name: "HC label overrides hub-tracked label on spoke",
+			name: "HC skips hub-tracked label on spoke when not HC-tracked",
 			spokeMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "my-hc",
-					Annotations: map[string]string{createdViaAnno: createdViaHypershift, propagatedLabelAnnotation: "env"},
-					Labels:      map[string]string{"env": "staging"},
+					Name: "my-hc",
+					Annotations: map[string]string{
+						createdViaAnno:            createdViaHypershift,
+						propagatedLabelAnnotation: "env",
+					},
+					Labels: map[string]string{"env": "staging"},
 				},
 			},
 			hc: &hyperv1beta1.HostedCluster{
@@ -725,10 +730,8 @@ func hcLabelTestCases() []hcLabelTestCase {
 					Labels: map[string]string{"env": "staging"},
 				},
 			},
-			expectedSpokeLabels:      map[string]string{"env": "prod"},
-			expectedHCAnnoKeysOnSpoke: []string{"env"},
-			expectedHubLabels:        map[string]string{"env": "prod"},
-			expectedHCAnnoKeysOnHub:   []string{"env"},
+			expectedSpokeLabels:       map[string]string{"env": "staging"},
+			expectedHubAnnoKeysOnSpoke: []string{"env"},
 		},
 		{
 			name: "HC system labels are not propagated",
@@ -742,7 +745,7 @@ func hcLabelTestCases() []hcLabelTestCase {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "my-hc", Namespace: "clusters",
 					Labels: map[string]string{
-						"env": "prod",
+						"env":                  "prod",
 						testAutoCreatedForInfra: "test-infra",
 					},
 				},
@@ -755,13 +758,21 @@ func hcLabelTestCases() []hcLabelTestCase {
 			expectedHCAnnoKeysOnSpoke: []string{"env"},
 			notExpectedHubLabels:      []string{testAutoCreatedForInfra},
 		},
+	}
+}
+
+func hcLabelAdvancedCases() []hcLabelTestCase {
+	return []hcLabelTestCase{
 		{
 			name: "HC label removed - cleaned from spoke and hub",
 			spokeMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "my-hc",
-					Annotations: map[string]string{createdViaAnno: createdViaHypershift, hcPropagatedLabelAnnotation: "env"},
-					Labels:      map[string]string{"env": "prod", "local": "keep"},
+					Name: "my-hc",
+					Annotations: map[string]string{
+						createdViaAnno:              createdViaHypershift,
+						hcPropagatedLabelAnnotation: "env",
+					},
+					Labels: map[string]string{"env": "prod", "local": "keep"},
 				},
 			},
 			hc: &hyperv1beta1.HostedCluster{
@@ -815,8 +826,10 @@ func hcLabelTestCases() []hcLabelTestCase {
 			hc: &hyperv1beta1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "my-hc", Namespace: "clusters",
-					Labels:      map[string]string{"env": "prod"},
-					Annotations: map[string]string{util.ManagedClusterAnnoKey: "custom-mc-name"},
+					Labels: map[string]string{"env": "prod"},
+					Annotations: map[string]string{
+						util.ManagedClusterAnnoKey: "custom-mc-name",
+					},
 				},
 			},
 			hubMC: &clusterv1.ManagedCluster{
@@ -825,7 +838,37 @@ func hcLabelTestCases() []hcLabelTestCase {
 			expectedSpokeLabels:      map[string]string{"env": "prod"},
 			expectedHCAnnoKeysOnSpoke: []string{"env"},
 		},
+		{
+			name: "HC matched by infraID when MC has auto-created-for-infra label",
+			spokeMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-hc",
+					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
+					Labels: map[string]string{
+						testAutoCreatedForInfra: "my-hc-abc12",
+					},
+				},
+			},
+			hc: &hyperv1beta1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-hc", Namespace: "clusters",
+					Labels: map[string]string{"env": "prod"},
+				},
+				Spec: hyperv1beta1.HostedClusterSpec{
+					InfraID: "my-hc-abc12",
+				},
+			},
+			hubMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: testHubMCName},
+			},
+			expectedSpokeLabels:      map[string]string{"env": "prod"},
+			expectedHCAnnoKeysOnSpoke: []string{"env"},
+		},
 	}
+}
+
+func hcLabelTestCases() []hcLabelTestCase {
+	return append(hcLabelBasicCases(), hcLabelAdvancedCases()...)
 }
 
 func runHCLabelTest(t *testing.T, tt hcLabelTestCase) {
@@ -1008,7 +1051,8 @@ func TestHubSyncSkipsHCOwnedLabels(t *testing.T) {
 	retrieved := &clusterv1.ManagedCluster{}
 	assert.Nil(t, spoke.Get(ctx, types.NamespacedName{Name: "my-hc"}, retrieved))
 
-	assert.Equal(t, "prod", retrieved.Labels["env"], "HC value should win over hub")
+	// HC env=prod is new to spoke (spoke had no env) → HC adds it and tracks it
+	assert.Equal(t, "prod", retrieved.Labels["env"], "HC env should be added since spoke had no env")
 	assert.Equal(t, "platform", retrieved.Labels["team"], "admin hub label should be propagated")
 
 	assert.Contains(t, retrieved.Annotations[hcPropagatedLabelAnnotation], "env")
@@ -1509,5 +1553,108 @@ func TestJoinSortedKeys(t *testing.T) {
 	t.Run("keys are sorted alphabetically", func(t *testing.T) {
 		result := joinSortedKeys(map[string]bool{"team": true, "env": true, "tier": true})
 		assert.Equal(t, testAnnotationEnvTeamTier, result)
+	})
+}
+
+func TestFindHostedCluster(t *testing.T) {
+	t.Run("duplicate HC names skips propagation", func(t *testing.T) {
+		spoke, _ := initLabelSyncClient(t)
+		zapLog, _ := zap.NewDevelopment()
+		ctx := context.Background()
+
+		lc := &LabelAgent{
+			spokeClient: spoke,
+			log:         zapr.NewLogger(zapLog),
+		}
+
+		spokeMC := &clusterv1.ManagedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "my-hc",
+				Annotations: map[string]string{createdViaAnno: createdViaHypershift},
+			},
+		}
+		hc1 := &hyperv1beta1.HostedCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-hc", Namespace: "ns-a"},
+		}
+		hc2 := &hyperv1beta1.HostedCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-hc", Namespace: "ns-b"},
+		}
+
+		assert.Nil(t, spoke.Create(ctx, hc1))
+		assert.Nil(t, spoke.Create(ctx, hc2))
+
+		result, err := lc.findHostedCluster(ctx, spokeMC)
+		assert.Nil(t, err)
+		assert.Nil(t, result, "should return nil when multiple HCs match by name")
+	})
+
+	t.Run("infraID match takes priority over name", func(t *testing.T) {
+		spoke, _ := initLabelSyncClient(t)
+		zapLog, _ := zap.NewDevelopment()
+		ctx := context.Background()
+
+		lc := &LabelAgent{
+			spokeClient: spoke,
+			log:         zapr.NewLogger(zapLog),
+		}
+
+		spokeMC := &clusterv1.ManagedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "my-hc",
+				Annotations: map[string]string{createdViaAnno: createdViaHypershift},
+				Labels:      map[string]string{testAutoCreatedForInfra: "my-hc-xyz99"},
+			},
+		}
+		hc := &hyperv1beta1.HostedCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-hc", Namespace: "clusters"},
+			Spec:       hyperv1beta1.HostedClusterSpec{InfraID: "my-hc-xyz99"},
+		}
+
+		assert.Nil(t, spoke.Create(ctx, hc))
+
+		result, err := lc.findHostedCluster(ctx, spokeMC)
+		assert.Nil(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "my-hc", result.Name)
+		assert.Equal(t, "clusters", result.Namespace)
+	})
+
+	t.Run("annotation match takes priority over infraID", func(t *testing.T) {
+		spoke, _ := initLabelSyncClient(t)
+		zapLog, _ := zap.NewDevelopment()
+		ctx := context.Background()
+
+		lc := &LabelAgent{
+			spokeClient: spoke,
+			log:         zapr.NewLogger(zapLog),
+		}
+
+		spokeMC := &clusterv1.ManagedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "custom-name",
+				Annotations: map[string]string{createdViaAnno: createdViaHypershift},
+				Labels:      map[string]string{testAutoCreatedForInfra: "my-hc-xyz99"},
+			},
+		}
+		hcByAnno := &hyperv1beta1.HostedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-hc", Namespace: "clusters",
+				Annotations: map[string]string{
+					util.ManagedClusterAnnoKey: "custom-name",
+				},
+			},
+		}
+		hcByInfra := &hyperv1beta1.HostedCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "other-hc", Namespace: "other-ns"},
+			Spec:       hyperv1beta1.HostedClusterSpec{InfraID: "my-hc-xyz99"},
+		}
+
+		assert.Nil(t, spoke.Create(ctx, hcByAnno))
+		assert.Nil(t, spoke.Create(ctx, hcByInfra))
+
+		result, err := lc.findHostedCluster(ctx, spokeMC)
+		assert.Nil(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "my-hc", result.Name, "annotation match should win")
 	})
 }

--- a/pkg/agent/managedcluster_sync_controller_test.go
+++ b/pkg/agent/managedcluster_sync_controller_test.go
@@ -22,6 +22,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+const (
+	testAnnotationEnvTeamTier = "env,team,tier"
+	testHubMCName             = "mce-my-hc"
+	testAutoCreatedForInfra   = "hypershift.openshift.io/auto-created-for-infra"
+)
+
 func strPtr(s string) *string { return &s }
 
 func initLabelSyncClient(t *testing.T) (client.Client, client.Client) {
@@ -557,7 +563,7 @@ func TestLabelPropagation(t *testing.T) {
 			spokeHostedCluster: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "hostedcluster",
-					Annotations: map[string]string{createdViaAnno: createdViaHypershift, propagatedLabelAnnotation: "env,team,tier"},
+					Annotations: map[string]string{createdViaAnno: createdViaHypershift, propagatedLabelAnnotation: testAnnotationEnvTeamTier},
 					Labels:      map[string]string{},
 				},
 			},
@@ -639,20 +645,22 @@ func TestLabelPropagation(t *testing.T) {
 	}
 }
 
-func TestHCLabelPropagation(t *testing.T) {
-	tests := []struct {
-		name                       string
-		spokeMC                    *clusterv1.ManagedCluster
-		hc                         *hyperv1beta1.HostedCluster
-		hubMC                      *clusterv1.ManagedCluster
-		expectedSpokeLabels        map[string]string
-		notExpectedSpokeLabels     []string
-		expectedHubLabels          map[string]string
-		notExpectedHubLabels       []string
-		expectedHCAnnoKeysOnSpoke  []string
-		expectedHCAnnoKeysOnHub    []string
-		expectedHubAnnoKeysOnSpoke []string
-	}{
+type hcLabelTestCase struct {
+	name                       string
+	spokeMC                    *clusterv1.ManagedCluster
+	hc                         *hyperv1beta1.HostedCluster
+	hubMC                      *clusterv1.ManagedCluster
+	expectedSpokeLabels        map[string]string
+	notExpectedSpokeLabels     []string
+	expectedHubLabels          map[string]string
+	notExpectedHubLabels       []string
+	expectedHCAnnoKeysOnSpoke  []string
+	expectedHCAnnoKeysOnHub    []string
+	expectedHubAnnoKeysOnSpoke []string
+}
+
+func hcLabelTestCases() []hcLabelTestCase {
+	return []hcLabelTestCase{
 		{
 			name: "HC label propagated to spoke and hub",
 			spokeMC: &clusterv1.ManagedCluster{
@@ -668,7 +676,7 @@ func TestHCLabelPropagation(t *testing.T) {
 				},
 			},
 			hubMC: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: "mce-my-hc"},
+				ObjectMeta: metav1.ObjectMeta{Name: testHubMCName},
 			},
 			expectedSpokeLabels:      map[string]string{"env": "prod"},
 			expectedHubLabels:        map[string]string{"env": "prod"},
@@ -691,7 +699,7 @@ func TestHCLabelPropagation(t *testing.T) {
 				},
 			},
 			hubMC: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: "mce-my-hc"},
+				ObjectMeta: metav1.ObjectMeta{Name: testHubMCName},
 			},
 			expectedSpokeLabels:      map[string]string{"env": "prod"},
 			expectedHCAnnoKeysOnSpoke: []string{"env"},
@@ -713,7 +721,7 @@ func TestHCLabelPropagation(t *testing.T) {
 			},
 			hubMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "mce-my-hc",
+					Name:   testHubMCName,
 					Labels: map[string]string{"env": "staging"},
 				},
 			},
@@ -734,18 +742,18 @@ func TestHCLabelPropagation(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "my-hc", Namespace: "clusters",
 					Labels: map[string]string{
-						"env":                       "prod",
-						"hypershift.openshift.io/auto-created-for-infra": "test-infra",
+						"env": "prod",
+						testAutoCreatedForInfra: "test-infra",
 					},
 				},
 			},
 			hubMC: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: "mce-my-hc"},
+				ObjectMeta: metav1.ObjectMeta{Name: testHubMCName},
 			},
-			expectedSpokeLabels:       map[string]string{"env": "prod"},
-			notExpectedSpokeLabels:     []string{"hypershift.openshift.io/auto-created-for-infra"},
-			expectedHCAnnoKeysOnSpoke:  []string{"env"},
-			notExpectedHubLabels:       []string{"hypershift.openshift.io/auto-created-for-infra"},
+			expectedSpokeLabels:      map[string]string{"env": "prod"},
+			notExpectedSpokeLabels:    []string{testAutoCreatedForInfra},
+			expectedHCAnnoKeysOnSpoke: []string{"env"},
+			notExpectedHubLabels:      []string{testAutoCreatedForInfra},
 		},
 		{
 			name: "HC label removed - cleaned from spoke and hub",
@@ -763,7 +771,7 @@ func TestHCLabelPropagation(t *testing.T) {
 			},
 			hubMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "mce-my-hc",
+					Name:        testHubMCName,
 					Annotations: map[string]string{hcPropagatedLabelAnnotation: "env"},
 					Labels:      map[string]string{"env": "prod"},
 				},
@@ -788,7 +796,7 @@ func TestHCLabelPropagation(t *testing.T) {
 			},
 			hubMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "mce-my-hc",
+					Name:   testHubMCName,
 					Labels: map[string]string{"team": "platform"},
 				},
 			},
@@ -818,77 +826,84 @@ func TestHCLabelPropagation(t *testing.T) {
 			expectedHCAnnoKeysOnSpoke: []string{"env"},
 		},
 	}
+}
 
-	for _, tt := range tests {
+func runHCLabelTest(t *testing.T, tt hcLabelTestCase) {
+	t.Helper()
+	ctx := context.Background()
+	spoke, hub := initLabelSyncClient(t)
+	zapLog, _ := zap.NewDevelopment()
+	os.Unsetenv("DISCOVERY_PREFIX")
+
+	lc := &LabelAgent{
+		hubClient:        hub,
+		spokeClient:      spoke,
+		clusterName:      "mce",
+		localClusterName: "local-cluster",
+		log:              zapr.NewLogger(zapLog),
+	}
+
+	assert.Nil(t, spoke.Create(ctx, tt.spokeMC))
+	if tt.hc != nil {
+		assert.Nil(t, spoke.Create(ctx, tt.hc))
+	}
+	if tt.hubMC != nil {
+		assert.Nil(t, hub.Create(ctx, tt.hubMC))
+	}
+
+	_, err := lc.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: tt.spokeMC.Name},
+	})
+	assert.Nil(t, err)
+
+	retrievedSpoke := &clusterv1.ManagedCluster{}
+	assert.Nil(t, spoke.Get(ctx, types.NamespacedName{Name: tt.spokeMC.Name}, retrievedSpoke))
+
+	for key, val := range tt.expectedSpokeLabels {
+		assert.Equal(t, val, retrievedSpoke.Labels[key], "spoke label %s mismatch", key)
+	}
+	for _, key := range tt.notExpectedSpokeLabels {
+		_, exists := retrievedSpoke.Labels[key]
+		assert.False(t, exists, "spoke label %s should not exist", key)
+	}
+
+	if tt.expectedHCAnnoKeysOnSpoke != nil {
+		anno := retrievedSpoke.Annotations[hcPropagatedLabelAnnotation]
+		for _, key := range tt.expectedHCAnnoKeysOnSpoke {
+			assert.Contains(t, anno, key, "spoke hc-tracking annotation should contain %s", key)
+		}
+	}
+	if tt.expectedHubAnnoKeysOnSpoke != nil {
+		anno := retrievedSpoke.Annotations[propagatedLabelAnnotation]
+		for _, key := range tt.expectedHubAnnoKeysOnSpoke {
+			assert.Contains(t, anno, key, "spoke hub-tracking annotation should contain %s", key)
+		}
+	}
+
+	if tt.hubMC != nil {
+		retrievedHub := &clusterv1.ManagedCluster{}
+		assert.Nil(t, hub.Get(ctx, types.NamespacedName{Name: tt.hubMC.Name}, retrievedHub))
+
+		for key, val := range tt.expectedHubLabels {
+			assert.Equal(t, val, retrievedHub.Labels[key], "hub label %s mismatch", key)
+		}
+		for _, key := range tt.notExpectedHubLabels {
+			_, exists := retrievedHub.Labels[key]
+			assert.False(t, exists, "hub label %s should not exist", key)
+		}
+		if tt.expectedHCAnnoKeysOnHub != nil {
+			anno := retrievedHub.Annotations[hcPropagatedLabelAnnotation]
+			for _, key := range tt.expectedHCAnnoKeysOnHub {
+				assert.Contains(t, anno, key, "hub hc-tracking annotation should contain %s", key)
+			}
+		}
+	}
+}
+
+func TestHCLabelPropagation(t *testing.T) {
+	for _, tt := range hcLabelTestCases() {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
-			spoke, hub := initLabelSyncClient(t)
-			zapLog, _ := zap.NewDevelopment()
-			os.Unsetenv("DISCOVERY_PREFIX")
-
-			lc := &LabelAgent{
-				hubClient:        hub,
-				spokeClient:      spoke,
-				clusterName:      "mce",
-				localClusterName: "local-cluster",
-				log:              zapr.NewLogger(zapLog),
-			}
-
-			assert.Nil(t, spoke.Create(ctx, tt.spokeMC))
-			if tt.hc != nil {
-				assert.Nil(t, spoke.Create(ctx, tt.hc))
-			}
-			if tt.hubMC != nil {
-				assert.Nil(t, hub.Create(ctx, tt.hubMC))
-			}
-
-			_, err := lc.Reconcile(ctx, ctrl.Request{
-				NamespacedName: types.NamespacedName{Name: tt.spokeMC.Name},
-			})
-			assert.Nil(t, err)
-
-			retrievedSpoke := &clusterv1.ManagedCluster{}
-			assert.Nil(t, spoke.Get(ctx, types.NamespacedName{Name: tt.spokeMC.Name}, retrievedSpoke))
-
-			for key, val := range tt.expectedSpokeLabels {
-				assert.Equal(t, val, retrievedSpoke.Labels[key], "spoke label %s mismatch", key)
-			}
-			for _, key := range tt.notExpectedSpokeLabels {
-				_, exists := retrievedSpoke.Labels[key]
-				assert.False(t, exists, "spoke label %s should not exist", key)
-			}
-
-			if tt.expectedHCAnnoKeysOnSpoke != nil {
-				anno := retrievedSpoke.Annotations[hcPropagatedLabelAnnotation]
-				for _, key := range tt.expectedHCAnnoKeysOnSpoke {
-					assert.Contains(t, anno, key, "spoke hc-tracking annotation should contain %s", key)
-				}
-			}
-			if tt.expectedHubAnnoKeysOnSpoke != nil {
-				anno := retrievedSpoke.Annotations[propagatedLabelAnnotation]
-				for _, key := range tt.expectedHubAnnoKeysOnSpoke {
-					assert.Contains(t, anno, key, "spoke hub-tracking annotation should contain %s", key)
-				}
-			}
-
-			if tt.hubMC != nil {
-				retrievedHub := &clusterv1.ManagedCluster{}
-				assert.Nil(t, hub.Get(ctx, types.NamespacedName{Name: tt.hubMC.Name}, retrievedHub))
-
-				for key, val := range tt.expectedHubLabels {
-					assert.Equal(t, val, retrievedHub.Labels[key], "hub label %s mismatch", key)
-				}
-				for _, key := range tt.notExpectedHubLabels {
-					_, exists := retrievedHub.Labels[key]
-					assert.False(t, exists, "hub label %s should not exist", key)
-				}
-				if tt.expectedHCAnnoKeysOnHub != nil {
-					anno := retrievedHub.Annotations[hcPropagatedLabelAnnotation]
-					for _, key := range tt.expectedHCAnnoKeysOnHub {
-						assert.Contains(t, anno, key, "hub hc-tracking annotation should contain %s", key)
-					}
-				}
-			}
+			runHCLabelTest(t, tt)
 		})
 	}
 }
@@ -919,7 +934,7 @@ func TestHCDeletedCleansUpLabels(t *testing.T) {
 	}
 	hubMC := &clusterv1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "mce-my-hc",
+			Name:        testHubMCName,
 			Annotations: map[string]string{hcPropagatedLabelAnnotation: "env,tier"},
 			Labels:      map[string]string{"env": "prod", "tier": "frontend", "admin-label": "keep"},
 		},
@@ -942,7 +957,7 @@ func TestHCDeletedCleansUpLabels(t *testing.T) {
 	assert.False(t, tierExists, "tier should be removed from spoke after HC deleted")
 
 	retrievedHub := &clusterv1.ManagedCluster{}
-	assert.Nil(t, hub.Get(ctx, types.NamespacedName{Name: "mce-my-hc"}, retrievedHub))
+	assert.Nil(t, hub.Get(ctx, types.NamespacedName{Name: testHubMCName}, retrievedHub))
 	assert.Equal(t, "keep", retrievedHub.Labels["admin-label"])
 	_, envExists = retrievedHub.Labels["env"]
 	assert.False(t, envExists, "env should be removed from hub after HC deleted")
@@ -976,7 +991,7 @@ func TestHubSyncSkipsHCOwnedLabels(t *testing.T) {
 	}
 	hubMC := &clusterv1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "mce-my-hc",
+			Name:   testHubMCName,
 			Labels: map[string]string{"env": "staging", "team": "platform"},
 		},
 	}
@@ -1480,7 +1495,7 @@ func TestParseAnnotation(t *testing.T) {
 	})
 
 	t.Run("multiple keys", func(t *testing.T) {
-		result := parseAnnotation("env,team,tier")
+		result := parseAnnotation(testAnnotationEnvTeamTier)
 		assert.Equal(t, map[string]bool{"env": true, "team": true, "tier": true}, result)
 	})
 }
@@ -1493,6 +1508,6 @@ func TestJoinSortedKeys(t *testing.T) {
 
 	t.Run("keys are sorted alphabetically", func(t *testing.T) {
 		result := joinSortedKeys(map[string]bool{"team": true, "env": true, "tier": true})
-		assert.Equal(t, "env,team,tier", result)
+		assert.Equal(t, testAnnotationEnvTeamTier, result)
 	})
 }

--- a/pkg/agent/managedcluster_sync_controller_test.go
+++ b/pkg/agent/managedcluster_sync_controller_test.go
@@ -26,6 +26,12 @@ const (
 	testHubMCName           = "mce-my-hc"
 	testAutoCreatedForInfra = "hypershift.openshift.io/auto-created-for-infra"
 	testCustomMCName        = "custom-name"
+	testLocalClusterName    = "local-cluster"
+	testHubMCNameDefault    = "mce-hc1"
+	testLocalVal            = "local-val"
+	testAnnotationEnvTeam   = "env,team"
+	testClusterMCE          = "cluster-mce"
+	testInfraID             = "my-hc-xyz99"
 )
 
 func strPtr(s string) *string { return &s }
@@ -44,7 +50,7 @@ func newLabelAgent(t *testing.T, spoke, hub client.Client, clusterName string) *
 		hubClient:        hub,
 		spokeClient:      spoke,
 		clusterName:      clusterName,
-		localClusterName: "local-cluster",
+		localClusterName: testLocalClusterName,
 		log:              zapr.NewLogger(zapLog),
 	}
 }
@@ -85,7 +91,7 @@ func TestLabelPropagation(t *testing.T) {
 			},
 			hubMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "mce-hc1",
+					Name:   testHubMCNameDefault,
 					Labels: map[string]string{"env": "prod", "team": "backend"},
 				},
 			},
@@ -99,17 +105,17 @@ func TestLabelPropagation(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "hc1",
 					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
-					Labels:      map[string]string{"env": "local-val"},
+					Labels:      map[string]string{"env": testLocalVal},
 				},
 			},
 			hubMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "mce-hc1",
+					Name:   testHubMCNameDefault,
 					Labels: map[string]string{"env": "hub-val"},
 				},
 			},
 			clusterName:    "mce",
-			expectedLabels: map[string]string{"env": "local-val"},
+			expectedLabels: map[string]string{"env": testLocalVal},
 		},
 		{
 			name: "tracked label overridden by hub",
@@ -125,7 +131,7 @@ func TestLabelPropagation(t *testing.T) {
 			},
 			hubMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "mce-hc1",
+					Name:   testHubMCNameDefault,
 					Labels: map[string]string{"env": "new"},
 				},
 			},
@@ -142,7 +148,7 @@ func TestLabelPropagation(t *testing.T) {
 			},
 			hubMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "mce-hc1",
+					Name: testHubMCNameDefault,
 					Labels: map[string]string{
 						"vendor": "OpenShift", "cloud": "Amazon", "region": "us-east-1",
 						"feature.open-cluster-management.io/addon-search": "available",
@@ -161,14 +167,14 @@ func TestLabelPropagation(t *testing.T) {
 					Name: "hc1",
 					Annotations: map[string]string{
 						createdViaAnno:            createdViaHypershift,
-						propagatedLabelAnnotation: "env,team",
+						propagatedLabelAnnotation: testAnnotationEnvTeam,
 					},
 					Labels: map[string]string{"env": "prod", "team": "backend", "local": "keep"},
 				},
 			},
 			hubMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "mce-hc1",
+					Name:   testHubMCNameDefault,
 					Labels: map[string]string{"env": "prod"},
 				},
 			},
@@ -183,7 +189,7 @@ func TestLabelPropagation(t *testing.T) {
 					Name: "hc1",
 					Annotations: map[string]string{
 						createdViaAnno:            createdViaHypershift,
-						propagatedLabelAnnotation: "env,team",
+						propagatedLabelAnnotation: testAnnotationEnvTeam,
 					},
 					Labels: map[string]string{"env": "prod", "team": "backend", "local": "keep"},
 				},
@@ -226,8 +232,8 @@ func TestLabelPropagation(t *testing.T) {
 					Labels: map[string]string{"env": "prod"},
 				},
 			},
-			clusterName:       "local-cluster",
-			localClusterName:  "local-cluster",
+			clusterName:       testLocalClusterName,
+			localClusterName:  testLocalClusterName,
 			expectedLabels:    map[string]string{"existing": "value"},
 			notExpectedLabels: []string{"env"},
 		},
@@ -241,7 +247,7 @@ func TestLabelPropagation(t *testing.T) {
 			},
 			hubMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "mce-hc1",
+					Name:   testHubMCNameDefault,
 					Labels: map[string]string{"env": "prod"},
 				},
 			},
@@ -263,7 +269,7 @@ func TestLabelPropagation(t *testing.T) {
 			},
 			hubMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "mce-hc1",
+					Name:   testHubMCNameDefault,
 					Labels: map[string]string{"env": "prod"},
 				},
 			},
@@ -281,7 +287,7 @@ func TestLabelPropagation(t *testing.T) {
 			},
 			hubMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "mce-hc1",
+					Name:   testHubMCNameDefault,
 					Labels: map[string]string{"env": "prod"},
 				},
 			},
@@ -306,7 +312,7 @@ func TestLabelPropagation(t *testing.T) {
 			},
 			hubMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "mce-hc1",
+					Name:   testHubMCNameDefault,
 					Labels: map[string]string{"env": "staging", "team": "backend"},
 				},
 			},
@@ -329,7 +335,7 @@ func TestLabelPropagation(t *testing.T) {
 				os.Unsetenv("DISCOVERY_PREFIX")
 			}
 
-			localCluster := "local-cluster"
+			localCluster := testLocalClusterName
 			if tt.localClusterName != "" {
 				localCluster = tt.localClusterName
 			}
@@ -377,7 +383,7 @@ type hcLabelTestCase struct {
 	expectedHubAnnoKeysOnSpoke []string
 }
 
-func hcLabelTestCases() []hcLabelTestCase {
+func hcLabelSyncCases() []hcLabelTestCase {
 	return []hcLabelTestCase{
 		{
 			name: "HC label propagated to spoke and hub",
@@ -407,7 +413,7 @@ func hcLabelTestCases() []hcLabelTestCase {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "my-hc",
 					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
-					Labels:      map[string]string{"env": "local-val"},
+					Labels:      map[string]string{"env": testLocalVal},
 				},
 			},
 			hc: &hyperv1beta1.HostedCluster{
@@ -419,7 +425,7 @@ func hcLabelTestCases() []hcLabelTestCase {
 			hubMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: testHubMCName},
 			},
-			expectedSpokeLabels: map[string]string{"env": "local-val"},
+			expectedSpokeLabels: map[string]string{"env": testLocalVal},
 		},
 		{
 			name: "HC skips hub-tracked label when not HC-tracked",
@@ -474,6 +480,32 @@ func hcLabelTestCases() []hcLabelTestCase {
 			notExpectedHubLabels:      []string{testAutoCreatedForInfra},
 		},
 		{
+			name: "HC annotation match maps to correct MC",
+			spokeMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "custom-mc-name",
+					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
+				},
+			},
+			hc: &hyperv1beta1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-hc", Namespace: "clusters",
+					Labels:      map[string]string{"env": "prod"},
+					Annotations: map[string]string{util.ManagedClusterAnnoKey: "custom-mc-name"},
+				},
+			},
+			hubMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "mce-custom-mc-name"},
+			},
+			expectedSpokeLabels:      map[string]string{"env": "prod"},
+			expectedHCAnnoKeysOnSpoke: []string{"env"},
+		},
+	}
+}
+
+func hcLabelCleanupCases() []hcLabelTestCase {
+	return []hcLabelTestCase{
+		{
 			name: "HC label removed cleans up spoke and hub",
 			spokeMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -522,27 +554,6 @@ func hcLabelTestCases() []hcLabelTestCase {
 			expectedSpokeLabels:       map[string]string{"env": "prod", "team": "platform"},
 			expectedHCAnnoKeysOnSpoke:  []string{"env"},
 			expectedHubAnnoKeysOnSpoke: []string{"team"},
-		},
-		{
-			name: "HC annotation match maps to correct MC",
-			spokeMC: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "custom-mc-name",
-					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
-				},
-			},
-			hc: &hyperv1beta1.HostedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "my-hc", Namespace: "clusters",
-					Labels:      map[string]string{"env": "prod"},
-					Annotations: map[string]string{util.ManagedClusterAnnoKey: "custom-mc-name"},
-				},
-			},
-			hubMC: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: "mce-custom-mc-name"},
-			},
-			expectedSpokeLabels:      map[string]string{"env": "prod"},
-			expectedHCAnnoKeysOnSpoke: []string{"env"},
 		},
 		{
 			name: "HC matched by infraID",
@@ -618,6 +629,10 @@ func hcLabelTestCases() []hcLabelTestCase {
 	}
 }
 
+func hcLabelTestCases() []hcLabelTestCase {
+	return append(hcLabelSyncCases(), hcLabelCleanupCases()...)
+}
+
 func runHCLabelTest(t *testing.T, tt hcLabelTestCase) {
 	t.Helper()
 	ctx := context.Background()
@@ -688,7 +703,7 @@ func TestMultiClusterLabelPropagation(t *testing.T) {
 	ctx := context.Background()
 	spoke, hub := initLabelSyncClient(t)
 	os.Unsetenv("DISCOVERY_PREFIX")
-	lc := newLabelAgent(t, spoke, hub, "cluster-mce")
+	lc := newLabelAgent(t, spoke, hub, testClusterMCE)
 
 	type pair struct {
 		spoke          *clusterv1.ManagedCluster
@@ -767,7 +782,7 @@ func TestReconcileDisableDiscovery(t *testing.T) {
 	}
 	hubMC := &clusterv1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "mce-hc1",
+			Name:   testHubMCNameDefault,
 			Labels: map[string]string{"env": "prod"},
 		},
 	}
@@ -811,11 +826,11 @@ func TestGetSpokeMCName(t *testing.T) {
 		discoveryPrefix *string
 		expected        string
 	}{
-		{"default prefix match", "cluster-mce-hc1", "cluster-mce", nil, "hc1"},
-		{"default prefix no match", "other-mce-hc1", "cluster-mce", nil, ""},
-		{"custom prefix match", "custom-hc-web", "cluster-mce", strPtr("custom"), "hc-web"},
-		{"custom prefix no match", "other-hc-web", "cluster-mce", strPtr("custom"), ""},
-		{"empty prefix returns name", "hc1", "cluster-mce", strPtr(""), "hc1"},
+		{"default prefix match", "cluster-mce-hc1", testClusterMCE, nil, "hc1"},
+		{"default prefix no match", "other-mce-hc1", testClusterMCE, nil, ""},
+		{"custom prefix match", "custom-hc-web", testClusterMCE, strPtr("custom"), "hc-web"},
+		{"custom prefix no match", "other-hc-web", testClusterMCE, strPtr("custom"), ""},
+		{"empty prefix returns name", "hc1", testClusterMCE, strPtr(""), "hc1"},
 	}
 
 	for _, tt := range tests {
@@ -836,7 +851,7 @@ func TestGetSpokeMCName(t *testing.T) {
 func TestMapHubMCToSpokeMC(t *testing.T) {
 	zapLog, _ := zap.NewDevelopment()
 	os.Unsetenv("DISCOVERY_PREFIX")
-	lc := &LabelAgent{clusterName: "cluster-mce", log: zapr.NewLogger(zapLog)}
+	lc := &LabelAgent{clusterName: testClusterMCE, log: zapr.NewLogger(zapLog)}
 
 	t.Run("matching hub MC returns request", func(t *testing.T) {
 		mc := &clusterv1.ManagedCluster{ObjectMeta: metav1.ObjectMeta{Name: "cluster-mce-hc1"}}
@@ -914,7 +929,7 @@ func TestLabelEventFilters(t *testing.T) {
 	})
 	t.Run("Update accepts propagated-labels annotation removed", func(t *testing.T) {
 		old := hosted.DeepCopy()
-		old.Annotations[propagatedLabelAnnotation] = "env,team"
+		old.Annotations[propagatedLabelAnnotation] = testAnnotationEnvTeam
 		assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: hosted}))
 	})
 	t.Run("Update accepts hc-propagated-labels annotation removed", func(t *testing.T) {
@@ -1015,12 +1030,12 @@ func TestFindHostedCluster(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "my-hc",
 				Annotations: map[string]string{createdViaAnno: createdViaHypershift},
-				Labels:      map[string]string{testAutoCreatedForInfra: "my-hc-xyz99"},
+				Labels:      map[string]string{testAutoCreatedForInfra: testInfraID},
 			},
 		}
 		assert.Nil(t, spoke.Create(ctx, &hyperv1beta1.HostedCluster{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-hc", Namespace: "clusters"},
-			Spec:       hyperv1beta1.HostedClusterSpec{InfraID: "my-hc-xyz99"},
+			Spec:       hyperv1beta1.HostedClusterSpec{InfraID: testInfraID},
 		}))
 
 		result, err := lc.findHostedCluster(ctx, spokeMC)
@@ -1038,7 +1053,7 @@ func TestFindHostedCluster(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        testCustomMCName,
 				Annotations: map[string]string{createdViaAnno: createdViaHypershift},
-				Labels:      map[string]string{testAutoCreatedForInfra: "my-hc-xyz99"},
+				Labels:      map[string]string{testAutoCreatedForInfra: testInfraID},
 			},
 		}
 		assert.Nil(t, spoke.Create(ctx, &hyperv1beta1.HostedCluster{
@@ -1049,7 +1064,7 @@ func TestFindHostedCluster(t *testing.T) {
 		}))
 		assert.Nil(t, spoke.Create(ctx, &hyperv1beta1.HostedCluster{
 			ObjectMeta: metav1.ObjectMeta{Name: "other-hc", Namespace: "other-ns"},
-			Spec:       hyperv1beta1.HostedClusterSpec{InfraID: "my-hc-xyz99"},
+			Spec:       hyperv1beta1.HostedClusterSpec{InfraID: testInfraID},
 		}))
 
 		result, err := lc.findHostedCluster(ctx, spokeMC)

--- a/pkg/agent/managedcluster_sync_controller_test.go
+++ b/pkg/agent/managedcluster_sync_controller_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/go-logr/zapr"
+	hyperv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/stolostron/hypershift-addon-operator/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -25,6 +27,8 @@ func strPtr(s string) *string { return &s }
 func initLabelSyncClient(t *testing.T) (client.Client, client.Client) {
 	scheme := runtime.NewScheme()
 	err := clusterv1.AddToScheme(scheme)
+	assert.Nil(t, err)
+	err = hyperv1beta1.AddToScheme(scheme)
 	assert.Nil(t, err)
 
 	spokeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
@@ -635,6 +639,369 @@ func TestLabelPropagation(t *testing.T) {
 	}
 }
 
+func TestHCLabelPropagation(t *testing.T) {
+	tests := []struct {
+		name                       string
+		spokeMC                    *clusterv1.ManagedCluster
+		hc                         *hyperv1beta1.HostedCluster
+		hubMC                      *clusterv1.ManagedCluster
+		expectedSpokeLabels        map[string]string
+		notExpectedSpokeLabels     []string
+		expectedHubLabels          map[string]string
+		notExpectedHubLabels       []string
+		expectedHCAnnoKeysOnSpoke  []string
+		expectedHCAnnoKeysOnHub    []string
+		expectedHubAnnoKeysOnSpoke []string
+	}{
+		{
+			name: "HC label propagated to spoke and hub",
+			spokeMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "my-hc",
+					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
+				},
+			},
+			hc: &hyperv1beta1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-hc", Namespace: "clusters",
+					Labels: map[string]string{"env": "prod"},
+				},
+			},
+			hubMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "mce-my-hc"},
+			},
+			expectedSpokeLabels:      map[string]string{"env": "prod"},
+			expectedHubLabels:        map[string]string{"env": "prod"},
+			expectedHCAnnoKeysOnSpoke: []string{"env"},
+			expectedHCAnnoKeysOnHub:   []string{"env"},
+		},
+		{
+			name: "HC label overrides existing spoke label",
+			spokeMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "my-hc",
+					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
+					Labels:      map[string]string{"env": "old-local"},
+				},
+			},
+			hc: &hyperv1beta1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-hc", Namespace: "clusters",
+					Labels: map[string]string{"env": "prod"},
+				},
+			},
+			hubMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "mce-my-hc"},
+			},
+			expectedSpokeLabels:      map[string]string{"env": "prod"},
+			expectedHCAnnoKeysOnSpoke: []string{"env"},
+		},
+		{
+			name: "HC label overrides hub-tracked label on spoke",
+			spokeMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "my-hc",
+					Annotations: map[string]string{createdViaAnno: createdViaHypershift, propagatedLabelAnnotation: "env"},
+					Labels:      map[string]string{"env": "staging"},
+				},
+			},
+			hc: &hyperv1beta1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-hc", Namespace: "clusters",
+					Labels: map[string]string{"env": "prod"},
+				},
+			},
+			hubMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "mce-my-hc",
+					Labels: map[string]string{"env": "staging"},
+				},
+			},
+			expectedSpokeLabels:      map[string]string{"env": "prod"},
+			expectedHCAnnoKeysOnSpoke: []string{"env"},
+			expectedHubLabels:        map[string]string{"env": "prod"},
+			expectedHCAnnoKeysOnHub:   []string{"env"},
+		},
+		{
+			name: "HC system labels are not propagated",
+			spokeMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "my-hc",
+					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
+				},
+			},
+			hc: &hyperv1beta1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-hc", Namespace: "clusters",
+					Labels: map[string]string{
+						"env":                       "prod",
+						"hypershift.openshift.io/auto-created-for-infra": "test-infra",
+					},
+				},
+			},
+			hubMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "mce-my-hc"},
+			},
+			expectedSpokeLabels:       map[string]string{"env": "prod"},
+			notExpectedSpokeLabels:     []string{"hypershift.openshift.io/auto-created-for-infra"},
+			expectedHCAnnoKeysOnSpoke:  []string{"env"},
+			notExpectedHubLabels:       []string{"hypershift.openshift.io/auto-created-for-infra"},
+		},
+		{
+			name: "HC label removed - cleaned from spoke and hub",
+			spokeMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "my-hc",
+					Annotations: map[string]string{createdViaAnno: createdViaHypershift, hcPropagatedLabelAnnotation: "env"},
+					Labels:      map[string]string{"env": "prod", "local": "keep"},
+				},
+			},
+			hc: &hyperv1beta1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-hc", Namespace: "clusters",
+				},
+			},
+			hubMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "mce-my-hc",
+					Annotations: map[string]string{hcPropagatedLabelAnnotation: "env"},
+					Labels:      map[string]string{"env": "prod"},
+				},
+			},
+			expectedSpokeLabels:    map[string]string{"local": "keep"},
+			notExpectedSpokeLabels: []string{"env"},
+			notExpectedHubLabels:   []string{"env"},
+		},
+		{
+			name: "HC and admin hub labels coexist independently",
+			spokeMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "my-hc",
+					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
+				},
+			},
+			hc: &hyperv1beta1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-hc", Namespace: "clusters",
+					Labels: map[string]string{"env": "prod"},
+				},
+			},
+			hubMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "mce-my-hc",
+					Labels: map[string]string{"team": "platform"},
+				},
+			},
+			expectedSpokeLabels:       map[string]string{"env": "prod", "team": "platform"},
+			expectedHCAnnoKeysOnSpoke:  []string{"env"},
+			expectedHubAnnoKeysOnSpoke: []string{"team"},
+		},
+		{
+			name: "HC with managedcluster-name annotation maps correctly",
+			spokeMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "custom-mc-name",
+					Annotations: map[string]string{createdViaAnno: createdViaHypershift},
+				},
+			},
+			hc: &hyperv1beta1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-hc", Namespace: "clusters",
+					Labels:      map[string]string{"env": "prod"},
+					Annotations: map[string]string{util.ManagedClusterAnnoKey: "custom-mc-name"},
+				},
+			},
+			hubMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "mce-custom-mc-name"},
+			},
+			expectedSpokeLabels:      map[string]string{"env": "prod"},
+			expectedHCAnnoKeysOnSpoke: []string{"env"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			spoke, hub := initLabelSyncClient(t)
+			zapLog, _ := zap.NewDevelopment()
+			os.Unsetenv("DISCOVERY_PREFIX")
+
+			lc := &LabelAgent{
+				hubClient:        hub,
+				spokeClient:      spoke,
+				clusterName:      "mce",
+				localClusterName: "local-cluster",
+				log:              zapr.NewLogger(zapLog),
+			}
+
+			assert.Nil(t, spoke.Create(ctx, tt.spokeMC))
+			if tt.hc != nil {
+				assert.Nil(t, spoke.Create(ctx, tt.hc))
+			}
+			if tt.hubMC != nil {
+				assert.Nil(t, hub.Create(ctx, tt.hubMC))
+			}
+
+			_, err := lc.Reconcile(ctx, ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: tt.spokeMC.Name},
+			})
+			assert.Nil(t, err)
+
+			retrievedSpoke := &clusterv1.ManagedCluster{}
+			assert.Nil(t, spoke.Get(ctx, types.NamespacedName{Name: tt.spokeMC.Name}, retrievedSpoke))
+
+			for key, val := range tt.expectedSpokeLabels {
+				assert.Equal(t, val, retrievedSpoke.Labels[key], "spoke label %s mismatch", key)
+			}
+			for _, key := range tt.notExpectedSpokeLabels {
+				_, exists := retrievedSpoke.Labels[key]
+				assert.False(t, exists, "spoke label %s should not exist", key)
+			}
+
+			if tt.expectedHCAnnoKeysOnSpoke != nil {
+				anno := retrievedSpoke.Annotations[hcPropagatedLabelAnnotation]
+				for _, key := range tt.expectedHCAnnoKeysOnSpoke {
+					assert.Contains(t, anno, key, "spoke hc-tracking annotation should contain %s", key)
+				}
+			}
+			if tt.expectedHubAnnoKeysOnSpoke != nil {
+				anno := retrievedSpoke.Annotations[propagatedLabelAnnotation]
+				for _, key := range tt.expectedHubAnnoKeysOnSpoke {
+					assert.Contains(t, anno, key, "spoke hub-tracking annotation should contain %s", key)
+				}
+			}
+
+			if tt.hubMC != nil {
+				retrievedHub := &clusterv1.ManagedCluster{}
+				assert.Nil(t, hub.Get(ctx, types.NamespacedName{Name: tt.hubMC.Name}, retrievedHub))
+
+				for key, val := range tt.expectedHubLabels {
+					assert.Equal(t, val, retrievedHub.Labels[key], "hub label %s mismatch", key)
+				}
+				for _, key := range tt.notExpectedHubLabels {
+					_, exists := retrievedHub.Labels[key]
+					assert.False(t, exists, "hub label %s should not exist", key)
+				}
+				if tt.expectedHCAnnoKeysOnHub != nil {
+					anno := retrievedHub.Annotations[hcPropagatedLabelAnnotation]
+					for _, key := range tt.expectedHCAnnoKeysOnHub {
+						assert.Contains(t, anno, key, "hub hc-tracking annotation should contain %s", key)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestHCDeletedCleansUpLabels(t *testing.T) {
+	ctx := context.Background()
+	spoke, hub := initLabelSyncClient(t)
+	zapLog, _ := zap.NewDevelopment()
+	os.Unsetenv("DISCOVERY_PREFIX")
+
+	lc := &LabelAgent{
+		hubClient:        hub,
+		spokeClient:      spoke,
+		clusterName:      "mce",
+		localClusterName: "local-cluster",
+		log:              zapr.NewLogger(zapLog),
+	}
+
+	spokeMC := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-hc",
+			Annotations: map[string]string{
+				createdViaAnno:              createdViaHypershift,
+				hcPropagatedLabelAnnotation: "env,tier",
+			},
+			Labels: map[string]string{"env": "prod", "tier": "frontend", "local": "keep"},
+		},
+	}
+	hubMC := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "mce-my-hc",
+			Annotations: map[string]string{hcPropagatedLabelAnnotation: "env,tier"},
+			Labels:      map[string]string{"env": "prod", "tier": "frontend", "admin-label": "keep"},
+		},
+	}
+
+	assert.Nil(t, spoke.Create(ctx, spokeMC))
+	assert.Nil(t, hub.Create(ctx, hubMC))
+
+	_, err := lc.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "my-hc"},
+	})
+	assert.Nil(t, err)
+
+	retrievedSpoke := &clusterv1.ManagedCluster{}
+	assert.Nil(t, spoke.Get(ctx, types.NamespacedName{Name: "my-hc"}, retrievedSpoke))
+	assert.Equal(t, "keep", retrievedSpoke.Labels["local"])
+	_, envExists := retrievedSpoke.Labels["env"]
+	assert.False(t, envExists, "env should be removed from spoke after HC deleted")
+	_, tierExists := retrievedSpoke.Labels["tier"]
+	assert.False(t, tierExists, "tier should be removed from spoke after HC deleted")
+
+	retrievedHub := &clusterv1.ManagedCluster{}
+	assert.Nil(t, hub.Get(ctx, types.NamespacedName{Name: "mce-my-hc"}, retrievedHub))
+	assert.Equal(t, "keep", retrievedHub.Labels["admin-label"])
+	_, envExists = retrievedHub.Labels["env"]
+	assert.False(t, envExists, "env should be removed from hub after HC deleted")
+}
+
+func TestHubSyncSkipsHCOwnedLabels(t *testing.T) {
+	ctx := context.Background()
+	spoke, hub := initLabelSyncClient(t)
+	zapLog, _ := zap.NewDevelopment()
+	os.Unsetenv("DISCOVERY_PREFIX")
+
+	lc := &LabelAgent{
+		hubClient:        hub,
+		spokeClient:      spoke,
+		clusterName:      "mce",
+		localClusterName: "local-cluster",
+		log:              zapr.NewLogger(zapLog),
+	}
+
+	spokeMC := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "my-hc",
+			Annotations: map[string]string{createdViaAnno: createdViaHypershift},
+		},
+	}
+	hc := &hyperv1beta1.HostedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-hc", Namespace: "clusters",
+			Labels: map[string]string{"env": "prod"},
+		},
+	}
+	hubMC := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "mce-my-hc",
+			Labels: map[string]string{"env": "staging", "team": "platform"},
+		},
+	}
+
+	assert.Nil(t, spoke.Create(ctx, spokeMC))
+	assert.Nil(t, spoke.Create(ctx, hc))
+	assert.Nil(t, hub.Create(ctx, hubMC))
+
+	_, err := lc.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "my-hc"},
+	})
+	assert.Nil(t, err)
+
+	retrieved := &clusterv1.ManagedCluster{}
+	assert.Nil(t, spoke.Get(ctx, types.NamespacedName{Name: "my-hc"}, retrieved))
+
+	assert.Equal(t, "prod", retrieved.Labels["env"], "HC value should win over hub")
+	assert.Equal(t, "platform", retrieved.Labels["team"], "admin hub label should be propagated")
+
+	assert.Contains(t, retrieved.Annotations[hcPropagatedLabelAnnotation], "env")
+	assert.Contains(t, retrieved.Annotations[propagatedLabelAnnotation], "team")
+	assert.NotContains(t, retrieved.Annotations[propagatedLabelAnnotation], "env",
+		"env should not be in hub tracking since HC owns it")
+}
+
 func TestMultiClusterLabelPropagation(t *testing.T) {
 	ctx := context.Background()
 	spoke, hub := initLabelSyncClient(t)
@@ -917,6 +1284,34 @@ func TestMapHubMCToSpokeMC(t *testing.T) {
 	})
 }
 
+func TestMapHCToSpokeMC(t *testing.T) {
+	zapLog, _ := zap.NewDevelopment()
+	lc := &LabelAgent{log: zapr.NewLogger(zapLog)}
+
+	t.Run("HC name maps to spoke MC name", func(t *testing.T) {
+		hc := &hyperv1beta1.HostedCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-hc", Namespace: "clusters"},
+		}
+		requests := lc.mapHCToSpokeMC(context.Background(), hc)
+		assert.Equal(t, []reconcile.Request{
+			{NamespacedName: types.NamespacedName{Name: "my-hc"}},
+		}, requests)
+	})
+
+	t.Run("HC with managedcluster-name annotation uses annotation value", func(t *testing.T) {
+		hc := &hyperv1beta1.HostedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-hc", Namespace: "clusters",
+				Annotations: map[string]string{util.ManagedClusterAnnoKey: "custom-name"},
+			},
+		}
+		requests := lc.mapHCToSpokeMC(context.Background(), hc)
+		assert.Equal(t, []reconcile.Request{
+			{NamespacedName: types.NamespacedName{Name: "custom-name"}},
+		}, requests)
+	})
+}
+
 func TestLabelEventFilters(t *testing.T) {
 	pred := labelEventFilters()
 
@@ -973,6 +1368,36 @@ func TestLabelEventFilters(t *testing.T) {
 		assert.False(t, result)
 	})
 
+	t.Run("UpdateFunc accepts when propagated-labels annotation is removed", func(t *testing.T) {
+		oldMC := hostedMC.DeepCopy()
+		oldMC.Annotations[propagatedLabelAnnotation] = "env,team"
+		result := pred.Update(event.UpdateEvent{
+			ObjectOld: oldMC,
+			ObjectNew: hostedMC,
+		})
+		assert.True(t, result)
+	})
+
+	t.Run("UpdateFunc accepts when hc-propagated-labels annotation is removed", func(t *testing.T) {
+		oldMC := hostedMC.DeepCopy()
+		oldMC.Annotations[hcPropagatedLabelAnnotation] = "env"
+		result := pred.Update(event.UpdateEvent{
+			ObjectOld: oldMC,
+			ObjectNew: hostedMC,
+		})
+		assert.True(t, result)
+	})
+
+	t.Run("UpdateFunc accepts when created-via annotation is added", func(t *testing.T) {
+		oldMC := hostedMC.DeepCopy()
+		delete(oldMC.Annotations, createdViaAnno)
+		result := pred.Update(event.UpdateEvent{
+			ObjectOld: oldMC,
+			ObjectNew: hostedMC,
+		})
+		assert.True(t, result)
+	})
+
 	t.Run("CreateFunc rejects non-ManagedCluster object", func(t *testing.T) {
 		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "some-pod"}}
 		result := pred.Create(event.CreateEvent{Object: pod})
@@ -996,5 +1421,78 @@ func TestLabelEventFilters(t *testing.T) {
 	t.Run("GenericFunc always returns false", func(t *testing.T) {
 		result := pred.Generic(event.GenericEvent{Object: hostedMC})
 		assert.False(t, result)
+	})
+}
+
+func TestHCLabelEventFilters(t *testing.T) {
+	pred := hcLabelEventFilters()
+
+	hc := &hyperv1beta1.HostedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-hc", Namespace: "clusters",
+			Labels: map[string]string{"env": "prod"},
+		},
+	}
+
+	t.Run("CreateFunc accepts HC", func(t *testing.T) {
+		result := pred.Create(event.CreateEvent{Object: hc})
+		assert.True(t, result)
+	})
+
+	t.Run("UpdateFunc accepts HC with label change", func(t *testing.T) {
+		oldHC := hc.DeepCopy()
+		oldHC.Labels = map[string]string{"env": "staging"}
+		result := pred.Update(event.UpdateEvent{
+			ObjectOld: oldHC,
+			ObjectNew: hc,
+		})
+		assert.True(t, result)
+	})
+
+	t.Run("UpdateFunc rejects HC with no label change", func(t *testing.T) {
+		result := pred.Update(event.UpdateEvent{
+			ObjectOld: hc.DeepCopy(),
+			ObjectNew: hc,
+		})
+		assert.False(t, result)
+	})
+
+	t.Run("DeleteFunc accepts HC deletion", func(t *testing.T) {
+		result := pred.Delete(event.DeleteEvent{Object: hc})
+		assert.True(t, result)
+	})
+
+	t.Run("GenericFunc returns false", func(t *testing.T) {
+		result := pred.Generic(event.GenericEvent{Object: hc})
+		assert.False(t, result)
+	})
+}
+
+func TestParseAnnotation(t *testing.T) {
+	t.Run("empty string returns empty map", func(t *testing.T) {
+		result := parseAnnotation("")
+		assert.Empty(t, result)
+	})
+
+	t.Run("single key", func(t *testing.T) {
+		result := parseAnnotation("env")
+		assert.Equal(t, map[string]bool{"env": true}, result)
+	})
+
+	t.Run("multiple keys", func(t *testing.T) {
+		result := parseAnnotation("env,team,tier")
+		assert.Equal(t, map[string]bool{"env": true, "team": true, "tier": true}, result)
+	})
+}
+
+func TestJoinSortedKeys(t *testing.T) {
+	t.Run("empty map returns empty string", func(t *testing.T) {
+		result := joinSortedKeys(map[string]bool{})
+		assert.Equal(t, "", result)
+	})
+
+	t.Run("keys are sorted alphabetically", func(t *testing.T) {
+		result := joinSortedKeys(map[string]bool{"team": true, "env": true, "tier": true})
+		assert.Equal(t, "env,team,tier", result)
 	})
 }

--- a/pkg/agent/managedcluster_sync_controller_test.go
+++ b/pkg/agent/managedcluster_sync_controller_test.go
@@ -69,18 +69,20 @@ func reconcileAndGet(
 
 // --- Hub-to-spoke label propagation ---
 
-func TestLabelPropagation(t *testing.T) {
-	tests := []struct {
-		name               string
-		spokeMC            *clusterv1.ManagedCluster
-		hubMC              *clusterv1.ManagedCluster
-		clusterName        string
-		localClusterName   string
-		discoveryPrefix    *string
-		expectedLabels     map[string]string
-		notExpectedLabels  []string
-		expectedAnnoKeys   []string
-	}{
+type hubLabelTestCase struct {
+	name             string
+	spokeMC          *clusterv1.ManagedCluster
+	hubMC            *clusterv1.ManagedCluster
+	clusterName      string
+	localClusterName string
+	discoveryPrefix  *string
+	expectedLabels   map[string]string
+	notExpectedLabels []string
+	expectedAnnoKeys []string
+}
+
+func hubLabelSyncCases() []hubLabelTestCase {
+	return []hubLabelTestCase{
 		{
 			name: "hub labels propagated to spoke",
 			spokeMC: &clusterv1.ManagedCluster{
@@ -95,8 +97,8 @@ func TestLabelPropagation(t *testing.T) {
 					Labels: map[string]string{"env": "prod", "team": "backend"},
 				},
 			},
-			clusterName:    "mce",
-			expectedLabels: map[string]string{"env": "prod", "team": "backend"},
+			clusterName:      "mce",
+			expectedLabels:   map[string]string{"env": "prod", "team": "backend"},
 			expectedAnnoKeys: []string{"env", "team"},
 		},
 		{
@@ -160,6 +162,11 @@ func TestLabelPropagation(t *testing.T) {
 			expectedLabels:    map[string]string{"env": "prod"},
 			notExpectedLabels: []string{"vendor", "cloud", "region", "feature.open-cluster-management.io/addon-search"},
 		},
+	}
+}
+
+func hubLabelCleanupCases() []hubLabelTestCase {
+	return []hubLabelTestCase{
 		{
 			name: "hub label removed from spoke",
 			spokeMC: &clusterv1.ManagedCluster{
@@ -199,6 +206,37 @@ func TestLabelPropagation(t *testing.T) {
 			expectedLabels:    map[string]string{"local": "keep"},
 			notExpectedLabels: []string{"env", "team"},
 		},
+		{
+			name: "multiple labels with partial removal",
+			spokeMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "hc1",
+					Annotations: map[string]string{
+						createdViaAnno:            createdViaHypershift,
+						propagatedLabelAnnotation: "env,team,old,deprecated",
+					},
+					Labels: map[string]string{
+						"env": "prod", "team": "backend",
+						"old": "rm", "deprecated": "rm", "local": "keep",
+					},
+				},
+			},
+			hubMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   testHubMCNameDefault,
+					Labels: map[string]string{"env": "staging", "team": "backend"},
+				},
+			},
+			clusterName:       "mce",
+			expectedLabels:    map[string]string{"env": "staging", "team": "backend", "local": "keep"},
+			notExpectedLabels: []string{"old", "deprecated"},
+			expectedAnnoKeys:  []string{"env", "team"},
+		},
+	}
+}
+
+func hubLabelEdgeCases() []hubLabelTestCase {
+	return []hubLabelTestCase{
 		{
 			name: "custom discovery prefix",
 			spokeMC: &clusterv1.ManagedCluster{
@@ -295,33 +333,14 @@ func TestLabelPropagation(t *testing.T) {
 			expectedLabels:   map[string]string{"env": "prod"},
 			expectedAnnoKeys: []string{"env"},
 		},
-		{
-			name: "multiple labels with partial removal",
-			spokeMC: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "hc1",
-					Annotations: map[string]string{
-						createdViaAnno:            createdViaHypershift,
-						propagatedLabelAnnotation: "env,team,old,deprecated",
-					},
-					Labels: map[string]string{
-						"env": "prod", "team": "backend",
-						"old": "rm", "deprecated": "rm", "local": "keep",
-					},
-				},
-			},
-			hubMC: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   testHubMCNameDefault,
-					Labels: map[string]string{"env": "staging", "team": "backend"},
-				},
-			},
-			clusterName:       "mce",
-			expectedLabels:    map[string]string{"env": "staging", "team": "backend", "local": "keep"},
-			notExpectedLabels: []string{"old", "deprecated"},
-			expectedAnnoKeys:  []string{"env", "team"},
-		},
 	}
+}
+
+func TestLabelPropagation(t *testing.T) {
+	var tests []hubLabelTestCase
+	tests = append(tests, hubLabelSyncCases()...)
+	tests = append(tests, hubLabelCleanupCases()...)
+	tests = append(tests, hubLabelEdgeCases()...)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -455,6 +474,11 @@ func hcLabelSyncCases() []hcLabelTestCase {
 			expectedSpokeLabels:       map[string]string{"env": "staging"},
 			expectedHubAnnoKeysOnSpoke: []string{"env"},
 		},
+	}
+}
+
+func hcLabelFilterAndMatchCases() []hcLabelTestCase {
+	return []hcLabelTestCase{
 		{
 			name: "HC takes ownership from hub tracking",
 			spokeMC: &clusterv1.ManagedCluster{
@@ -480,7 +504,7 @@ func hcLabelSyncCases() []hcLabelTestCase {
 				},
 			},
 			expectedSpokeLabels:       map[string]string{"env": "prod"},
-			expectedHCAnnoKeysOnSpoke: []string{"env"},
+			expectedHCAnnoKeysOnSpoke:  []string{"env"},
 			expectedHubAnnoKeysOnSpoke: []string{},
 		},
 		{
@@ -665,6 +689,7 @@ func hcLabelInteractionCases() []hcLabelTestCase {
 
 func hcLabelTestCases() []hcLabelTestCase {
 	cases := hcLabelSyncCases()
+	cases = append(cases, hcLabelFilterAndMatchCases()...)
 	cases = append(cases, hcLabelCleanupCases()...)
 	return append(cases, hcLabelInteractionCases()...)
 }

--- a/pkg/agent/managedcluster_sync_controller_test.go
+++ b/pkg/agent/managedcluster_sync_controller_test.go
@@ -456,6 +456,34 @@ func hcLabelSyncCases() []hcLabelTestCase {
 			expectedHubAnnoKeysOnSpoke: []string{"env"},
 		},
 		{
+			name: "HC takes ownership from hub tracking",
+			spokeMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-hc",
+					Annotations: map[string]string{
+						createdViaAnno:            createdViaHypershift,
+						propagatedLabelAnnotation: "env",
+					},
+					Labels: map[string]string{"env": "prod"},
+				},
+			},
+			hc: &hyperv1beta1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-hc", Namespace: "clusters",
+					Labels: map[string]string{"env": "prod"},
+				},
+			},
+			hubMC: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   testHubMCName,
+					Labels: map[string]string{"env": "prod"},
+				},
+			},
+			expectedSpokeLabels:       map[string]string{"env": "prod"},
+			expectedHCAnnoKeysOnSpoke: []string{"env"},
+			expectedHubAnnoKeysOnSpoke: []string{},
+		},
+		{
 			name: "HC system labels not propagated",
 			spokeMC: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -578,6 +606,11 @@ func hcLabelCleanupCases() []hcLabelTestCase {
 			expectedSpokeLabels:      map[string]string{"env": "prod"},
 			expectedHCAnnoKeysOnSpoke: []string{"env"},
 		},
+	}
+}
+
+func hcLabelInteractionCases() []hcLabelTestCase {
+	return []hcLabelTestCase{
 		{
 			name: "HC deleted cleans up tracked labels",
 			spokeMC: &clusterv1.ManagedCluster{
@@ -631,7 +664,9 @@ func hcLabelCleanupCases() []hcLabelTestCase {
 }
 
 func hcLabelTestCases() []hcLabelTestCase {
-	return append(hcLabelSyncCases(), hcLabelCleanupCases()...)
+	cases := hcLabelSyncCases()
+	cases = append(cases, hcLabelCleanupCases()...)
+	return append(cases, hcLabelInteractionCases()...)
 }
 
 func runHCLabelTest(t *testing.T, tt hcLabelTestCase) {

--- a/pkg/agent/managedcluster_sync_controller_test.go
+++ b/pkg/agent/managedcluster_sync_controller_test.go
@@ -358,9 +358,10 @@ func TestLabelPropagation(t *testing.T) {
 				assert.False(t, exists, "label %s should not exist", key)
 			}
 			if tt.expectedAnnoKeys != nil {
-				anno := mc.Annotations[propagatedLabelAnnotation]
+				tracked := parseAnnotation(mc.Annotations[propagatedLabelAnnotation])
+				assert.Len(t, tracked, len(tt.expectedAnnoKeys))
 				for _, key := range tt.expectedAnnoKeys {
-					assert.Contains(t, anno, key)
+					assert.True(t, tracked[key], "tracked key %s missing", key)
 				}
 			}
 		})
@@ -658,15 +659,17 @@ func runHCLabelTest(t *testing.T, tt hcLabelTestCase) {
 		assert.False(t, exists, "spoke label %s should not exist", key)
 	}
 	if tt.expectedHCAnnoKeysOnSpoke != nil {
-		anno := mc.Annotations[hcPropagatedLabelAnnotation]
+		tracked := parseAnnotation(mc.Annotations[hcPropagatedLabelAnnotation])
+		assert.Len(t, tracked, len(tt.expectedHCAnnoKeysOnSpoke))
 		for _, key := range tt.expectedHCAnnoKeysOnSpoke {
-			assert.Contains(t, anno, key)
+			assert.True(t, tracked[key], "spoke hc-tracked key %s missing", key)
 		}
 	}
 	if tt.expectedHubAnnoKeysOnSpoke != nil {
-		anno := mc.Annotations[propagatedLabelAnnotation]
+		tracked := parseAnnotation(mc.Annotations[propagatedLabelAnnotation])
+		assert.Len(t, tracked, len(tt.expectedHubAnnoKeysOnSpoke))
 		for _, key := range tt.expectedHubAnnoKeysOnSpoke {
-			assert.Contains(t, anno, key)
+			assert.True(t, tracked[key], "spoke hub-tracked key %s missing", key)
 		}
 	}
 
@@ -681,9 +684,10 @@ func runHCLabelTest(t *testing.T, tt hcLabelTestCase) {
 			assert.False(t, exists, "hub label %s should not exist", key)
 		}
 		if tt.expectedHCAnnoKeysOnHub != nil {
-			anno := hubMC.Annotations[hcPropagatedLabelAnnotation]
+			tracked := parseAnnotation(hubMC.Annotations[hcPropagatedLabelAnnotation])
+			assert.Len(t, tracked, len(tt.expectedHCAnnoKeysOnHub))
 			for _, key := range tt.expectedHCAnnoKeysOnHub {
-				assert.Contains(t, anno, key)
+				assert.True(t, tracked[key], "hub hc-tracked key %s missing", key)
 			}
 		}
 	}
@@ -1033,15 +1037,21 @@ func TestFindHostedCluster(t *testing.T) {
 				Labels:      map[string]string{testAutoCreatedForInfra: testInfraID},
 			},
 		}
+		// Name-only match (no infraID, no annotation)
 		assert.Nil(t, spoke.Create(ctx, &hyperv1beta1.HostedCluster{
-			ObjectMeta: metav1.ObjectMeta{Name: "my-hc", Namespace: "clusters"},
+			ObjectMeta: metav1.ObjectMeta{Name: "my-hc", Namespace: "wrong-ns"},
+		}))
+		// InfraID match with a different name
+		assert.Nil(t, spoke.Create(ctx, &hyperv1beta1.HostedCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "infra-hc", Namespace: "clusters"},
 			Spec:       hyperv1beta1.HostedClusterSpec{InfraID: testInfraID},
 		}))
 
 		result, err := lc.findHostedCluster(ctx, spokeMC)
 		assert.Nil(t, err)
 		assert.NotNil(t, result)
-		assert.Equal(t, "my-hc", result.Name)
+		assert.Equal(t, "infra-hc", result.Name, "infraID match should win over name")
+		assert.Equal(t, "clusters", result.Namespace)
 	})
 
 	t.Run("annotation match takes priority over infraID", func(t *testing.T) {

--- a/pkg/manager/manifests/permission/clusterrole.yaml
+++ b/pkg/manager/manifests/permission/clusterrole.yaml
@@ -5,4 +5,4 @@ metadata:
 rules:
   - apiGroups: ["cluster.open-cluster-management.io"]
     resources: ["managedclusters"]
-    verbs: ["get", "list", "watch", "delete"]    
+    verbs: ["get", "list", "watch", "patch", "delete"]


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Add label propagation from HostedCluster resources to their corresponding ManagedCluster resources on both the MCE spoke and ACM hub
* HostedCluster labels are the highest-priority source and always override existing values on ManagedCluster resources
* Introduce `hypershift.open-cluster-management.io/hc-propagated-labels` annotation to track HC-originated labels separately from hub-originated labels
* Add a watch on HostedCluster resources with label-change predicates for instant reconciliation
* Modify existing hub-to-spoke sync to skip labels owned by the HostedCluster, preventing lower-priority sources from overwriting HC labels
* Add cleanup logic to remove HC-propagated labels from both spoke and hub ManagedClusters when the HostedCluster is deleted
* Add `patch` verb to the hub ClusterRole for ManagedCluster resources to support HC-to-hub label propagation

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
* RFE: HostedCluster labels should be the ultimate source of truth and automatically propagate to corresponding ManagedCluster resources. This ensures that labels set on HostedClusters are consistently reflected across both the MCE spoke and ACM hub without manual intervention. Combined with the existing hub-to-spoke sync, this creates a complete label management hierarchy: HostedCluster > ACM Hub admin labels > local spoke labels.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* [ACM-32271](https://redhat.atlassian.net/browse/ACM-32268)

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
=== RUN   TestLabelPropagation
--- PASS: TestLabelPropagation (0.07s)
=== RUN   TestHCLabelPropagation
--- PASS: TestHCLabelPropagation (0.02s)
=== RUN   TestHCDeletedCleansUpLabels
--- PASS: TestHCDeletedCleansUpLabels (0.00s)
=== RUN   TestHubSyncSkipsHCOwnedLabels
--- PASS: TestHubSyncSkipsHCOwnedLabels (0.00s)
=== RUN   TestMultiClusterLabelPropagation
--- PASS: TestMultiClusterLabelPropagation (0.01s)
=== RUN   TestReconcileDisableDiscovery
--- PASS: TestReconcileDisableDiscovery (0.00s)
=== RUN   TestReconcileSpokeNotFound
--- PASS: TestReconcileSpokeNotFound (0.00s)
=== RUN   TestGetSpokeMCName
--- PASS: TestGetSpokeMCName (0.00s)
=== RUN   TestMapHubMCToSpokeMC
--- PASS: TestMapHubMCToSpokeMC (0.00s)
=== RUN   TestMapHCToSpokeMC
--- PASS: TestMapHCToSpokeMC (0.00s)
=== RUN   TestLabelEventFilters
--- PASS: TestLabelEventFilters (0.00s)
=== RUN   TestHCLabelEventFilters
--- PASS: TestHCLabelEventFilters (0.00s)
=== RUN   TestParseAnnotation
--- PASS: TestParseAnnotation (0.00s)
=== RUN   TestJoinSortedKeys
--- PASS: TestJoinSortedKeys (0.00s)
PASS
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	2.301s

[ACM-32271]: https://redhat.atlassian.net/browse/ACM-32271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two-phase, bidirectional label sync between HostedCluster and ManagedCluster with precedence rules, propagated-key tracking, deterministic cleanup, improved HostedCluster matching, and expanded event triggers for reliable reconciliation.

* **Tests**
  * Extensive unit tests covering HostedCluster↔ManagedCluster propagation, matching/ambiguity handling, event-filtering, annotation tracking, and cleanup scenarios.

* **Chores**
  * Added permission to allow patching ManagedCluster labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->