### PR TITLE
ACM-33069: Fix syncHubLabelsToSpoke cleanup logic

### DIFF
--- a/pkg/agent/managedcluster_sync_controller.go
+++ b/pkg/agent/managedcluster_sync_controller.go
@@ -449,7 +449,7 @@ func (c *LabelAgent) syncHubLabelsToSpoke(
 	// go through the previous tracking labels and if they dont exist on the current hub labels
 	// then remove the previously tracked labels
 	for key := range previousAnnotationTracking {
-		if _, exists := hubMC.Labels[key]; !exists {
+		if _, exists := hubMC.Labels[key]; !exists || hcOwnedOnHub[key] {
 			delete(spokeLabels, key)
 			changed = true
 		}

--- a/pkg/agent/managedcluster_sync_controller_test.go
+++ b/pkg/agent/managedcluster_sync_controller_test.go
@@ -761,6 +761,55 @@ func TestHCLabelPropagation(t *testing.T) {
 	}
 }
 
+// Regression test for ACM-33069: hub-tracked label removed while HC has the
+// same key. Requires two reconciles — the first removes the orphaned hub value,
+// the second lets HC sync propagate its value.
+func TestHubLabelRemovedWhileHCHasSameKey(t *testing.T) {
+	ctx := context.Background()
+	spoke, hub := initLabelSyncClient(t)
+	os.Unsetenv("DISCOVERY_PREFIX")
+	lc := newLabelAgent(t, spoke, hub, "mce")
+
+	spokeMC := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-hc",
+			Annotations: map[string]string{
+				createdViaAnno:            createdViaHypershift,
+				propagatedLabelAnnotation: "env",
+			},
+			Labels: map[string]string{"env": "staging"},
+		},
+	}
+	hc := &hyperv1beta1.HostedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-hc", Namespace: "clusters",
+			Labels: map[string]string{"env": "prod"},
+		},
+	}
+	hubMC := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: testHubMCName},
+	}
+
+	assert.Nil(t, spoke.Create(ctx, spokeMC))
+	assert.Nil(t, spoke.Create(ctx, hc))
+	assert.Nil(t, hub.Create(ctx, hubMC))
+
+	// Reconcile 1: hub sync removes the orphaned env=staging from spoke
+	mc := reconcileAndGet(t, lc, spoke, "my-hc")
+	_, envExists := mc.Labels["env"]
+	assert.False(t, envExists,
+		"env should be removed from spoke after hub label deleted")
+	hubTracked := parseAnnotation(mc.Annotations[propagatedLabelAnnotation])
+	assert.Empty(t, hubTracked, "propagated-labels should be empty")
+
+	// Reconcile 2: HC sync adds env=prod now that the key is free
+	mc = reconcileAndGet(t, lc, spoke, "my-hc")
+	assert.Equal(t, "prod", mc.Labels["env"],
+		"HC should propagate env=prod on second reconcile")
+	hcTracked := parseAnnotation(mc.Annotations[hcPropagatedLabelAnnotation])
+	assert.True(t, hcTracked["env"], "env should be HC-tracked")
+}
+
 // --- Multi-cluster propagation ---
 
 func TestMultiClusterLabelPropagation(t *testing.T) {


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Fix `syncHubLabelsToSpoke` cleanup logic to also remove a hub-tracked label from the spoke when the label key is now owned by the HostedCluster (present in `hc-propagated-labels` on the hub MC).
* Add regression test `TestHubLabelRemovedWhileHCHasSameKey` that exercises the two-reconcile ACM-33069 scenario end-to-end.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
* Bug fix. When a hub-propagated label (e.g. `env=staging`) is removed from the ACM hub ManagedCluster while the HostedCluster has the same key (`env=prod`), `syncHCLabelsToHub` writes the HC value to the hub MC during reconciliation. The subsequent `syncHubLabelsToSpoke` re-reads the hub MC and sees the key still exists (now HC-owned), so the old `!exists` check evaluates to false and the stale spoke label is never deleted. The fix adds `|| hcOwnedOnHub[key]` so that hub-tracked labels are also removed from the spoke when the key has been taken over by HC propagation.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference:
* ACM-33069

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
=== RUN   TestLabelPropagation
--- PASS: TestLabelPropagation (0.02s)
=== RUN   TestHCLabelPropagation
--- PASS: TestHCLabelPropagation (0.01s)
=== RUN   TestHubLabelRemovedWhileHCHasSameKey
--- PASS: TestHubLabelRemovedWhileHCHasSameKey (0.00s)
=== RUN   TestMultiClusterLabelPropagation
--- PASS: TestMultiClusterLabelPropagation (0.00s)
=== RUN   TestReconcileDisableDiscovery
--- PASS: TestReconcileDisableDiscovery (0.00s)
=== RUN   TestReconcileSpokeNotFound
--- PASS: TestReconcileSpokeNotFound (0.00s)
=== RUN   TestGetSpokeMCName
--- PASS: TestGetSpokeMCName (0.00s)
=== RUN   TestMapHubMCToSpokeMC
--- PASS: TestMapHubMCToSpokeMC (0.00s)
=== RUN   TestMapHCToSpokeMC
--- PASS: TestMapHCToSpokeMC (0.00s)
=== RUN   TestLabelEventFilters
--- PASS: TestLabelEventFilters (0.00s)
=== RUN   TestHCLabelEventFilters
--- PASS: TestHCLabelEventFilters (0.00s)
=== RUN   TestParseAnnotation
--- PASS: TestParseAnnotation (0.00s)
=== RUN   TestJoinSortedKeys
--- PASS: TestJoinSortedKeys (0.00s)
=== RUN   TestFindHostedCluster
--- PASS: TestFindHostedCluster (0.00s)
PASS
ok  	github.com/stolostron/hypershift-addon-operator/pkg/agent	2.377s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed label synchronization to properly handle label removal when ownership transitions from hub to HostedCluster on managed clusters.

* **Tests**
  * Added regression test for label ownership transition scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->