### PR TITLE
fix: force reinstall when MCE reconciliation strips OIDC S3 args (ACM-35409)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 WORKDIR /go/src/github.com/stolostron/hypershift-addon-operator
 COPY . .
 ENV GO_PACKAGE github.com/stolostron/hypershift-addon-operator
+# Fall back to direct VCS download when the Go module proxy returns an error,
+# and skip the checksum database to reduce the number of network round-trips.
+ENV GOPROXY=https://proxy.golang.org,direct
+ENV GONOSUMDB=*
 
 # Build
 RUN make build --warn-undefined-variables

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,6 @@ FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 WORKDIR /go/src/github.com/stolostron/hypershift-addon-operator
 COPY . .
 ENV GO_PACKAGE github.com/stolostron/hypershift-addon-operator
-# Fall back to direct VCS download when the Go module proxy returns an error,
-# and skip the checksum database to reduce the number of network round-trips.
-ENV GOPROXY=https://proxy.golang.org,direct
-ENV GONOSUMDB=*
 
 # Build
 RUN make build --warn-undefined-variables

--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -1059,8 +1059,9 @@ func getContainerEnvVar(envVars []corev1.EnvVar, imageName string) string {
 // contains all three required OIDC S3 storage provider arguments (bucket-name, region,
 // and credentials/secret). Checking all three guards against partial stripping where
 // only some flags are removed while the bucket-name remains, which would still result
-// in an incomplete OIDC configuration. Uses HasPrefix to match both the space-separated
-// form (--flag value) and the equals form (--flag=value) produced by hypershift install.
+// in an incomplete OIDC configuration. Each flag is matched exactly (--flag value form)
+// or as a prefix of "--flag=" (--flag=value form) to avoid false-positive matches on
+// flags that share a common prefix (e.g. --oidc-storage-provider-s3-regionX).
 // Used to detect when MCE reconciliation has overwritten the deployment without OIDC
 // args so the addon agent forces a reinstall to restore them (ACM-35409).
 func (c *UpgradeController) deploymentHasOIDCArgs(operatorDeployment appsv1.Deployment) bool {
@@ -1072,19 +1073,25 @@ func (c *UpgradeController) deploymentHasOIDCArgs(operatorDeployment appsv1.Depl
 	hasSecret := false
 	for _, arg := range operatorDeployment.Spec.Template.Spec.Containers[0].Args {
 		switch {
-		case strings.HasPrefix(arg, "--oidc-storage-provider-s3-bucket-name"):
+		case oidcFlagMatch(arg, "--oidc-storage-provider-s3-bucket-name"):
 			hasBucket = true
-		case strings.HasPrefix(arg, "--oidc-storage-provider-s3-region"):
+		case oidcFlagMatch(arg, "--oidc-storage-provider-s3-region"):
 			hasRegion = true
 		// hypershift install may render the secret arg as either
 		// --oidc-storage-provider-s3-secret (secret name) or
 		// --oidc-storage-provider-s3-credentials (file path).
-		case strings.HasPrefix(arg, "--oidc-storage-provider-s3-secret"),
-			strings.HasPrefix(arg, "--oidc-storage-provider-s3-credentials"):
+		case oidcFlagMatch(arg, "--oidc-storage-provider-s3-secret"),
+			oidcFlagMatch(arg, "--oidc-storage-provider-s3-credentials"):
 			hasSecret = true
 		}
 	}
 	return hasBucket && hasRegion && hasSecret
+}
+
+// oidcFlagMatch returns true when arg matches flag exactly (space-separated form:
+// --flag value) or as a "--flag=..." prefix (equals form: --flag=value).
+func oidcFlagMatch(arg, flag string) bool {
+	return arg == flag || strings.HasPrefix(arg, flag+"=")
 }
 
 func (c *UpgradeController) secretDataUpdated(secretName string, secret corev1.Secret) bool {

--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -1056,19 +1056,35 @@ func getContainerEnvVar(envVars []corev1.EnvVar, imageName string) string {
 }
 
 // deploymentHasOIDCArgs returns true if the HyperShift operator deployment already
-// contains the OIDC S3 storage provider bucket-name argument. It is used to detect
-// cases where MCE reconciliation has overwritten the deployment and stripped the OIDC
-// args, so that the addon agent forces a reinstall to restore them (ACM-35409).
+// contains all three required OIDC S3 storage provider arguments (bucket-name, region,
+// and credentials/secret). Checking all three guards against partial stripping where
+// only some flags are removed while the bucket-name remains, which would still result
+// in an incomplete OIDC configuration. Uses HasPrefix to match both the space-separated
+// form (--flag value) and the equals form (--flag=value) produced by hypershift install.
+// Used to detect when MCE reconciliation has overwritten the deployment without OIDC
+// args so the addon agent forces a reinstall to restore them (ACM-35409).
 func (c *UpgradeController) deploymentHasOIDCArgs(operatorDeployment appsv1.Deployment) bool {
 	if len(operatorDeployment.Spec.Template.Spec.Containers) == 0 {
 		return false
 	}
+	hasBucket := false
+	hasRegion := false
+	hasSecret := false
 	for _, arg := range operatorDeployment.Spec.Template.Spec.Containers[0].Args {
-		if arg == "--oidc-storage-provider-s3-bucket-name" {
-			return true
+		switch {
+		case strings.HasPrefix(arg, "--oidc-storage-provider-s3-bucket-name"):
+			hasBucket = true
+		case strings.HasPrefix(arg, "--oidc-storage-provider-s3-region"):
+			hasRegion = true
+		// hypershift install may render the secret arg as either
+		// --oidc-storage-provider-s3-secret (secret name) or
+		// --oidc-storage-provider-s3-credentials (file path).
+		case strings.HasPrefix(arg, "--oidc-storage-provider-s3-secret"),
+			strings.HasPrefix(arg, "--oidc-storage-provider-s3-credentials"):
+			hasSecret = true
 		}
 	}
-	return false
+	return hasBucket && hasRegion && hasSecret
 }
 
 func (c *UpgradeController) secretDataUpdated(secretName string, secret corev1.Secret) bool {

--- a/pkg/install/hypershift.go
+++ b/pkg/install/hypershift.go
@@ -389,13 +389,17 @@ func (c *UpgradeController) runHypershiftInstall(ctx context.Context, controller
 		// compare installed operator images to the new image stream
 		// compare locally saved secrets to the hub secrets as well
 		// If they are the same, skip re-install.
+		// Also force re-install if OIDC is configured on the hub but the running deployment
+		// is missing the OIDC args — this can happen when MCE reconciliation overwrites the
+		// HyperShift deployment without preserving the OIDC S3 configuration (ACM-35409).
 		if reinstallCheckRequired &&
 			!(c.operatorImagesUpdated(im, *operatorDeployment) ||
 				c.secretDataUpdated(util.HypershiftBucketSecretName, *se) ||
 				c.secretDataUpdated(util.HypershiftPrivateLinkSecretName, *spl) ||
 				c.secretDataUpdated(util.HypershiftAzurePrivateSecretName, *sAzurePrivate) ||
 				c.secretDataUpdated(util.HypershiftExternalDNSSecretName, *sExtDNS) ||
-				c.configmapDataUpdated(util.HypershiftInstallFlagsCM, installFlagsCM)) {
+				c.configmapDataUpdated(util.HypershiftInstallFlagsCM, installFlagsCM)) &&
+			(!oidcBucket || c.deploymentHasOIDCArgs(*operatorDeployment)) {
 			c.log.Info("no image/secret/install-flag change, skip hypershift operator installation")
 
 			if err := c.updateHyperShiftDeployment(ctx); err != nil {
@@ -1049,6 +1053,22 @@ func getContainerEnvVar(envVars []corev1.EnvVar, imageName string) string {
 		}
 	}
 	return ""
+}
+
+// deploymentHasOIDCArgs returns true if the HyperShift operator deployment already
+// contains the OIDC S3 storage provider bucket-name argument. It is used to detect
+// cases where MCE reconciliation has overwritten the deployment and stripped the OIDC
+// args, so that the addon agent forces a reinstall to restore them (ACM-35409).
+func (c *UpgradeController) deploymentHasOIDCArgs(operatorDeployment appsv1.Deployment) bool {
+	if len(operatorDeployment.Spec.Template.Spec.Containers) == 0 {
+		return false
+	}
+	for _, arg := range operatorDeployment.Spec.Template.Spec.Containers[0].Args {
+		if arg == "--oidc-storage-provider-s3-bucket-name" {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *UpgradeController) secretDataUpdated(secretName string, secret corev1.Secret) bool {

--- a/pkg/install/hypershift_test.go
+++ b/pkg/install/hypershift_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stolostron/hypershift-addon-operator/pkg/metrics"
 	"github.com/stolostron/hypershift-addon-operator/pkg/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -1788,7 +1789,7 @@ func TestReinstallWhenOIDCArgsStripped(t *testing.T) {
 	addonNs := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: aCtrl.addonNamespace},
 	}
-	aCtrl.hubClient.Create(ctx, addonNs)
+	require.NoError(t, aCtrl.hubClient.Create(ctx, addonNs), "failed to create addon namespace")
 	defer aCtrl.hubClient.Delete(ctx, addonNs)
 
 	// Bucket secret exists on the hub — OIDC is configured
@@ -1804,7 +1805,7 @@ func TestReinstallWhenOIDCArgsStripped(t *testing.T) {
 			"aws-access-key-id":     []byte(`aws_s3_key_id`),
 		},
 	}
-	aCtrl.hubClient.Create(ctx, bucketSecret)
+	require.NoError(t, aCtrl.hubClient.Create(ctx, bucketSecret), "failed to create hub bucket secret")
 	defer aCtrl.hubClient.Delete(ctx, bucketSecret)
 
 	// Locally-saved secret matches hub — no secret change detected
@@ -1820,7 +1821,7 @@ func TestReinstallWhenOIDCArgsStripped(t *testing.T) {
 			"aws-access-key-id":     []byte(`aws_s3_key_id`),
 		},
 	}
-	aCtrl.spokeUncachedClient.Create(ctx, bucketSecretLocal)
+	require.NoError(t, aCtrl.spokeUncachedClient.Create(ctx, bucketSecretLocal), "failed to create local bucket secret")
 	defer aCtrl.spokeUncachedClient.Delete(ctx, bucketSecretLocal)
 
 	// Image stream with same images as the running deployment — no image change detected
@@ -1836,7 +1837,7 @@ func TestReinstallWhenOIDCArgsStripped(t *testing.T) {
 	ims := &imageapi.ImageStream{}
 	ims.Spec.Tags = tr
 	imb, err := yaml.Marshal(ims)
-	assert.Nil(t, err, "expected Marshal to succeed: %s", err)
+	require.NoError(t, err, "expected Marshal to succeed")
 
 	overrideCM := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1845,13 +1846,13 @@ func TestReinstallWhenOIDCArgsStripped(t *testing.T) {
 		},
 		Data: map[string]string{util.HypershiftOverrideKey: base64.StdEncoding.EncodeToString(imb)},
 	}
-	aCtrl.spokeUncachedClient.Create(ctx, overrideCM)
+	require.NoError(t, aCtrl.spokeUncachedClient.Create(ctx, overrideCM), "failed to create image override configmap")
 	defer aCtrl.spokeUncachedClient.Delete(ctx, overrideCM)
 
 	hypershiftNs := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: "hypershift"},
 	}
-	aCtrl.spokeUncachedClient.Create(ctx, hypershiftNs)
+	require.NoError(t, aCtrl.spokeUncachedClient.Create(ctx, hypershiftNs), "failed to create hypershift namespace")
 	defer aCtrl.spokeUncachedClient.Delete(ctx, hypershiftNs)
 
 	// Simulate MCE reconciliation stripping OIDC args: deployment has correct images
@@ -1888,7 +1889,7 @@ func TestReinstallWhenOIDCArgsStripped(t *testing.T) {
 			},
 		},
 	}
-	aCtrl.spokeUncachedClient.Create(ctx, dp)
+	require.NoError(t, aCtrl.spokeUncachedClient.Create(ctx, dp), "failed to create hypershift operator deployment")
 	defer aCtrl.spokeUncachedClient.Delete(ctx, dp)
 
 	assert.Eventually(t, func() bool {

--- a/pkg/install/hypershift_test.go
+++ b/pkg/install/hypershift_test.go
@@ -1721,6 +1721,14 @@ func TestSkipHypershiftInstallWithNoChange(t *testing.T) {
 						Name:  "nginx",
 						Image: "hypershift-operator@sha256:aaa",
 						Ports: []corev1.ContainerPort{{ContainerPort: 80}},
+						// OIDC args must be present so the skip-reinstall check passes
+						// (bucket secret is configured on the hub, so deploymentHasOIDCArgs
+						// must return true to allow skipping reinstall — ACM-35409).
+						Args: []string{
+							"--oidc-storage-provider-s3-bucket-name", "my-bucket",
+							"--oidc-storage-provider-s3-region", "us-east-1",
+							"--oidc-storage-provider-s3-secret", util.HypershiftBucketSecretName,
+						},
 						Env: []corev1.EnvVar{
 							{Name: "hypershift-operator", Value: "hypershift-operator@sha256:aaa"},
 							{Name: util.HypershiftEnvVarImageAwsCapiProvider, Value: "cluster-api-aws-controller@sha256:aaa"},
@@ -1750,10 +1758,159 @@ func TestSkipHypershiftInstallWithNoChange(t *testing.T) {
 	assert.Nil(t, err, "there was no error in calling HyperShift installation")
 	// All images in the hypershift operator deployment are the same as what is in the image override configmap
 	// All secrets data from the hub is the same as those saved locally on the agent side
-	// expect no install job
+	// OIDC args are present in the deployment — expect no install job
 	noInstallJob, err := noInstallJobs(ctx, aCtrl.spokeUncachedClient, aCtrl.addonNamespace)
 	assert.Nil(t, err, "there should be no error in RunHypershiftOperatorInstallOnAgentStartup")
 	assert.True(t, noInstallJob, "there should be no hypershift installation job")
+}
+
+// TestReinstallWhenOIDCArgsStripped verifies that when the OIDC S3 bucket secret is
+// configured on the hub but the running deployment is missing the OIDC args (e.g. because
+// MCE reconciliation overwrote the deployment), the addon agent forces a reinstall
+// instead of silently skipping it (ACM-35409).
+func TestReinstallWhenOIDCArgsStripped(t *testing.T) {
+	ctx := context.Background()
+
+	zapLog, _ := zap.NewDevelopment()
+	client := initClient()
+	aCtrl := &UpgradeController{
+		spokeUncachedClient:       client,
+		hubClient:                 client,
+		log:                       zapr.NewLogger(zapLog),
+		addonNamespace:            "addon",
+		operatorImage:             "my-test-image",
+		clusterName:               "cluster1",
+		pullSecret:                "pull-secret",
+		withOverride:              true,
+		hypershiftInstallExecutor: &HypershiftTestCliExecutor{},
+	}
+
+	addonNs := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: aCtrl.addonNamespace},
+	}
+	aCtrl.hubClient.Create(ctx, addonNs)
+	defer aCtrl.hubClient.Delete(ctx, addonNs)
+
+	// Bucket secret exists on the hub — OIDC is configured
+	bucketSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.HypershiftBucketSecretName,
+			Namespace: aCtrl.clusterName,
+		},
+		Data: map[string][]byte{
+			"bucket":                []byte(`my-bucket`),
+			"region":                []byte(`us-east-1`),
+			"aws-secret-access-key": []byte(`aws_s3_secret`),
+			"aws-access-key-id":     []byte(`aws_s3_key_id`),
+		},
+	}
+	aCtrl.hubClient.Create(ctx, bucketSecret)
+	defer aCtrl.hubClient.Delete(ctx, bucketSecret)
+
+	// Locally-saved secret matches hub — no secret change detected
+	bucketSecretLocal := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.HypershiftBucketSecretName,
+			Namespace: aCtrl.addonNamespace,
+		},
+		Data: map[string][]byte{
+			"bucket":                []byte(`my-bucket`),
+			"region":                []byte(`us-east-1`),
+			"aws-secret-access-key": []byte(`aws_s3_secret`),
+			"aws-access-key-id":     []byte(`aws_s3_key_id`),
+		},
+	}
+	aCtrl.spokeUncachedClient.Create(ctx, bucketSecretLocal)
+	defer aCtrl.spokeUncachedClient.Delete(ctx, bucketSecretLocal)
+
+	// Image stream with same images as the running deployment — no image change detected
+	tr := []imageapi.TagReference{}
+	tr = append(tr, imageapi.TagReference{Name: hsOperatorImage, From: &corev1.ObjectReference{Name: "hypershift-operator@sha256:aaa"}})
+	tr = append(tr, imageapi.TagReference{Name: util.ImageStreamAwsCapiProvider, From: &corev1.ObjectReference{Name: "cluster-api-aws-controller@sha256:aaa"}})
+	tr = append(tr, imageapi.TagReference{Name: util.ImageStreamAzureCapiProvider, From: &corev1.ObjectReference{Name: "cluster-api-provider-azure@sha256:aaa"}})
+	tr = append(tr, imageapi.TagReference{Name: util.ImageStreamKubevertCapiProvider, From: &corev1.ObjectReference{Name: "cluster-api-provider-kubevirt@sha256:aaa"}})
+	tr = append(tr, imageapi.TagReference{Name: util.ImageStreamKonnectivity, From: &corev1.ObjectReference{Name: "apiserver-network-proxy@sha256:aaa"}})
+	tr = append(tr, imageapi.TagReference{Name: util.ImageStreamAwsEncyptionProvider, From: &corev1.ObjectReference{Name: "aws-encryption-provider@sha256:aaa"}})
+	tr = append(tr, imageapi.TagReference{Name: util.ImageStreamClusterApi, From: &corev1.ObjectReference{Name: "cluster-api@sha256:aaa"}})
+	tr = append(tr, imageapi.TagReference{Name: util.ImageStreamAgentCapiProvider, From: &corev1.ObjectReference{Name: "cluster-api-provider-agent@sha256:aaa"}})
+	ims := &imageapi.ImageStream{}
+	ims.Spec.Tags = tr
+	imb, err := yaml.Marshal(ims)
+	assert.Nil(t, err, "expected Marshal to succeed: %s", err)
+
+	overrideCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.HypershiftDownstreamOverride,
+			Namespace: aCtrl.addonNamespace,
+		},
+		Data: map[string]string{util.HypershiftOverrideKey: base64.StdEncoding.EncodeToString(imb)},
+	}
+	aCtrl.spokeUncachedClient.Create(ctx, overrideCM)
+	defer aCtrl.spokeUncachedClient.Delete(ctx, overrideCM)
+
+	hypershiftNs := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "hypershift"},
+	}
+	aCtrl.spokeUncachedClient.Create(ctx, hypershiftNs)
+	defer aCtrl.spokeUncachedClient.Delete(ctx, hypershiftNs)
+
+	// Simulate MCE reconciliation stripping OIDC args: deployment has correct images
+	// but is MISSING --oidc-storage-provider-s3-bucket-name and related args.
+	dp := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "operator",
+			Namespace: "hypershift",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "operator",
+						Image: "hypershift-operator@sha256:aaa",
+						// No OIDC args — simulates MCE reconciliation overwriting the deployment
+						Args: []string{"--namespace", "hypershift"},
+						Env: []corev1.EnvVar{
+							{Name: "hypershift-operator", Value: "hypershift-operator@sha256:aaa"},
+							{Name: util.HypershiftEnvVarImageAwsCapiProvider, Value: "cluster-api-aws-controller@sha256:aaa"},
+							{Name: util.HypershiftEnvVarImageAzureCapiProvider, Value: "cluster-api-provider-azure@sha256:aaa"},
+							{Name: util.HypershiftEnvVarImageKubevertCapiProvider, Value: "cluster-api-provider-kubevirt@sha256:aaa"},
+							{Name: util.HypershiftEnvVarImageKonnectivity, Value: "apiserver-network-proxy@sha256:aaa"},
+							{Name: util.HypershiftEnvVarImageAwsEncyptionProvider, Value: "aws-encryption-provider@sha256:aaa"},
+							{Name: util.HypershiftEnvVarImageClusterApi, Value: "cluster-api@sha256:aaa"},
+							{Name: util.HypershiftEnvVarImageAgentCapiProvider, Value: "cluster-api-provider-agent@sha256:aaa"},
+						},
+					}},
+				},
+			},
+		},
+	}
+	aCtrl.spokeUncachedClient.Create(ctx, dp)
+	defer aCtrl.spokeUncachedClient.Delete(ctx, dp)
+
+	assert.Eventually(t, func() bool {
+		theDeployment := &appsv1.Deployment{}
+		err := aCtrl.spokeUncachedClient.Get(ctx, types.NamespacedName{Namespace: "hypershift", Name: "operator"}, theDeployment)
+		return err == nil
+	}, 10*time.Second, 1*time.Second, "The test operator deployment was created successfully")
+
+	// Mark the install job as succeeded asynchronously so RunHypershiftOperatorInstallOnAgentStartup
+	// does not block indefinitely waiting for job completion.
+	go updateHsInstallJobToSucceeded(ctx, aCtrl.spokeUncachedClient, aCtrl.addonNamespace)
+
+	// Run the hypershift operator installation to simulate addon agent startup.
+	// Images and secrets are unchanged, but OIDC args are missing from the deployment.
+	// The addon agent must NOT skip the reinstall — it must trigger an install job to
+	// restore the OIDC args (ACM-35409).
+	err = aCtrl.RunHypershiftOperatorInstallOnAgentStartup(ctx)
+	assert.Nil(t, err, "RunHypershiftOperatorInstallOnAgentStartup should not error")
+
+	noInstallJob, err := noInstallJobs(ctx, aCtrl.spokeUncachedClient, aCtrl.addonNamespace)
+	assert.Nil(t, err, "there should be no error checking for install jobs")
+	assert.False(t, noInstallJob, "an install job must be created to restore the stripped OIDC args")
 }
 
 func TestCreateSpokeCredential(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes a bug where MCE reconciliation overwrites the HyperShift operator deployment without OIDC S3 storage provider arguments, causing all AWS `HostedCluster` creations to fail with `ValidOIDCConfiguration: False` until a manual re-patch.

## Root Cause

The addon agent's skip-reinstall logic (on startup with no image/secret changes) only checked images and secrets — it never verified that the OIDC deployment args were still present. When MCE's own backplane reconciliation reset the deployment, the addon agent saw "no changes" and skipped the reinstall, leaving the OIDC args gone.

## Fix

Added `deploymentHasOIDCArgs` check to the skip-reinstall condition in `runHypershiftInstall`:

```go
(!oidcBucket || c.deploymentHasOIDCArgs(*operatorDeployment))
```

When the OIDC bucket secret is configured on the hub but `--oidc-storage-provider-s3-bucket-name` is missing from the running deployment, the skip is rejected and a full reinstall is triggered to restore the OIDC args.

## Testing

- Updated `TestSkipHypershiftInstallWithNoChange` to include OIDC args in the test deployment (required to allow skip when bucket secret is configured)
- Added `TestReinstallWhenOIDCArgsStripped` which exactly reproduces the bug: same images, same secrets, but deployment missing OIDC args → verifies an install job is created

## Jira

[ACM-35409](https://redhat.atlassian.net/browse/ACM-35409) — reported by Ryan Jenkins via Chai Bot

## Test plan

- [x] `make test` passes (all packages)
- [x] `TestSkipHypershiftInstallWithNoChange` — skip still works when OIDC args are present
- [x] `TestReinstallWhenOIDCArgsStripped` — reinstall is forced when OIDC args are stripped

Made with [Cursor](https://cursor.com)

[ACM-35409]: https://redhat.atlassian.net/browse/ACM-35409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved HyperShift operator install behavior for OIDC hubs. If OIDC is enabled but the currently running operator deployment is missing the required OIDC S3 bucket configuration arguments, the operator will now force a reinstall instead of skipping.
* **Tests**
  * Added/updated coverage to validate both the reinstall-skip case when OIDC args are present and the forced reinstall case when OIDC args are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->