### PR TITLE
ACM-35337: Set KUBE_FEATURE_WatchListClient=false on the agent deployment s…

### DIFF
--- a/pkg/manager/manifests/templates/deployment.yaml
+++ b/pkg/manager/manifests/templates/deployment.yaml
@@ -123,6 +123,8 @@ spec:
           - "--multicluster-pull-secret={{ .MulticlusterEnginePullSecret }}"
           - --metrics-bind-address=0.0.0.0:8383
         env:
+        - name: KUBE_FEATURE_WatchListClient
+          value: "false"
         - name: POD_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION

<!-- Include a list of changes, include what this PR does -->
# Description of the change(s):
* Set KUBE_FEATURE_WatchListClient=false on the agent deployment so reflectors use legacy List+Watch until bookmark delivery is fixed upstream.

<!-- include a brief description of why, and the stake holders. ie. Bug, RFE, enhancement, etc... -->
## Why do we need this PR:
*  MCE 2.11.2 ships client-go v0.35.1 with WatchListClient enabled by default. On OCP 4.21 the apiserver does not reliably deliver initial-events-end bookmarks, so controller-runtime informers never sync and the agent exits.

<!-- include the Jira or GitHub issue link. Github issue links help identify this PR in your issue -->
## Issue reference: 
* https://redhat.atlassian.net/browse/ACM-35337

<!-- the last few lines, showing the test coverage and success.
     Use the output from "make test" or vscode golang Test All output.
     Add any additional test output that is relevant as well -->
## Test API/Unit - Success
```script

```
