### PR TITLE
ACM-33881: Bump addon-framework to 348aab34 for RBAC subject fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	k8s.io/client-go v0.35.0-alpha.0
 	k8s.io/component-base v0.35.0-alpha.0
 	k8s.io/utils v0.0.0-20260108192941-914a6e750570
-	open-cluster-management.io/addon-framework v1.2.0
+	open-cluster-management.io/addon-framework v1.2.1-0.20260204021841-348aab340dbf
 	open-cluster-management.io/api v1.2.0
 	sigs.k8s.io/controller-runtime v0.22.4
 )

--- a/go.sum
+++ b/go.sum
@@ -1277,8 +1277,8 @@ kubevirt.io/containerized-data-importer-api v1.63.1 h1:g2I9za0QEscRsQjOOK/MM0fey
 kubevirt.io/containerized-data-importer-api v1.63.1/go.mod h1:VGp35wxpLXU18b7cnEpmcThI3AjcZUSfg/Zfql44U4o=
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90 h1:QMrd0nKP0BGbnxTqakhDZAUhGKxPiPiN5gSDqKUmGGc=
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90/go.mod h1:018lASpFYBsYN6XwmA2TIrPCx6e0gviTd/ZNtSitKgc=
-open-cluster-management.io/addon-framework v1.2.0 h1:/HsZmavrIrRzvH/htZxEhasrIxNOYW9YYUeOEPEefeQ=
-open-cluster-management.io/addon-framework v1.2.0/go.mod h1:dIcbnfLXMbXvO4T32ZY8dmok0OSA0UsrDGR27LLv69Q=
+open-cluster-management.io/addon-framework v1.2.1-0.20260204021841-348aab340dbf h1:t9mSMx4ieMPOTNpyJJSMi54XpMFwLHl2shQk4YuELj0=
+open-cluster-management.io/addon-framework v1.2.1-0.20260204021841-348aab340dbf/go.mod h1:dIcbnfLXMbXvO4T32ZY8dmok0OSA0UsrDGR27LLv69Q=
 open-cluster-management.io/api v1.2.0 h1:+yeQgJiErrur5S4s205UM37EcZ2XbC9pFSm0xgV5/hU=
 open-cluster-management.io/api v1.2.0/go.mod h1:YcmA6SpGEekIMxdoeVIIyOaBhMA6ImWRLXP4g8n8T+4=
 open-cluster-management.io/sdk-go v1.2.0 h1:O9LCOoy5JfgK3k4e2OCBY2ZoCqBEwLbEWClqP01FkQI=


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Bump hypershift-addon-operator to use addon-framework at commit `348aab34` (pseudo-version `v1.2.1-0.20260204021841-348aab340dbf`)

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
* In the hub namespace for each managed cluster (e.g. local-cluster), the RoleBinding for the `hypershift addon` agent included the group `system:authenticated`. That group covers every logged-in user and every service account, so they all inherited the addon agent Role—including full secret/configmap access in that namespace—without any project-specific RoleBinding.

`open-cluster-management.io/addon-framework v1.2.0` sets registration subjects via KubeClientSignerConfigurations → DefaultGroups(), which incorrectly added `system:authenticated`. hypershift-addon-operator only calls that shared helper in manager.go; it did not add the group itself.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://redhat.atlassian.net/browse/ACM-33881

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to improve stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->