### PR TITLE
ACM-35017: add CLAUDE.md and CVE handoff workflow Cursor rule

### DIFF
--- a/.cursor/rules/cve-workflow.mdc
+++ b/.cursor/rules/cve-workflow.mdc
@@ -1,0 +1,45 @@
+---
+description: CVE/vulnerability ticket handoff workflow for HyperShift to Sustaining Engineering. Use when handling a CVE ticket, assigning vulnerabilities to ocp-sustaining-admins, or completing backport handoff for hypershift-addon-operator or hypershift-deployment-controller.
+alwaysApply: false
+---
+
+# CVE / Vulnerability Handoff Workflow
+
+Part of the Sustaining Engineering transition ([ACM-27405](https://redhat.atlassian.net/browse/ACM-27405)).
+
+## Affected Repos
+
+- `hypershift-addon-operator`
+- `hypershift-deployment-controller`
+
+## Steps
+
+### 1 — Verify fix is on main
+
+Confirm the fix PR is merged and CI is green on `main`.
+
+### 2 — Find the Jira ticket
+
+Search with JQL:
+
+```
+project = ACM AND component = HyperShift AND (issuetype = Vulnerability OR labels = CVE) AND statusCategory != Done
+```
+
+### 3 — Add handoff comment
+
+```
+Fix merged on main: <PR_URL>
+
+Affected versions requiring backport: <e.g. ACM 2.13, 2.14, 2.15>
+
+Backport notes: <breaking changes, dependency requirements, or "none">
+```
+
+### 4 — Reassign to ocp-sustaining-admins
+
+### 5 — Transition ticket to In Progress
+
+## No Open CVEs / Onboarding
+
+Search (step 2), add a comment confirming team understanding, close the ticket.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# HyperShift Addon Operator — Claude Context
+
+## Project
+
+Go module: `github.com/stolostron/hypershift-addon-operator`
+
+Deploys the HyperShift operator onto managed clusters as an OCM addon for ACM / multicluster-engine.
+
+- Hub manager: `pkg/manager/`
+- Spoke agent: `pkg/agent/`
+- Install lifecycle: `pkg/install/`
+
+## Key Commands
+
+```bash
+make build          # vendor + fmt + vet
+make test           # fmt + vet + envtest (excludes e2e)
+make vendor         # go mod tidy + go mod vendor
+make docker-build   # build container image
+```
+
+## CVE / Vulnerability Workflow
+
+See `.cursor/rules/cve-workflow.mdc` for the full step-by-step process.
+
+Once a CVE fix lands on main: verify the PR, find the Jira ticket, add a handoff comment (PR links + affected versions + backport notes), reassign to `ocp-sustaining-admins`, transition to `In Progress`.
+
+Parent initiative: [ACM-27405](https://redhat.atlassian.net/browse/ACM-27405)


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` — project-level context auto-loaded by Claude when working in this repo
- Adds `.cursor/rules/cve-workflow.mdc` — on-demand Cursor rule with the full step-by-step CVE/vulnerability ticket handoff process to Sustaining Engineering

Both files encode the workflow from [ACM-35017](https://redhat.atlassian.net/browse/ACM-35017) as part of the Sustaining Engineering transition ([ACM-27405](https://redhat.atlassian.net/browse/ACM-27405)):
1. Verify fix is merged and green on `main`
2. Find the Jira vulnerability ticket
3. Add a handoff comment (PR links, affected versions, backport notes)
4. Reassign to `ocp-sustaining-admins`
5. Transition ticket to `In Progress`

## Why these files

| File | Purpose | Loaded by |
|---|---|---|
| `CLAUDE.md` | Project context with brief CVE workflow summary | Claude — auto-loaded always |
| `.cursor/rules/cve-workflow.mdc` | Full step-by-step workflow | Cursor — injected on demand when handling CVE tickets |

Neither file affects the operator binary or any runtime behavior.

Closes [ACM-35017](https://redhat.atlassian.net/browse/ACM-35017)

Signed-off-by: yiraeChristineKim <yikim@redhat.com>

[ACM-35017]: https://redhat.atlassian.net/browse/ACM-35017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-27405]: https://redhat.atlassian.net/browse/ACM-27405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-35017]: https://redhat.atlassian.net/browse/ACM-35017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ