### PR TITLE
Fix hcp-cli-download killed under OOM bug

### DIFF
--- a/pkg/manager/manifests/cli/deployment.yaml
+++ b/pkg/manager/manifests/cli/deployment.yaml
@@ -69,9 +69,6 @@ spec:
           requests:
             cpu: 10m
             memory: 128Mi
-          limits:
-            cpu: 50m
-            memory: 256Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION


<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Remove container limits from hcp-cli-download. Other components in the multicluster hub do not set limits, so hcp-cli-download now follows the same pattern. Ref: https://redhat.atlassian.net/browse/ACM-34026

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
* bug fix

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
*  https://redhat.atlassian.net/browse/ACM-34026

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
hypershift-addon-operator % make test
go fmt ./...
go vet ./...
KUBEBUILDER_ASSETS="/Users/yiraekim/Library/Application Support/io.kubebuilder.envtest/k8s/1.28.3-darwin-arm64" go test github.com/stolostron/hypershift-addon-operator/cmd github.com/stolostron/hypershift-addon-operator/pkg/agent github.com/stolostron/hypershift-addon-operator/pkg/install github.com/stolostron/hypershift-addon-operator/pkg/manager github.com/stolostron/hypershift-addon-operator/pkg/metrics github.com/stolostron/hypershift-addon-operator/pkg/util -coverprofile cover.out
        github.com/stolostron/hypershift-addon-operator/cmd             coverage: 0.0% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/agent       92.754s coverage: 73.1% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/install     155.970s        coverage: 87.0% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/manager     134.341s        coverage: 70.0% of statements
ok      github.com/stolostron/hypershift-addon-operator/pkg/metrics     3.054s  coverage: 100.0% of statements
        github.com/stolostron/hypershift-addon-operator/pkg/util                coverage: 0.0% of statements
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container resource constraints in the deployment configuration by removing upper resource limits while retaining baseline resource requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->