### PR TITLE
adding logic to pick up nodeselector and tolerations for hypershift o…

### DIFF
--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -788,11 +788,40 @@ func (c *UpgradeController) operatorUpgradable(ctx context.Context) (error, bool
 	return nil, true, obj
 }
 
+func (c *UpgradeController) getAgentPodPlacement() ([]corev1.Toleration, map[string]string) {
+	selfPodNamespace := os.Getenv("POD_NAMESPACE")
+	if len(selfPodNamespace) == 0 {
+		return nil, nil
+	}
+
+	selfPodName := os.Getenv("POD_NAME")
+	if len(selfPodName) == 0 {
+		return nil, nil
+	}
+
+	pod := &corev1.Pod{}
+	key := types.NamespacedName{Namespace: selfPodNamespace, Name: selfPodName}
+	if err := c.spokeUncachedClient.Get(context.TODO(), key, pod); err != nil {
+		c.log.Error(err, "failed getting addon agent pod for nodeSelector or tolerations")
+		return nil, nil
+	}
+	
+	return pod.Spec.Tolerations, pod.Spec.NodeSelector
+}
+
 func (c *UpgradeController) updateHyperShiftDeployment(ctx context.Context) error {
 	obj := &appsv1.Deployment{}
 
 	if err := c.spokeUncachedClient.Get(ctx, hypershiftOperatorKey, obj); err != nil {
 		return err
+	}
+
+	tolerations, nodeSelector := c.getAgentPodPlacement()
+	if tolerations != nil {
+		obj.Spec.Template.Spec.Tolerations = tolerations
+	}
+	if nodeSelector != nil {
+		obj.Spec.Template.Spec.NodeSelector = nodeSelector
 	}
 
 	// Update pull image
@@ -831,6 +860,14 @@ func (c *UpgradeController) updateExtDnsDeployment(ctx context.Context) error {
 
 	if err := c.spokeUncachedClient.Get(ctx, externalDNSOperatorKey, obj); err != nil {
 		return err
+	}
+
+	tolerations, nodeSelector := c.getAgentPodPlacement()
+	if tolerations != nil {
+		obj.Spec.Template.Spec.Tolerations = tolerations
+	}
+	if nodeSelector != nil {
+		obj.Spec.Template.Spec.NodeSelector = nodeSelector
 	}
 
 	// Update pull image

--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -397,6 +397,14 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 				c.secretDataUpdated(util.HypershiftExternalDNSSecretName, *sExtDNS) ||
 				c.configmapDataUpdated(util.HypershiftInstallFlagsCM, installFlagsCM)) {
 			c.log.Info("no image/secret/install-flag change, skip hypershift operator installation")
+
+			if err := c.updateHyperShiftDeployment(ctx); err != nil {
+				c.log.Error(err, "failed to update the hypershift operator deployment")
+			}
+			if err := c.updateExtDnsDeployment(ctx); err != nil {
+				c.log.Error(err, "failed to update the external DNS operator deployment")
+			}
+
 			return nil
 		}
 	} else {
@@ -817,12 +825,8 @@ func (c *UpgradeController) updateHyperShiftDeployment(ctx context.Context) erro
 	}
 
 	tolerations, nodeSelector := c.getAgentPodPlacement()
-	if tolerations != nil {
-		obj.Spec.Template.Spec.Tolerations = tolerations
-	}
-	if nodeSelector != nil {
-		obj.Spec.Template.Spec.NodeSelector = nodeSelector
-	}
+	obj.Spec.Template.Spec.Tolerations = tolerations
+	obj.Spec.Template.Spec.NodeSelector = nodeSelector
 
 	// Update pull image
 	if c.pullSecret != "" {
@@ -863,12 +867,8 @@ func (c *UpgradeController) updateExtDnsDeployment(ctx context.Context) error {
 	}
 
 	tolerations, nodeSelector := c.getAgentPodPlacement()
-	if tolerations != nil {
-		obj.Spec.Template.Spec.Tolerations = tolerations
-	}
-	if nodeSelector != nil {
-		obj.Spec.Template.Spec.NodeSelector = nodeSelector
-	}
+	obj.Spec.Template.Spec.Tolerations = tolerations
+	obj.Spec.Template.Spec.NodeSelector = nodeSelector
 
 	// Update pull image
 	if c.pullSecret != "" {

--- a/pkg/install/hypershift_test.go
+++ b/pkg/install/hypershift_test.go
@@ -264,6 +264,193 @@ func TestDeploymentExistsWithNoImage(t *testing.T) {
 	}
 }
 
+func TestGetAgentPodPlacement(t *testing.T) {
+	ctx := context.Background()
+	zapLog, _ := zap.NewDevelopment()
+	aCtrl := &UpgradeController{
+		spokeUncachedClient: 	initClient(),
+		log:				 	zapr.NewLogger(zapLog),
+		addonNamespace: 		"addon",
+		pullSecret: 			"pullsecret",
+	}
+
+	agentPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hypershift-addon-agent",
+			Namespace: "addon-namespace",
+		},
+		Spec: corev1.PodSpec{
+			NodeSelector: map[string]string{
+				"node-role.kubernetes.io/infra": "",
+			},
+			Tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+		},
+	}
+
+	// Call the function under test
+	tolerations, nodeSelector := aCtrl.getAgentPodPlacement()
+	assert.Nil(t, nodeSelector)
+	assert.Nil(t, tolerations)
+
+	os.Setenv("POD_NAME", "hypershift-addon-agent")
+	os.Setenv("POD_NAMESPACE", "addon-namespace")
+	defer os.Unsetenv("POD_NAME")
+	defer os.Unsetenv("POD_NAMESPACE")
+
+	aCtrl.spokeUncachedClient.Create(ctx, agentPod)
+
+	// Call the function under test
+	tolerations, nodeSelector = aCtrl.getAgentPodPlacement()
+
+	// Assert
+	assert.Equal(t, map[string]string{"node-role.kubernetes.io/infra": ""}, nodeSelector)
+	assert.Equal(t, []corev1.Toleration{
+		{
+			Key:      "node-role.kubernetes.io/infra",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+	}, tolerations)
+}
+
+func TestUpdateHyperShiftDeployment(t *testing.T) {
+	ctx := context.Background()
+	zapLog, _ := zap.NewDevelopment()
+	aCtrl := &UpgradeController{
+		spokeUncachedClient: 	initClient(),
+		log:				 	zapr.NewLogger(zapLog),
+		addonNamespace: 		"addon",
+		pullSecret: 			"",
+	}
+
+	// Create the agent pod with placement
+	agentPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hypershift-addon-agent",
+			Namespace: "addon",
+		},
+		Spec: corev1.PodSpec{
+			NodeSelector: map[string]string{
+				"node-role.kubernetes.io/infra": "",
+			},
+			Tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+		},
+	}
+	assert.Nil(t, aCtrl.spokeUncachedClient.Create(ctx, agentPod))
+
+	// Create the operator Deployment (no placement yet)
+	operatorDeploy := initDeployObj()
+	operatorDeploy.Spec.Template.Spec.Containers = []corev1.Container{
+		{Name: "operator", Image: "test-image"},
+	}
+	assert.Nil(t, aCtrl.spokeUncachedClient.Create(ctx, operatorDeploy))
+
+	// Set env vars so getAgentPodPlacement can find the pod
+	os.Setenv("POD_NAME", "hypershift-addon-agent")
+	os.Setenv("POD_NAMESPACE", "addon")
+	defer os.Unsetenv("POD_NAME")
+	defer os.Unsetenv("POD_NAMESPACE")
+
+	// Call the function under test
+	err := aCtrl.updateHyperShiftDeployment(ctx)
+	assert.Nil(t, err)
+
+	// Re-fetch and assert placement was applied
+	updated := &appsv1.Deployment{}
+	err = aCtrl.spokeUncachedClient.Get(ctx, hypershiftOperatorKey, updated)
+	assert.Nil(t, err)
+	assert.Equal(t, map[string]string{"node-role.kubernetes.io/infra": ""}, updated.Spec.Template.Spec.NodeSelector)
+	assert.Equal(t, []corev1.Toleration{
+		{
+			Key:      "node-role.kubernetes.io/infra",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+	}, updated.Spec.Template.Spec.Tolerations)
+}
+
+func TestUpdateExtDnsDeploymentNodePlacement(t *testing.T) {
+	ctx := context.Background()
+	zapLog, _ := zap.NewDevelopment()
+	aCtrl := &UpgradeController{
+		spokeUncachedClient: initClient(),
+		log:                 zapr.NewLogger(zapLog),
+		addonNamespace:      "addon",
+		pullSecret:          "",
+	}
+	agentPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hypershift-addon-agent",
+			Namespace: "addon",
+		},
+		Spec: corev1.PodSpec{
+			NodeSelector: map[string]string{
+				"node-role.kubernetes.io/infra": "",
+			},
+			Tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+		},
+	}
+	assert.Nil(t, aCtrl.spokeUncachedClient.Create(ctx, agentPod))
+	// Create the ExternalDNS Deployment
+	extDnsDeploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.HypershiftOperatorExternalDNSName,
+			Namespace: util.HypershiftOperatorNamespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "external-dns", Image: "test-image"},
+					},
+				},
+			},
+		},
+	}
+
+	assert.Nil(t, aCtrl.spokeUncachedClient.Create(ctx, extDnsDeploy))
+
+	os.Setenv("POD_NAME", "hypershift-addon-agent")
+	os.Setenv("POD_NAMESPACE", "addon")
+	defer os.Unsetenv("POD_NAME")
+	defer os.Unsetenv("POD_NAMESPACE")
+
+	err := aCtrl.updateExtDnsDeployment(ctx)
+
+	assert.Nil(t, err)
+
+	updated := &appsv1.Deployment{}
+	err = aCtrl.spokeUncachedClient.Get(ctx, externalDNSOperatorKey, updated)
+
+	assert.Nil(t, err)
+	assert.Equal(t, map[string]string{"node-role.kubernetes.io/infra": ""}, updated.Spec.Template.Spec.NodeSelector)
+	assert.Equal(t, []corev1.Toleration{
+		{
+			Key:      "node-role.kubernetes.io/infra",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+	}, updated.Spec.Template.Spec.Tolerations)
+}
+
 func TestRunHypershiftRender(t *testing.T) {
 	ctx := context.Background()
 	args := []string{

--- a/pkg/install/install_job.go
+++ b/pkg/install/install_job.go
@@ -40,6 +40,14 @@ func (c *UpgradeController) runHyperShiftInstallJob(ctx context.Context, image, 
 		ImagePullSecrets:   []corev1.LocalObjectReference{{Name: c.pullSecret}},
 	}
 
+	tolerations, nodeSelector := c.getAgentPodPlacement()
+	if tolerations != nil {
+		jobPodSpec.Tolerations = tolerations
+	}
+	if nodeSelector != nil {
+		jobPodSpec.NodeSelector = nodeSelector
+	}
+
 	// Enable RHOBS
 	if strings.EqualFold(os.Getenv("RHOBS_MONITORING"), "true") {
 		jobPodSpec.Containers[0].Env = []corev1.EnvVar{

--- a/pkg/manager/manifests/templates/clusterrole.yaml
+++ b/pkg/manager/manifests/templates/clusterrole.yaml
@@ -6,7 +6,7 @@ metadata:
 rules:
   # Allow addon agent run with openshift library-go
   - apiGroups: [""]
-    resources: ["pod", "namespaces"]
+    resources: ["pods", "namespaces"]
     verbs: ["get", "list", "patch", "update", "create", "watch"]  
   - apiGroups: ["apps"]
     resources: ["deployments"]

--- a/pkg/manager/manifests/templates/deployment.yaml
+++ b/pkg/manager/manifests/templates/deployment.yaml
@@ -123,6 +123,14 @@ spec:
           - "--multicluster-pull-secret={{ .MulticlusterEnginePullSecret }}"
           - --metrics-bind-address=0.0.0.0:8383
         env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
 {{- if .hcMaxNumber }}
         - name: HC_MAX_NUMBER
           value: "{{ .hcMaxNumber }}"


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Propagate nodeSelector and tolerations from the AddOnDeploymentConfig (ADC) `hypershift-addon-deploy-config` to the HyperShift operator and ExternalDNS operator Deployments on the spoke cluster.
* Add `POD_NAME` and `POD_NAMESPACE` environment variables (via Downward API) to the addon agent Deployment template so the agent can look up its own pod spec at runtime.
* Add a `getAgentPodPlacement()` helper that reads the agent pod's nodeSelector/tolerations and applies them in `updateHyperShiftDeployment`, `updateExtDnsDeployment`, and `runHyperShiftInstallJob`.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
* Bug fix. When a customer configures nodeSelector/tolerations via the MultiClusterHub CR, the settings flow to the ADC and are applied to the hypershift-addon-agent pod, but are not propagated to the HyperShift operator Deployment in the `hypershift` namespace. This causes the operator pods to remain on worker nodes instead of the designated infra nodes.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference:
* https://issues.redhat.com/browse/ACM-30156

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script
=== RUN   TestGetAgentPodPlacement
--- PASS: TestGetAgentPodPlacement (0.01s)
=== RUN   TestUpdateHyperShiftDeployment
--- PASS: TestUpdateHyperShiftDeployment (0.00s)
=== RUN   TestUpdateExtDnsDeploymentNodePlacement
--- PASS: TestUpdateExtDnsDeploymentNodePlacement (0.00s)
PASS
ok  	github.com/stolostron/hypershift-addon-operator/pkg/install	1.813s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HyperShift operator and External-DNS deployments inherit node placement (tolerations and node selectors) from the addon agent pod
  * HyperShift install jobs apply agent pod placement settings
  * Agent pod now exposes POD_NAME and POD_NAMESPACE via downward API; RBAC updated to allow reading pods

* **Tests**
  * Added unit tests for agent placement detection and deployment/update behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->