### PR TITLE
ACM-35337: hypershift-addon-agent CrashLoopBackOff

### DIFF
--- a/pkg/manager/manifests/templates/deployment.yaml
+++ b/pkg/manager/manifests/templates/deployment.yaml
@@ -123,6 +123,8 @@ spec:
           - "--multicluster-pull-secret={{ .MulticlusterEnginePullSecret }}"
           - --metrics-bind-address=0.0.0.0:8383
         env:
+        - name: KUBE_FEATURE_WatchListClient
+          value: "false"
 {{- if .hcMaxNumber }}
         - name: HC_MAX_NUMBER
           value: "{{ .hcMaxNumber }}"


### PR DESCRIPTION
<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Disable WatchListClient at process startup so reflectors use the legacy List + Watch path (no bookmark required).

* Added `cmd/clientgo_features.go` with an init() that calls Set(features.WatchListClient, false) via a type assertion on features.FeatureGates() — the supported client-go API.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  MCE 2.11.2 ships hypershift-addon built with client-go v0.35.1, which enables WatchListClient by default. Informers use streaming-list watches and wait for a bookmark event to mark initial sync complete. On OCP 4.21 (K8s 1.34.8), those bookmarks are not delivered reliably, so controller-runtime never finishes cache sync and the process exits causing CrashLoopBackOff.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://redhat.atlassian.net/browse/ACM-35337

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled the WatchListClient feature by default at startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->