### PR TITLE
Add FIPS build flags to Konflux Dockerfile

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -14,7 +14,7 @@ COPY ./ ./
 # Cache the go build into the the Go’s compiler cache folder so we take benefits of compiler caching across docker build calls
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    go build -mod=readonly -o bin/hypershift-addon cmd/main.go
+    CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -mod=readonly -o bin/hypershift-addon cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
## Summary

- Adds `CGO_ENABLED=1` and `GOEXPERIMENT=strictfipsruntime` to the Konflux/RHTAP `Dockerfile.rhtap` build for the hypershift-addon-operator image.
- Addresses [HYPBLD-844](https://redhat.atlassian.net/browse/HYPBLD-844) FIPS build flag requirements.

This pull request was created by Cursor.

## Test plan

- [ ] Verify Konflux/RHTAP pipeline build succeeds for hypershift-addon-operator on backplane-2.11
- [ ] Confirm built binaries link against FIPS crypto libraries as expected


Made with [Cursor](https://cursor.com)

[HYPBLD-844]: https://redhat.atlassian.net/browse/HYPBLD-844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ