### PR TITLE
OCPBUGS-86791: Add operator.openshift.io/clusterapis RBAC to addon agent ClusterRole

### DIFF
--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -1,8 +1,10 @@
 package manager
 
 import (
+	"bytes"
 	"context"
 	"testing"
+	"text/template"
 
 	"github.com/go-logr/zapr"
 	consolev1 "github.com/openshift/api/console/v1"
@@ -20,6 +22,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	fakeaddon "open-cluster-management.io/api/client/addon/clientset/versioned/fake"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
@@ -145,4 +148,48 @@ func initClient() client.Client {
 	ncb.WithScheme(scheme)
 	return ncb.Build()
 
+}
+
+func Test_ClusterRoleContainsClusterAPIPermissions(t *testing.T) {
+	tmplData, err := fs.ReadFile("manifests/templates/clusterrole.yaml")
+	assert.Nil(t, err, "should read embedded clusterrole template")
+
+	tmpl, err := template.New("clusterrole").Parse(string(tmplData))
+	assert.Nil(t, err, "should parse template")
+
+	var rendered bytes.Buffer
+	err = tmpl.Execute(&rendered, map[string]string{
+		"SpokeRolebindingName":  "test-cluster-hypershift-addon",
+		"AddonInstallNamespace": "open-cluster-management-agent-addon",
+	})
+	assert.Nil(t, err, "should render template")
+
+	clusterRole := &rbacv1.ClusterRole{}
+	err = yaml.NewYAMLOrJSONDecoder(&rendered, 4096).Decode(clusterRole)
+	assert.Nil(t, err, "should decode rendered ClusterRole")
+
+	found := false
+	for _, rule := range clusterRole.Rules {
+		for _, apiGroup := range rule.APIGroups {
+			if apiGroup != "operator.openshift.io" {
+				continue
+			}
+			for _, resource := range rule.Resources {
+				if resource == "clusterapis" {
+					found = true
+					verbSet := make(map[string]bool)
+					for _, v := range rule.Verbs {
+						verbSet[v] = true
+					}
+					for _, required := range []string{"get", "list", "watch", "patch"} {
+						assert.True(t, verbSet[required],
+							"operator.openshift.io/clusterapis must include verb %q", required)
+					}
+				}
+			}
+		}
+	}
+	assert.True(t, found,
+		"ClusterRole must include operator.openshift.io/clusterapis rule "+
+			"(required by hypershift CAPI coordination, see openshift/hypershift#7996)")
 }

--- a/pkg/manager/manifests/templates/clusterrole.yaml
+++ b/pkg/manager/manifests/templates/clusterrole.yaml
@@ -84,3 +84,7 @@ rules:
   - apiGroups: [ "discovery.open-cluster-management.io" ]
     resources: [ "discoveredclusters" ]
     verbs: [ "*" ]
+  # Coordinate CAPI CRD ownership with Cluster CAPI Operator (openshift/hypershift#7996)
+  - apiGroups: ["operator.openshift.io"]
+    resources: ["clusterapis"]
+    verbs: ["get", "list", "watch", "patch"]


### PR DESCRIPTION
## Summary

Fixes: https://redhat.atlassian.net/browse/OCPBUGS-86791

The HyperShift install code (`openshift/hypershift` PR #7996) added CAPI coordination
logic that patches `clusterapis.operator.openshift.io/cluster` to register unmanaged CRDs
with the Cluster CAPI Operator. However, the addon agent ClusterRole template was never
updated to grant these permissions.

When the `ClusterAPIInstall` FeatureGate is enabled, the install job fails with:

```
clusterapis.operator.openshift.io "cluster" is forbidden: User
"system:serviceaccount:open-cluster-management-agent-addon:hypershift-addon-agent-sa"
cannot patch resource "clusterapis" in API group "operator.openshift.io" at the cluster scope
```

This PR adds the required RBAC rules for `operator.openshift.io/clusterapis`.

## Operations Required

The install code performs:
- `Patch` (server-side apply) — `ensureUnmanagedCRDs()` applies the unmanaged CRD list
- `Get` — `waitForCAPIOperatorSync()` polls the resource status

## Testing Results

| Environment | Result |
|-------------|--------|
| OCP 4.22-rc.4 + MCE 2.17.0 | **FAIL** without fix, **PASS** with equivalent RBAC applied manually |
| OCP 4.22-rc.5 + MCE 2.17.0 | **FAIL** without fix (reproduced on clean cluster) |
| OCP 4.22-rc.5 + MCE 2.11.1 | Not affected (CAPI coordination code absent in older HyperShift) |

After applying equivalent RBAC manually, install job output:
```
All 67 CRDs passed dry-run validation
ClusterAPI API detected, coordinating with Cluster CAPI Operator
Applied ClusterAPI config with 52 unmanaged CRDs
```

## Test Plan

- Unit test added: `Test_ClusterRoleContainsClusterAPIPermissions` validates the rendered
  template includes the required RBAC rule
- Deploy OCP 4.22 with `ClusterAPIInstall` FeatureGate enabled
- Install MCE with hypershift addon
- Verify `hypershift-install-job` completes past the CAPI coordination step

## Related

- Feature: https://redhat.atlassian.net/browse/OCPSTRAT-2789
- Implementation: https://github.com/openshift/hypershift/pull/7996

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a validation test ensuring the ClusterRole grants expected permissions on cluster API resources.

* **New Features**
  * Expanded RBAC to allow get, list, watch, and patch operations on cluster API resources to support coordination with the Cluster CAPI operator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->